### PR TITLE
FIX:fix ZK Register bugs

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemoting.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/AbstractRpcRemoting.java
@@ -340,7 +340,7 @@ public abstract class AbstractRpcRemoting extends ChannelDuplexHandler implement
     }
 
     /**
-     * 用于测试。发现线程池满时可以打开这个变量，把堆栈打出来分享
+     * For testing. When the thread pool is full, you can change this variable and share the stack
      */
     boolean allowDumpStack = false;
 

--- a/discovery/src/main/java/com/alibaba/fescar/discovery/registry/ZookeeperRegisterServiceImpl.java
+++ b/discovery/src/main/java/com/alibaba/fescar/discovery/registry/ZookeeperRegisterServiceImpl.java
@@ -69,7 +69,8 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
     private static final ConcurrentMap<String, List<InetSocketAddress>> CLUSTER_ADDRESS_MAP = new ConcurrentHashMap<>();
     private static final ConcurrentMap<String, List<IZkChildListener>> LISTENER_SERVICE_MAP = new ConcurrentHashMap<>();
 
-    private static final Set<String> REGISTERED_PATH_SET = Collections.synchronizedSet(new HashSet<>(1));
+    private static final int REGISTERED_PATH_SET_SIZE = 1;
+    private static final Set<String> REGISTERED_PATH_SET = Collections.synchronizedSet(new HashSet<>(REGISTERED_PATH_SET_SIZE));
 
     private ZookeeperRegisterServiceImpl() {}
 

--- a/discovery/src/main/java/com/alibaba/fescar/discovery/registry/ZookeeperRegisterServiceImpl.java
+++ b/discovery/src/main/java/com/alibaba/fescar/discovery/registry/ZookeeperRegisterServiceImpl.java
@@ -69,7 +69,7 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
     private static final ConcurrentMap<String, List<InetSocketAddress>> CLUSTER_ADDRESS_MAP = new ConcurrentHashMap<>();
     private static final ConcurrentMap<String, List<IZkChildListener>> LISTENER_SERVICE_MAP = new ConcurrentHashMap<>();
 
-    private static final Set<String> REGISTERED_PATH_SET = Collections.synchronizedSet(new HashSet<>());
+    private static final Set<String> REGISTERED_PATH_SET = Collections.synchronizedSet(new HashSet<>(1));
 
     private ZookeeperRegisterServiceImpl() {}
 

--- a/discovery/src/main/java/com/alibaba/fescar/discovery/registry/ZookeeperRegisterServiceImpl.java
+++ b/discovery/src/main/java/com/alibaba/fescar/discovery/registry/ZookeeperRegisterServiceImpl.java
@@ -216,10 +216,7 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
     private void recover() throws Exception {
         // recover Server
         if (!REGISTERED_PATH_SET.isEmpty()){
-            List<String> pathList = new ArrayList<>(REGISTERED_PATH_SET);
-            for (String path : pathList) {
-                doRegister(path);
-            }
+            REGISTERED_PATH_SET.forEach(path -> doRegister(path));
         }
         // recover client
         if (!LISTENER_SERVICE_MAP.isEmpty()){

--- a/discovery/src/main/java/com/alibaba/fescar/discovery/registry/ZookeeperRegisterServiceImpl.java
+++ b/discovery/src/main/java/com/alibaba/fescar/discovery/registry/ZookeeperRegisterServiceImpl.java
@@ -16,21 +16,26 @@
 
 package com.alibaba.fescar.discovery.registry;
 
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
+import com.alibaba.fescar.common.util.CollectionUtils;
 import com.alibaba.fescar.common.util.NetUtil;
 import com.alibaba.fescar.config.Configuration;
 import com.alibaba.fescar.config.ConfigurationFactory;
-import com.alibaba.nacos.client.naming.utils.CollectionUtils;
-
 import org.I0Itec.zkclient.IZkChildListener;
+import org.I0Itec.zkclient.IZkStateListener;
 import org.I0Itec.zkclient.ZkClient;
+import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static com.alibaba.fescar.common.Constants.IP_PORT_SPLIT_CHAR;
 
@@ -63,6 +68,8 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
     private static final ConcurrentMap<String, List<InetSocketAddress>> CLUSTER_ADDRESS_MAP = new ConcurrentHashMap<>();
     private static final ConcurrentMap<String, List<IZkChildListener>> LISTENER_SERVICE_MAP = new ConcurrentHashMap<>();
 
+    private static final ConcurrentMap<String,String> REGISTERED_PATH_MAP = new ConcurrentHashMap<>();
+
     private ZookeeperRegisterServiceImpl() {}
 
     public static ZookeeperRegisterServiceImpl getInstance() {
@@ -81,7 +88,21 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
         NetUtil.validAddress(address);
 
         String path = getRegisterPathByPath(address);
-        getClientInstance().createPersistent(path, true);
+        doRegister(path);
+    }
+
+    private boolean doRegister(String path) {
+        if (checkExists(path)) {
+            return false;
+        }
+        getClientInstance().createEphemeral(path, true);
+        REGISTERED_PATH_MAP.putIfAbsent(path, null);
+        return true;
+    }
+
+
+    private boolean checkExists(String path) {
+        return getClientInstance().exists(path);
     }
 
     @Override
@@ -90,6 +111,7 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
 
         String path = getRegisterPathByPath(address);
         getClientInstance().delete(path);
+        REGISTERED_PATH_MAP.remove(path);
     }
 
     @Override
@@ -169,8 +191,48 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
             if (!zkClient.exists(ROOT_PATH_WITHOUT_SUFFIX)) {
                 zkClient.createPersistent(ROOT_PATH_WITHOUT_SUFFIX, true);
             }
+            zkClient.subscribeStateChanges(new IZkStateListener() {
+
+                @Override
+                public void handleStateChanged(Watcher.Event.KeeperState keeperState) throws Exception {
+                    //ignore
+                }
+
+                @Override
+                public void handleNewSession() throws Exception {
+                    recover();
+                }
+
+                @Override
+                public void handleSessionEstablishmentError(Throwable throwable) throws Exception {
+                    //ignore
+                }
+            });
         }
         return zkClient;
+    }
+
+    private void recover() throws Exception {
+        // recover Server
+        if (!REGISTERED_PATH_MAP.isEmpty()){
+            List<String> pathList = new ArrayList<>(REGISTERED_PATH_MAP.keySet());
+            for (String path : pathList) {
+                doRegister(path);
+            }
+        }
+        // recover client
+        if (!LISTENER_SERVICE_MAP.isEmpty()){
+            Map<String, List<IZkChildListener>> listenerMap = new HashMap<>(LISTENER_SERVICE_MAP);
+            for (Map.Entry<String, List<IZkChildListener>> listenerEntry : listenerMap.entrySet()){
+                List<IZkChildListener> iZkChildListeners = listenerEntry.getValue();
+                if (CollectionUtils.isEmpty(iZkChildListeners)){
+                    continue;
+                }
+                for (IZkChildListener listener : iZkChildListeners){
+                    subscribe(listenerEntry.getKey(), listener);
+                }
+            }
+        }
     }
 
     private void subscribeCluster(String clusterName) throws Exception {


### PR DESCRIPTION
this can replace the shutdownHook in the RedisRegistry.Another benefit is that the shutdown code is unified

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
1.fix ZK USES persistent nodes and does not support disconnected reconnections
2.A Chinese document has been modified

