### PR TITLE
bugfix:MergedSendRunnable can be closed by accident

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemotingClient.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemotingClient.java
@@ -439,13 +439,21 @@ public abstract class AbstractRpcRemotingClient extends AbstractRpcRemoting
                     if (mergeMessage.msgIds.size() > 1) {
                         printMergeMessageLog(mergeMessage);
                     }
-                    Channel sendChannel = connect(address);
+                    Channel sendChannel = null;
                     try {
+                        sendChannel = connect(address);
                         sendRequest(sendChannel, mergeMessage);
                     } catch (FrameworkException e) {
                         if (e.getErrcode() == FrameworkErrorCode.ChannelIsNotWritable
-                            && address != null) {
+                            && address != null && sendChannel != null) {
                             destroyChannel(address, sendChannel);
+                        }
+                        // fast fail
+                        for (Long msgId : mergeMessage.msgIds) {
+                            MessageFuture messageFuture = futures.remove(msgId);
+                            if (messageFuture != null){
+                                messageFuture.setResultMessage(null);
+                            }
                         }
                         LOGGER.error("", "client merge call failed", e);
                     }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
https://github.com/seata/seata/issues/724.
1.In the MergedSendRunnable class, the connect method can throw a FrameworkException that causes the run method to permanently close.
2.MessageFuture will wait until the timeout, which I've optimized.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

