### PR TITLE
Refactor Charset using and blob utils.

### DIFF
--- a/common/src/main/java/io/seata/common/Constants.java
+++ b/common/src/main/java/io/seata/common/Constants.java
@@ -15,6 +15,8 @@
  */
 package io.seata.common;
 
+import java.nio.charset.Charset;
+
 /**
  * The type Constants.
  *
@@ -97,4 +99,13 @@ public class Constants {
      */
     public final static String TCC_ACTION_CONTEXT = "actionContext";
 
+    /**
+     * default charset name
+     */
+    public static final String DEFAULT_CHARSET_NAME = "UTF-8";
+    
+    /**
+     * default charset is utf-8
+     */
+    public static final Charset DEFAULT_CHARSET = Charset.forName(DEFAULT_CHARSET_NAME);
 }

--- a/common/src/main/java/io/seata/common/loader/EnhancedServiceLoader.java
+++ b/common/src/main/java/io/seata/common/loader/EnhancedServiceLoader.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.seata.common.Constants;
 import io.seata.common.executor.Initialize;
 import io.seata.common.util.CollectionUtils;
 
@@ -259,7 +260,7 @@ public class EnhancedServiceLoader {
                 java.net.URL url = urls.nextElement();
                 BufferedReader reader = null;
                 try {
-                    reader = new BufferedReader(new InputStreamReader(url.openStream(), "utf-8"));
+                    reader = new BufferedReader(new InputStreamReader(url.openStream(), Constants.DEFAULT_CHARSET));
                     String line = null;
                     while ((line = reader.readLine()) != null) {
                         final int ci = line.indexOf('#');

--- a/common/src/main/java/io/seata/common/util/BlobUtils.java
+++ b/common/src/main/java/io/seata/common/util/BlobUtils.java
@@ -15,19 +15,18 @@
  */
 package io.seata.common.util;
 
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 import java.sql.Blob;
 
 import javax.sql.rowset.serial.SerialBlob;
 
-import io.seata.common.exception.ShouldNeverHappenException;
+import io.seata.common.Constants;
 import io.seata.common.exception.ShouldNeverHappenException;
 
 /**
  * The type Blob utils.
  *
  * @author jimin.jm @alibaba-inc.com
+ * @author Geng Zhang
  */
 public class BlobUtils {
 
@@ -47,7 +46,7 @@ public class BlobUtils {
         }
 
         try {
-            return new SerialBlob(str.getBytes());
+            return new SerialBlob(str.getBytes(Constants.DEFAULT_CHARSET));
         } catch (Exception e) {
             throw new ShouldNeverHappenException(e);
         }
@@ -65,26 +64,43 @@ public class BlobUtils {
         }
 
         try {
-            return new String(blob.getBytes((long)1, (int)blob.length()));
+            return new String(blob.getBytes((long) 1, (int) blob.length()), Constants.DEFAULT_CHARSET);
         } catch (Exception e) {
             throw new ShouldNeverHappenException(e);
         }
     }
 
     /**
-     * Input stream 2 string string.
+     * Byte array to blob
      *
-     * @param is the is
-     * @return the string
+     * @param bytes the byte array
+     * @return the blob
      */
-    public static String inputStream2String(InputStream is) {
+    public static Blob bytes2Blob(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            int i = -1;
-            while ((i = is.read()) != -1) {
-                baos.write(i);
-            }
-            return baos.toString();
+            return new SerialBlob(bytes);
+        } catch (Exception e) {
+            throw new ShouldNeverHappenException(e);
+        }
+    }
+
+    /**
+     * Blob to byte array.
+     *
+     * @param blob the blob
+     * @return the byte array
+     */
+    public static byte[] blob2Bytes(Blob blob) {
+        if (blob == null) {
+            return null;
+        }
+
+        try {
+            return blob.getBytes((long) 1, (int) blob.length());
         } catch (Exception e) {
             throw new ShouldNeverHappenException(e);
         }

--- a/common/src/main/java/io/seata/common/util/StringUtils.java
+++ b/common/src/main/java/io/seata/common/util/StringUtils.java
@@ -15,18 +15,16 @@
  */
 package io.seata.common.util;
 
+import io.seata.common.Constants;
+import io.seata.common.exception.ShouldNeverHappenException;
+
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
-import java.sql.Blob;
-import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
-
-import javax.sql.rowset.serial.SerialBlob;
 
 /**
  * The type String utils.
@@ -92,48 +90,47 @@ public class StringUtils {
     }
 
     /**
-     * String 2 blob blob.
-     *
-     * @param str the str
-     * @return the blob
-     * @throws SQLException the sql exception
-     */
-    public static Blob string2blob(String str) throws SQLException {
-        if (str == null) {
-            return null;
-        }
-        return new SerialBlob(str.getBytes());
-    }
-
-    /**
-     * Blob 2 string string.
-     *
-     * @param blob the blob
-     * @return the string
-     * @throws SQLException the sql exception
-     */
-    public static String blob2string(Blob blob) throws SQLException {
-        if (blob == null) {
-            return null;
-        }
-
-        return new String(blob.getBytes((long)1, (int)blob.length()));
-    }
-
-    /**
      * Input stream 2 string string.
      *
      * @param is the is
      * @return the string
-     * @throws IOException the io exception
      */
-    public static String inputStream2String(InputStream is) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        int i = -1;
-        while ((i = is.read()) != -1) {
-            baos.write(i);
+    public static String inputStream2String(InputStream is) {
+        if (is == null) {
+            return null;
         }
-        return baos.toString();
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            int i = -1;
+            while ((i = is.read()) != -1) {
+                baos.write(i);
+            }
+            return baos.toString(Constants.DEFAULT_CHARSET_NAME);
+        } catch (Exception e) {
+            throw new ShouldNeverHappenException(e);
+        }
+    }
+
+    /**
+     * Input stream to byte array
+     *
+     * @param is the is
+     * @return the byte array
+     */
+    public static byte[] inputStream2Bytes(InputStream is) {
+        if (is == null) {
+            return null;
+        }
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            int i = -1;
+            while ((i = is.read()) != -1) {
+                baos.write(i);
+            }
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new ShouldNeverHappenException(e);
+        }
     }
 
     /**

--- a/common/src/test/java/io/seata/common/util/BlobUtilsTest.java
+++ b/common/src/test/java/io/seata/common/util/BlobUtilsTest.java
@@ -15,21 +15,22 @@
  */
 package io.seata.common.util;
 
-import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
 
 import javax.sql.rowset.serial.SerialBlob;
 
-import org.junit.jupiter.api.Disabled;
+import io.seata.common.Constants;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * The type Blob utils test.
  *
  * @author Otis.z
+ * @author Geng Zhang
  * @date 2019 /2/26
  */
 public class BlobUtilsTest {
@@ -41,8 +42,9 @@ public class BlobUtilsTest {
      */
     @Test
     public void testString2blob() throws SQLException {
+        assertNull(BlobUtils.string2blob(null));
         assertThat(BlobUtils.string2blob("123abc")).isEqualTo(
-            new SerialBlob("123abc".getBytes(Charset.forName("UTF-8"))));
+            new SerialBlob("123abc".getBytes(Constants.DEFAULT_CHARSET)));
     }
 
     /**
@@ -52,19 +54,24 @@ public class BlobUtilsTest {
      */
     @Test
     public void testBlob2string() throws SQLException {
-        assertThat(BlobUtils.blob2string(new SerialBlob("123absent".getBytes(Charset.forName("UTF-8"))))).isEqualTo(
+        assertNull(BlobUtils.blob2string(null));
+        assertThat(BlobUtils.blob2string(new SerialBlob("123absent".getBytes(Constants.DEFAULT_CHARSET)))).isEqualTo(
             "123absent");
     }
 
-    /**
-     * Test input stream 2 string.
-     */
     @Test
-    @Disabled
-    public void testInputStream2String() {
-        InputStream inputStream = BlobUtilsTest.class.getClassLoader().getResourceAsStream("test.txt");
-        assertThat(BlobUtils.inputStream2String(inputStream)).isEqualTo("abc\n"
-            + ":\"klsdf\n"
-            + "2ks,x:\".,-3sd˚ø≤ø¬≥");
+    void bytes2Blob() throws UnsupportedEncodingException, SQLException {
+        assertNull(BlobUtils.bytes2Blob(null));
+        byte[] bs = "xxa哈哈dd".getBytes(Constants.DEFAULT_CHARSET_NAME);
+        assertThat(BlobUtils.bytes2Blob(bs)).isEqualTo(
+                new SerialBlob(bs));
+    }
+
+    @Test
+    void blob2Bytes() throws UnsupportedEncodingException, SQLException {
+        assertNull(BlobUtils.blob2Bytes(null));
+        byte[] bs = "xxa哈哈dd".getBytes(Constants.DEFAULT_CHARSET_NAME);
+        assertThat(BlobUtils.blob2Bytes(new SerialBlob(bs))).isEqualTo(
+                bs);
     }
 }

--- a/common/src/test/java/io/seata/common/util/StringUtilsTest.java
+++ b/common/src/test/java/io/seata/common/util/StringUtilsTest.java
@@ -15,17 +15,15 @@
  */
 package io.seata.common.util;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.sql.SQLException;
 
-import javax.sql.rowset.serial.SerialBlob;
-
+import io.seata.common.Constants;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * The type String utils test.
@@ -48,43 +46,25 @@ public class StringUtilsTest {
         assertThat(StringUtils.isNullOrEmpty(" ")).isFalse();
     }
 
-    /**
-     * Test string 2 blob.
-     *
-     * @throws SQLException the sql exception
-     */
     @Test
-    public void testString2blob() throws SQLException {
-        assertThat(StringUtils.string2blob(null)).isNull();
-        String[] strs = new String[] {"abc", "", " "};
-        for (String str : strs) {
-            assertThat(StringUtils.string2blob(str)).isEqualTo(new SerialBlob(str.getBytes()));
-        }
-    }
-
-    /**
-     * Test blob 2 string.
-     *
-     * @throws SQLException the sql exception
-     */
-    @Test
-    public void testBlob2string() throws SQLException {
-        String[] strs = new String[] {"abc", " "};
-        for (String str : strs) {
-            assertThat(StringUtils.blob2string(new SerialBlob(str.getBytes()))).isEqualTo(str);
-
-        }
-    }
-
-    /**
-     * Test input stream 2 string.
-     */
-    @Test
-    @Disabled
     public void testInputStream2String() throws IOException {
-        InputStream inputStream = StringUtilsTest.class.getClassLoader().getResourceAsStream("test.txt");
-        assertThat(StringUtils.inputStream2String(inputStream))
-            .isEqualTo("abc\n" + ":\"klsdf\n" + "2ks,x:\".,-3sd˚ø≤ø¬≥");
+        assertNull(StringUtils.inputStream2String(null));
+        String data = "abc\n"
+                + ":\"klsdf\n"
+                + "2ks,x:\".,-3sd˚ø≤ø¬≥";
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(data.getBytes(Constants.DEFAULT_CHARSET));
+        assertThat(StringUtils.inputStream2String(inputStream)).isEqualTo(data);
+    }
+
+    @Test
+    void inputStream2Bytes() {
+        assertNull(StringUtils.inputStream2Bytes(null));
+        String data = "abc\n"
+                + ":\"klsdf\n"
+                + "2ks,x:\".,-3sd˚ø≤ø¬≥";
+        byte[] bs = data.getBytes(Constants.DEFAULT_CHARSET);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(data.getBytes(Constants.DEFAULT_CHARSET));
+        assertThat(StringUtils.inputStream2Bytes(inputStream)).isEqualTo(bs);
     }
 
     @Test

--- a/core/src/main/java/io/seata/core/protocol/AbstractMessage.java
+++ b/core/src/main/java/io/seata/core/protocol/AbstractMessage.java
@@ -18,6 +18,7 @@ package io.seata.core.protocol;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 
+import io.seata.common.Constants;
 import io.seata.core.protocol.transaction.BranchCommitRequest;
 import io.seata.core.protocol.transaction.BranchCommitResponse;
 import io.seata.core.protocol.transaction.BranchRegisterRequest;
@@ -152,7 +153,7 @@ public abstract class AbstractMessage implements MessageCodec, Serializable {
     /**
      * The constant UTF8.
      */
-    protected static final Charset UTF8 = Charset.forName("utf-8");
+    protected static final Charset UTF8 = Constants.DEFAULT_CHARSET;
     /**
      * The Ctx.
      */

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogManager.java
@@ -18,7 +18,6 @@ package io.seata.rm.datasource.undo;
 import com.alibaba.druid.util.JdbcConstants;
 import io.seata.common.exception.NotSupportYetException;
 import io.seata.common.util.BlobUtils;
-import io.seata.common.util.StringUtils;
 import io.seata.core.exception.TransactionException;
 import io.seata.rm.datasource.ConnectionContext;
 import io.seata.rm.datasource.ConnectionProxy;
@@ -161,7 +160,7 @@ public final class UndoLogManager {
                     }
 
                     Blob b = rs.getBlob("rollback_info");
-                    String rollbackInfo = StringUtils.blob2string(b);
+                    String rollbackInfo = BlobUtils.blob2string(b);
                     BranchUndoLog branchUndoLog = UndoLogParserFactory.getInstance().decode(rollbackInfo);
 
                     for (SQLUndoLog sqlUndoLog : branchUndoLog.getSqlUndoLogs()) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

- All use default `UTF-8` charset
- Remove `BlobUtils#inputStream2String()` which duplicate with StringUtils
- Delete `StringUtils#string2blob()` which duplicate with BlobUtils
- Add `BlobUtils#blob2Bytes()` and `BlobUtils#bytes2Blob()`
- Add more test case.