### PR TITLE
 optimize the timeout settings of rpc, timeout exception occurs when high cocurrent

### DIFF
--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyBaseConfig.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyBaseConfig.java
@@ -16,6 +16,10 @@
 
 package com.alibaba.fescar.core.rpc.netty;
 
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.alibaba.fescar.common.exception.ShouldNeverHappenException;
 import com.alibaba.fescar.config.Configuration;
 import com.alibaba.fescar.config.ConfigurationFactory;
@@ -34,9 +38,6 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.NettyRuntime;
 import io.netty.util.internal.PlatformDependent;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The type Netty base config.
@@ -71,6 +72,11 @@ public class NettyBaseConfig {
      * The constant WORKER_THREAD_SIZE.
      */
     protected static int WORKER_THREAD_SIZE;
+    
+    /**
+     * The constant RPC_REQUEST_TIMEOUT
+     */
+    protected static int RPC_REQUEST_TIMEOUT;
 
     /**
      * The constant TRANSPORT_SERVER_TYPE.
@@ -94,6 +100,11 @@ public class NettyBaseConfig {
     private static final int DEFAULT_WRITE_IDLE_SECONDS = 5;
 
     private static final int READIDLE_BASE_WRITEIDLE = 3;
+    
+    /**
+     * 设置默认的req超时时间
+     */
+    private static final int DEFAULT_RPC_REQUEST_TIMEOUT = 30*1000;
 
     /**
      * The constant MAX_WRITE_IDLE_SECONDS.
@@ -119,6 +130,17 @@ public class NettyBaseConfig {
             WORKER_THREAD_SIZE = WorkThreadMode.getModeByName(workerThreadSize).getValue();
         } else {
             WORKER_THREAD_SIZE = WorkThreadMode.Default.getValue();
+        }
+        
+        String requestTimeOut =  CONFIG.getConfig("rpc.request.timeout");
+        if (StringUtils.isEmpty(requestTimeOut) || StringUtils.isBlank(requestTimeOut)){
+            RPC_REQUEST_TIMEOUT = DEFAULT_RPC_REQUEST_TIMEOUT;
+        }else {
+            try {
+                RPC_REQUEST_TIMEOUT = Integer.parseInt(requestTimeOut);
+            } catch (NumberFormatException e) {
+                RPC_REQUEST_TIMEOUT = DEFAULT_RPC_REQUEST_TIMEOUT;
+            }
         }
         TRANSPORT_SERVER_TYPE = TransportServerType.valueOf(CONFIG.getConfig("transport.server"));
         switch (TRANSPORT_SERVER_TYPE) {

--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyClientConfig.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyClientConfig.java
@@ -16,8 +16,6 @@
 
 package com.alibaba.fescar.core.rpc.netty;
 
-import org.apache.commons.lang.StringUtils;
-
 import com.alibaba.fescar.core.rpc.netty.NettyPoolKey.TransactionRole;
 
 import io.netty.channel.Channel;
@@ -37,7 +35,6 @@ public class NettyClientConfig extends NettyBaseConfig {
     private int perHostMaxConn = 2;
     private static final int PER_HOST_MIN_CONN = 2;
     private int pendingConnSize = Integer.MAX_VALUE;
-    private static int RPC_REQUEST_TIMEOUT;
     private final boolean useConnPool = false;
     private static String vgroup;
     private static String clientAppName;
@@ -57,25 +54,6 @@ public class NettyClientConfig extends NettyBaseConfig {
     private static final boolean DEFAULT_POOL_TEST_BORROW = true;
     private static final boolean DEFAULT_POOL_TEST_RETURN = true;
     private static final boolean DEFAULT_POOL_LIFO = true;
-    
-    /**
-     * 设置默认的req超时时间
-     */
-    private static final int DEFAULT_RPC_REQUEST_TIMEOUT = 30*1000;
-    
-    
-    static {
-        String requestTimeOut =  CONFIG.getConfig("rpc.request.timeout");
-        if (StringUtils.isEmpty(requestTimeOut) || StringUtils.isBlank(requestTimeOut)){
-            RPC_REQUEST_TIMEOUT = DEFAULT_RPC_REQUEST_TIMEOUT;
-        }else {
-            try {
-                RPC_REQUEST_TIMEOUT = Integer.parseInt(requestTimeOut);
-            } catch (NumberFormatException e) {
-                RPC_REQUEST_TIMEOUT = DEFAULT_RPC_REQUEST_TIMEOUT;
-            }
-        }
-    }
     /**
      * Gets connect timeout millis.
      *

--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyClientConfig.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyClientConfig.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fescar.core.rpc.netty;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.alibaba.fescar.core.rpc.netty.NettyPoolKey.TransactionRole;
 
 import io.netty.channel.Channel;
@@ -35,7 +37,7 @@ public class NettyClientConfig extends NettyBaseConfig {
     private int perHostMaxConn = 2;
     private static final int PER_HOST_MIN_CONN = 2;
     private int pendingConnSize = Integer.MAX_VALUE;
-    private static final int RPC_REQUEST_TIMEOUT = 30 * 1000;
+    private static int RPC_REQUEST_TIMEOUT;
     private final boolean useConnPool = false;
     private static String vgroup;
     private static String clientAppName;
@@ -55,7 +57,25 @@ public class NettyClientConfig extends NettyBaseConfig {
     private static final boolean DEFAULT_POOL_TEST_BORROW = true;
     private static final boolean DEFAULT_POOL_TEST_RETURN = true;
     private static final boolean DEFAULT_POOL_LIFO = true;
-
+    
+    /**
+     * 设置默认的req超时时间
+     */
+    private static final int DEFAULT_RPC_REQUEST_TIMEOUT = 30*1000;
+    
+    
+    static {
+        String requestTimeOut =  CONFIG.getConfig("rpc.request.timeout");
+        if (StringUtils.isEmpty(requestTimeOut) || StringUtils.isBlank(requestTimeOut)){
+            RPC_REQUEST_TIMEOUT = DEFAULT_RPC_REQUEST_TIMEOUT;
+        }else {
+            try {
+                RPC_REQUEST_TIMEOUT = Integer.parseInt(requestTimeOut);
+            } catch (NumberFormatException e) {
+                RPC_REQUEST_TIMEOUT = DEFAULT_RPC_REQUEST_TIMEOUT;
+            }
+        }
+    }
     /**
      * Gets connect timeout millis.
      *

--- a/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyServerConfig.java
+++ b/core/src/main/java/com/alibaba/fescar/core/rpc/netty/NettyServerConfig.java
@@ -37,7 +37,6 @@ public class NettyServerConfig extends NettyBaseConfig {
     private int writeBufferHighWaterMark = 67108864;
     private int writeBufferLowWaterMark = 1048576;
     private static final int DEFAULT_LISTEN_PORT = 8091;
-    private static final int RPC_REQUEST_TIMEOUT = 30 * 1000;
     private boolean enableServerPooledByteBufAllocator = true;
     private int serverChannelMaxIdleTimeSeconds = 30;
     private static final String DEFAULT_BOSS_THREAD_PREFIX = "NettyBoss";

--- a/server/src/main/resources/file.conf
+++ b/server/src/main/resources/file.conf
@@ -49,3 +49,7 @@ client {
   }
   report.retry.count = 5
 }
+
+rpc {
+    request.timeout = 30000
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->


### Ⅰ. Describe what this PR did
在进行dubbo调用时,经常会出现服务端调用超时回滚的现象

### II. Describe how to verify it
在server中的file.conf文件中,将rpc.request.timeout的值进行重新设置,再次进行并发调用即可,如果客户端需要进行一样的设置,一样需要在samples中的file.conf进行设置

ps:如果不能进行合并,请改进一下配置的超时时间,方便调用