### PR TITLE
Break undo if data snapshot is not changed.

### DIFF
--- a/common/src/main/java/io/seata/common/util/CollectionUtils.java
+++ b/common/src/main/java/io/seata/common/util/CollectionUtils.java
@@ -21,6 +21,7 @@ import java.util.Collection;
  * The type Collection utils.
  *
  * @author zhangsen
+ * @author Geng Zhang
  */
 public class CollectionUtils {
 
@@ -42,5 +43,24 @@ public class CollectionUtils {
      */
     public static boolean isNotEmpty(Collection col){
         return col != null && col.size() > 0;
+    }
+
+    /**
+     * Is size equals boolean.
+     *
+     * @param col0 the col 0
+     * @param col1 the col 1
+     * @return the boolean
+     */
+    public static boolean isSizeEquals(Collection col0, Collection col1) {
+        if (col0 == null) {
+            return col1 == null;
+        } else {
+            if (col1 == null) {
+                return false;
+            } else {
+                return col0.size() == col1.size();
+            }
+        }
     }
 }

--- a/common/src/main/java/io/seata/common/util/StringUtils.java
+++ b/common/src/main/java/io/seata/common/util/StringUtils.java
@@ -32,6 +32,7 @@ import javax.sql.rowset.serial.SerialBlob;
  * The type String utils.
  *
  * @author jimin.jm @alibaba-inc.com
+ * @author Geng Zhang
  */
 public class StringUtils {
 
@@ -45,7 +46,7 @@ public class StringUtils {
      * @param str the str
      * @return the boolean
      */
-    public static final boolean isNullOrEmpty(String str) {
+    public static boolean isNullOrEmpty(String str) {
         return (str == null) || (str.isEmpty());
     }
 
@@ -195,5 +196,33 @@ public class StringUtils {
             sb.append(";");
         }
         return sb.toString();
+    }
+
+    /**
+     * Equals boolean.
+     *
+     * @param a the a
+     * @param b the b
+     * @return boolean
+     */
+    public static boolean equals(String a, String b) {
+        if (a == null) {
+            return b == null;
+        }
+        return a.equals(b);
+    }
+
+    /**
+     * Equals ignore case boolean.
+     *
+     * @param a the a
+     * @param b the b
+     * @return the boolean
+     */
+    public static boolean equalsIgnoreCase(String a, String b) {
+        if (a == null) {
+            return b == null;
+        }
+        return a.equalsIgnoreCase(b);
     }
 }

--- a/common/src/test/java/io/seata/common/util/CollectionUtilsTest.java
+++ b/common/src/test/java/io/seata/common/util/CollectionUtilsTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.common.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Geng Zhang
+ */
+public class CollectionUtilsTest {
+
+    @Test
+    public void isSizeEquals() {
+        List<String> list0 = new ArrayList<>();
+        List<String> list1 = new ArrayList<>();
+        Assertions.assertTrue(CollectionUtils.isSizeEquals(null, null));
+        Assertions.assertFalse(CollectionUtils.isSizeEquals(null, list0));
+        Assertions.assertFalse(CollectionUtils.isSizeEquals(list1, null));
+        Assertions.assertTrue(CollectionUtils.isSizeEquals(list0, list1));
+
+        list0.add("111");
+        Assertions.assertFalse(CollectionUtils.isSizeEquals(list0, list1));
+        list1.add("111");
+        Assertions.assertTrue(CollectionUtils.isSizeEquals(list0, list1));
+    }
+}

--- a/common/src/test/java/io/seata/common/util/StringUtilsTest.java
+++ b/common/src/test/java/io/seata/common/util/StringUtilsTest.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 
 import javax.sql.rowset.serial.SerialBlob;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * The type String utils test.
  *
  * @author Otis.z
+ * @author Geng Zhang
  * @date 2019 /2/20
  */
 public class StringUtilsTest {
@@ -83,5 +85,27 @@ public class StringUtilsTest {
         InputStream inputStream = StringUtilsTest.class.getClassLoader().getResourceAsStream("test.txt");
         assertThat(StringUtils.inputStream2String(inputStream))
             .isEqualTo("abc\n" + ":\"klsdf\n" + "2ks,x:\".,-3sd˚ø≤ø¬≥");
+    }
+
+    @Test
+    void testEquals() {
+        Assertions.assertTrue(StringUtils.equals("1", "1"));
+        Assertions.assertFalse(StringUtils.equals("1", "2"));
+        Assertions.assertFalse(StringUtils.equals(null, "1"));
+        Assertions.assertFalse(StringUtils.equals("1", null));
+        Assertions.assertFalse(StringUtils.equals("", null));
+        Assertions.assertFalse(StringUtils.equals(null, ""));
+    }
+
+    @Test
+    void testEqualsIgnoreCase() {
+        Assertions.assertTrue(StringUtils.equalsIgnoreCase("a", "a"));
+        Assertions.assertTrue(StringUtils.equalsIgnoreCase("a", "A"));
+        Assertions.assertTrue(StringUtils.equalsIgnoreCase("A", "a"));
+        Assertions.assertFalse(StringUtils.equalsIgnoreCase("1", "2"));
+        Assertions.assertFalse(StringUtils.equalsIgnoreCase(null, "1"));
+        Assertions.assertFalse(StringUtils.equalsIgnoreCase("1", null));
+        Assertions.assertFalse(StringUtils.equalsIgnoreCase("", null));
+        Assertions.assertFalse(StringUtils.equalsIgnoreCase(null, ""));
     }
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/DataCompareUtils.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/DataCompareUtils.java
@@ -1,0 +1,150 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource;
+
+import io.seata.common.util.CollectionUtils;
+import io.seata.common.util.StringUtils;
+import io.seata.rm.datasource.sql.struct.Field;
+import io.seata.rm.datasource.sql.struct.Row;
+import io.seata.rm.datasource.sql.struct.TableMeta;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The type Data compare utils.
+ *
+ * @author Geng Zhang
+ */
+public class DataCompareUtils {
+
+    /**
+     * Is field equals.
+     *
+     * @param f0 the f0
+     * @param f1  the f1
+     * @return the boolean
+     */
+    public static boolean isFieldEquals(Field f0, Field f1) {
+        if (f0 == null) {
+            return f1 == null;
+        } else {
+            if (f1 == null) {
+                return false;
+            } else {
+                if (StringUtils.equalsIgnoreCase(f0.getName(), f1.getName())
+                        && f0.getType() == f1.getType()) {
+                    if (f0.getValue() == null) {
+                        return f1.getValue() == null;
+                    } else {
+                        if (f1.getValue() == null) {
+                            return false;
+                        } else {
+                            return f0.getValue().equals(f1.getValue());
+                        }
+                    }
+                } else {
+                    return false;
+                }
+            }
+        }
+    }
+
+    /**
+     * Is image equals.
+     *
+     * @param beforeImage the before image
+     * @param afterImage  the after image
+     * @return boolean
+     */
+    public static boolean isRecordsEquals(TableRecords beforeImage, TableRecords afterImage) {
+        if (beforeImage == null) {
+            return afterImage == null;
+        } else {
+            if (afterImage == null) {
+                return false;
+            } else {
+                if (beforeImage.getTableName().equalsIgnoreCase(afterImage.getTableName())
+                        && CollectionUtils.isSizeEquals(beforeImage.getRows(), afterImage.getRows())) {
+                    return compareRows(beforeImage.getTableMeta(), beforeImage.getRows(), afterImage.getRows());
+                } else {
+                    return false;
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Is rows equals.
+     *
+     * @param tableMetaData the table meta data
+     * @param oldRows       the old rows
+     * @param newRows       the new rows
+     * @return the boolean
+     */
+    public static boolean isRowsEquals(TableMeta tableMetaData, List<Row> oldRows, List<Row> newRows) {
+        return CollectionUtils.isSizeEquals(oldRows, newRows) && compareRows(tableMetaData, oldRows, newRows);
+    }
+
+    private static boolean compareRows(TableMeta tableMetaData, List<Row> oldRows, List<Row> newRows) {
+        // old row to map
+        Map<String, Map<String, Field>> oldRowsMap = rowListToMap(oldRows, tableMetaData.getPkName());
+        // new row to map
+        Map<String, Map<String, Field>> newRowsMap = rowListToMap(newRows, tableMetaData.getPkName());
+        // compare data
+        for (String rowKey : oldRowsMap.keySet()) {
+            Map<String, Field> oldRow = oldRowsMap.get(rowKey);
+            Map<String, Field> newRow = newRowsMap.get(rowKey);
+            if (newRow == null) {
+                return false;
+            }
+            for (String fieldName : oldRow.keySet()) {
+                Field oldField = oldRow.get(fieldName);
+                Field newField = newRow.get(fieldName);
+                if (newField == null) {
+                    return false;
+                }
+                if (!isFieldEquals(oldField, newField)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static Map<String, Map<String, Field>> rowListToMap(List<Row> rowList, String primaryKey) {
+        // {value of primaryKey, value of all columns}
+        Map<String, Map<String, Field>> rowMap = new HashMap<>();
+        for (Row row : rowList) {
+            // {uppercase fieldName : field}
+            Map<String, Field> colsMap = new HashMap<>();
+            String rowKey = null;
+            for (int j = 0; j < row.getFields().size(); j++) {
+                Field field = row.getFields().get(j);
+                if (field.getName().equalsIgnoreCase(primaryKey)) {
+                    rowKey = String.valueOf(field.getValue());
+                }
+                colsMap.put(field.getName().trim().toUpperCase(), field);
+            }
+            rowMap.put(rowKey, colsMap);
+        }
+        return rowMap;
+    }
+
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoExecutor.java
@@ -20,6 +20,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 
+import io.seata.rm.datasource.DataCompareUtils;
 import io.seata.rm.datasource.sql.struct.Field;
 import io.seata.rm.datasource.sql.struct.KeyType;
 import io.seata.rm.datasource.sql.struct.Row;
@@ -29,6 +30,7 @@ import io.seata.rm.datasource.sql.struct.TableRecords;
  * The type Abstract undo executor.
  *
  * @author sharajava
+ * @author Geng Zhang
  */
 public abstract class AbstractUndoExecutor {
 
@@ -60,8 +62,12 @@ public abstract class AbstractUndoExecutor {
      * @throws SQLException the sql exception
      */
     public void executeOn(Connection conn) throws SQLException {
-        dataValidation(conn);
 
+        // no need undo if the before data snapshot is equivalent to the after data snapshot.
+        if (DataCompareUtils.isRecordsEquals(sqlUndoLog.getBeforeImage(), sqlUndoLog.getAfterImage())) {
+            return;
+        }
+        dataValidation(conn);
         try {
             String undoSQL = buildUndoSQL();
 
@@ -87,7 +93,7 @@ public abstract class AbstractUndoExecutor {
 
         } catch (Exception ex) {
             if (ex instanceof SQLException) {
-                throw (SQLException)ex;
+                throw (SQLException) ex;
             } else {
                 throw new SQLException(ex);
             }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/DataCompareUtilsTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/DataCompareUtilsTest.java
@@ -1,0 +1,154 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource;
+
+import io.seata.rm.datasource.sql.struct.Field;
+import io.seata.rm.datasource.sql.struct.Row;
+import io.seata.rm.datasource.sql.struct.TableMeta;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Geng Zhang
+ */
+public class DataCompareUtilsTest {
+
+    @Test
+    public void isFieldEquals() {
+        Field field0 = new Field("name", 0, "111");
+        Field field1 = new Field("name", 1, "111");
+        Field field2 = new Field("name", 0, "222");
+        Field field3 = new Field("age", 0, "222");
+        Field field4 = new Field("name", 0, null);
+
+        Assertions.assertFalse(DataCompareUtils.isFieldEquals(field0, null));
+        Assertions.assertFalse(DataCompareUtils.isFieldEquals(null, field0));
+        Assertions.assertFalse(DataCompareUtils.isFieldEquals(field0, field1));
+        Assertions.assertFalse(DataCompareUtils.isFieldEquals(field0, field2));
+        Assertions.assertFalse(DataCompareUtils.isFieldEquals(field0, field3));
+        Assertions.assertFalse(DataCompareUtils.isFieldEquals(field0, field4));
+
+        Field field10 = new Field("Name", 0, "111");
+        Field field11 = new Field("Name", 0, null);
+        Assertions.assertTrue(DataCompareUtils.isFieldEquals(field0, field10));
+        Assertions.assertTrue(DataCompareUtils.isFieldEquals(field4, field11));
+    }
+
+    @Test
+    public void isRecordsEquals() {
+        TableMeta tableMeta = Mockito.mock(TableMeta.class);
+        Mockito.when(tableMeta.getPkName()).thenReturn("pk");
+        Mockito.when(tableMeta.getTableName()).thenReturn("table_name");
+
+        TableRecords beforeImage = new TableRecords();
+        beforeImage.setTableName("table_name");
+        beforeImage.setTableMeta(tableMeta);
+
+        List<Row> rows = new ArrayList<>();
+        Row row = new Row();
+        Field field01 = addField(row,"pk", 1, "12345");
+        Field field02 = addField(row,"age", 1, "18");
+        rows.add(row);
+        beforeImage.setRows(rows);
+
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, null));
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(null, beforeImage));
+
+        TableRecords afterImage = new TableRecords();
+        afterImage.setTableName("table_name1"); // wrong table name
+        afterImage.setTableMeta(tableMeta);
+
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage));
+        afterImage.setTableName("table_name");
+
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage));
+
+        List<Row> rows2 = new ArrayList<>();
+        Row row2 = new Row();
+        Field field11 = addField(row2,"pk", 1, "12345");
+        Field field12 = addField(row2,"age", 1, "18");
+        rows2.add(row2);
+        afterImage.setRows(rows2);
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(beforeImage, afterImage));
+
+        field11.setValue("23456");
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage));
+        field11.setValue("12345");
+
+        field12.setName("sex");
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage));
+        field12.setName("age");
+
+        field12.setValue("19");
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage));
+        field12.setName("18");
+
+        Field field3 = new Field("pk", 1, "12346");
+        Row row3 = new Row();
+        row3.add(field3);
+        rows2.add(row3);
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage));
+        
+
+        beforeImage.setRows(new ArrayList<>());
+        afterImage.setRows(new ArrayList<>());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(beforeImage, afterImage));
+    }
+    
+    private Field addField(Row row, String name, int type, Object value){
+        Field field = new Field(name, type, value);
+        row.add(field);
+        return field;
+    }
+
+    @Test
+    public void isRowsEquals() {
+        TableMeta tableMeta = Mockito.mock(TableMeta.class);
+        Mockito.when(tableMeta.getPkName()).thenReturn("pk");
+        Mockito.when(tableMeta.getTableName()).thenReturn("table_name");
+
+        List<Row> rows = new ArrayList<>();
+        Field field = new Field("pk", 1, "12345");
+        Row row = new Row();
+        row.add(field);
+        rows.add(row);
+
+        Assertions.assertFalse(DataCompareUtils.isRowsEquals(tableMeta, rows, null));
+        Assertions.assertFalse(DataCompareUtils.isRowsEquals(tableMeta, null, rows));
+
+        List<Row> rows2 = new ArrayList<>();
+        Field field2 = new Field("pk", 1, "12345");
+        Row row2 = new Row();
+        row2.add(field2);
+        rows2.add(row2);
+        Assertions.assertTrue(DataCompareUtils.isRowsEquals(tableMeta, rows, rows2));
+
+        field.setValue("23456");
+        Assertions.assertFalse(DataCompareUtils.isRowsEquals(tableMeta, rows, rows2));
+        field.setValue("12345");
+
+        Field field3 = new Field("pk", 1, "12346");
+        Row row3 = new Row();
+        row3.add(field3);
+        rows2.add(row3);
+        Assertions.assertFalse(DataCompareUtils.isRowsEquals(tableMeta, rows, rows2));
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

- Add DataCompareUtils
- Add some test case.
- Do not execute `undo` if the before data snapshot is equivalent to the after data snapshot.

### Ⅱ. Does this pull request fix one issue?

Part of #1049 
