### PR TITLE
change the key type to `String`

### DIFF
--- a/core/src/main/java/io/seata/core/rpc/netty/RmRpcClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmRpcClient.java
@@ -221,7 +221,8 @@ public final class RmRpcClient extends AbstractRpcRemotingClient {
                     LOGGER.info("RmRpcClient channel" + ctx.channel() + " idle.");
                 }
                 try {
-                    nettyClientKeyPool.invalidateObject(poolKeyMap.get(ctx.channel().remoteAddress()), ctx.channel());
+                    String serverAddress = NetUtil.toStringAddress(ctx.channel().remoteAddress());
+                    nettyClientKeyPool.invalidateObject(poolKeyMap.get(serverAddress), ctx.channel());
                 } catch (Exception exx) {
                     LOGGER.error(exx.getMessage());
                 } finally {

--- a/core/src/main/java/io/seata/core/rpc/netty/TmRpcClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/TmRpcClient.java
@@ -193,7 +193,8 @@ public final class TmRpcClient extends AbstractRpcRemotingClient {
                     LOGGER.info("channel" + ctx.channel() + " read idle.");
                 }
                 try {
-                    nettyClientKeyPool.invalidateObject(poolKeyMap.get(ctx.channel().remoteAddress()), ctx.channel());
+                    String serverAddress = NetUtil.toStringAddress(ctx.channel().remoteAddress());
+                    nettyClientKeyPool.invalidateObject(poolKeyMap.get(serverAddress), ctx.channel());
                 } catch (Exception exx) {
                     LOGGER.error(exx.getMessage());
                 } finally {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
The return type of `ctx.channel().remoteAddress()`  isn't  `String`.I changed it. 

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

