### PR TITLE
undo the pr of 'disable createDependencyReducedPom' #1033

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -423,7 +423,7 @@
                             <createSourcesJar>true</createSourcesJar>
                             <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
                             <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
                             <artifactSet>
                                 <includes>
                                     <include>io.seata:seata-common</include>


### PR DESCRIPTION
Set the createDependencyReducedPom to true.

The code of seata-* has all be packed  into the seata-all.jar,  and should not be inclueded in the seata-all.pom.