### PR TITLE
Change the method definition of UndoLogParser for better extensibility.

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.alibaba.fastjson.annotation.JSONField;
 import io.seata.common.exception.ShouldNeverHappenException;
 
 /**
@@ -31,8 +30,7 @@ import io.seata.common.exception.ShouldNeverHappenException;
  */
 public class TableRecords {
 
-    @JSONField(serialize = false)
-    private TableMeta tableMeta;
+    private transient TableMeta tableMeta;
 
     private String tableName;
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/JSONBasedUndoLogParser.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/JSONBasedUndoLogParser.java
@@ -17,6 +17,7 @@ package io.seata.rm.datasource.undo;
 
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.SerializerFeature;
+import io.seata.common.Constants;
 
 /**
  * The type Json based undo log parser.
@@ -26,12 +27,14 @@ import com.alibaba.fastjson.serializer.SerializerFeature;
 public class JSONBasedUndoLogParser implements UndoLogParser {
 
     @Override
-    public String encode(BranchUndoLog branchUndoLog) {
-        return JSON.toJSONString(branchUndoLog, SerializerFeature.WriteDateUseDateFormat);
+    public byte[] encode(BranchUndoLog branchUndoLog) {
+        String json = JSON.toJSONString(branchUndoLog, SerializerFeature.WriteDateUseDateFormat);
+        return json.getBytes(Constants.DEFAULT_CHARSET);
     }
 
     @Override
-    public BranchUndoLog decode(String text) {
+    public BranchUndoLog decode(byte[] bytes) {
+        String text = new String(bytes, Constants.DEFAULT_CHARSET);
         return JSON.parseObject(text, BranchUndoLog.class);
     }
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogManager.java
@@ -16,6 +16,7 @@
 package io.seata.rm.datasource.undo;
 
 import com.alibaba.druid.util.JdbcConstants;
+import io.seata.common.Constants;
 import io.seata.common.exception.NotSupportYetException;
 import io.seata.common.util.BlobUtils;
 import io.seata.core.exception.TransactionException;
@@ -102,10 +103,10 @@ public final class UndoLogManager {
         branchUndoLog.setBranchId(branchID);
         branchUndoLog.setSqlUndoLogs(connectionContext.getUndoItems());
 
-        String undoLogContent = UndoLogParserFactory.getInstance().encode(branchUndoLog);
+        byte[] undoLogContent = UndoLogParserFactory.getInstance().encode(branchUndoLog);
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Flushing UNDO LOG: " + undoLogContent);
+            LOGGER.debug("Flushing UNDO LOG: {}",new String(undoLogContent, Constants.DEFAULT_CHARSET));
         }
 
         insertUndoLogWithNormal(xid, branchID, undoLogContent, cp.getTargetConnection());
@@ -154,13 +155,15 @@ public final class UndoLogManager {
                     // ensuring that only the undo_log in the normal state is processed.
                     int state = rs.getInt("log_status");
                     if (!canUndo(state)) {
-                        LOGGER.info("xid {} branch {}, ignore {} undo_log",
-                            xid, branchId, state);
+                        if (LOGGER.isInfoEnabled()) {
+                            LOGGER.info("xid {} branch {}, ignore {} undo_log",
+                                    xid, branchId, state);
+                        }
                         return;
                     }
 
                     Blob b = rs.getBlob("rollback_info");
-                    String rollbackInfo = BlobUtils.blob2string(b);
+                    byte[] rollbackInfo = BlobUtils.blob2Bytes(b);
                     BranchUndoLog branchUndoLog = UndoLogParserFactory.getInstance().decode(rollbackInfo);
 
                     for (SQLUndoLog sqlUndoLog : branchUndoLog.getSqlUndoLogs()) {
@@ -185,20 +188,26 @@ public final class UndoLogManager {
                 if (exists) {
                     deleteUndoLog(xid, branchId, conn);
                     conn.commit();
-                    LOGGER.info("xid {} branch {}, undo_log deleted with {}",
-                        xid, branchId, State.GlobalFinished.name());
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("xid {} branch {}, undo_log deleted with {}",
+                                xid, branchId, State.GlobalFinished.name());
+                    }
                 } else {
                     insertUndoLogWithGlobalFinished(xid, branchId, conn);
                     conn.commit();
-                    LOGGER.info("xid {} branch {}, undo_log added with {}",
-                        xid, branchId, State.GlobalFinished.name());
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("xid {} branch {}, undo_log added with {}",
+                                xid, branchId, State.GlobalFinished.name());
+                    }
                 }
 
                 return;
             } catch (SQLIntegrityConstraintViolationException e) {
                 // Possible undo_log has been inserted into the database by other processes, retrying rollback undo_log
-                LOGGER.info("xid {} branch {}, undo_log inserted, retry rollback",
-                    xid, branchId);
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("xid {} branch {}, undo_log inserted, retry rollback",
+                            xid, branchId);
+                }
             } catch (Throwable e) {
                 if (conn != null) {
                     try {
@@ -244,16 +253,16 @@ public final class UndoLogManager {
             deletePST = conn.prepareStatement(batchDeleteSql);
             int paramsIndex = 1;
             for (Long branchId : branchIds) {
-                deletePST.setLong(paramsIndex++,branchId);
+                deletePST.setLong(paramsIndex++, branchId);
             }
-            for (String xid: xids){
+            for (String xid : xids) {
                 deletePST.setString(paramsIndex++, xid);
             }
             int deleteRows = deletePST.executeUpdate();
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("batch delete undo log size " + deleteRows);
             }
-        }catch (Exception e){
+        } catch (Exception e) {
             if (!(e instanceof SQLException)) {
                 e = new SQLException(e);
             }
@@ -267,7 +276,7 @@ public final class UndoLogManager {
     }
 
     protected static String toBatchDeleteUndoLogSql(int xidSize, int branchIdSize) {
-        StringBuilder sqlBuilder = new StringBuilder();
+        StringBuilder sqlBuilder = new StringBuilder(64);
         sqlBuilder.append("DELETE FROM ")
                 .append(UNDO_LOG_TABLE_NAME)
                 .append(" WHERE  branch_id IN ");
@@ -303,7 +312,7 @@ public final class UndoLogManager {
             deletePST.setLong(1, branchId);
             deletePST.setString(2, xid);
             deletePST.executeUpdate();
-        }catch (Exception e){
+        } catch (Exception e) {
             if (!(e instanceof SQLException)) {
                 e = new SQLException(e);
             }
@@ -316,23 +325,23 @@ public final class UndoLogManager {
     }
 
     private static void insertUndoLogWithNormal(String xid, long branchID,
-                                                String undoLogContent, Connection conn) throws SQLException {
+                                                byte[] undoLogContent, Connection conn) throws SQLException {
         insertUndoLog(xid, branchID, undoLogContent, State.Normal, conn);
     }
 
     private static void insertUndoLogWithGlobalFinished(String xid, long branchID,
                                                         Connection conn) throws SQLException {
-        insertUndoLog(xid, branchID, "{}", State.GlobalFinished, conn);
+        insertUndoLog(xid, branchID, "{}".getBytes(Constants.DEFAULT_CHARSET), State.GlobalFinished, conn);
     }
 
     private static void insertUndoLog(String xid, long branchID,
-                                      String undoLogContent, State state, Connection conn) throws SQLException {
+                                      byte[] undoLogContent, State state, Connection conn) throws SQLException {
         PreparedStatement pst = null;
         try {
             pst = conn.prepareStatement(INSERT_UNDO_LOG_SQL);
             pst.setLong(1, branchID);
             pst.setString(2, xid);
-            pst.setBlob(3, BlobUtils.string2blob(undoLogContent));
+            pst.setBlob(3, BlobUtils.bytes2Blob(undoLogContent));
             pst.setInt(4, state.getValue());
             pst.executeUpdate();
         } catch (Exception e) {

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BaseExecutorTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BaseExecutorTest.java
@@ -22,7 +22,7 @@ import io.seata.rm.datasource.sql.struct.Row;
 /**
  * @author Geng Zhang
  */
-public class BaseExecutorTest {
+public abstract class BaseExecutorTest {
 
     protected static Field addField(Row row, String name, int type, Object value) {
         Field field = new Field(name, type, value);

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BaseH2Test.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BaseH2Test.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo;
+
+import io.seata.rm.datasource.sql.struct.ColumnMeta;
+import io.seata.rm.datasource.sql.struct.Field;
+import io.seata.rm.datasource.sql.struct.KeyType;
+import io.seata.rm.datasource.sql.struct.Row;
+import io.seata.rm.datasource.sql.struct.TableMeta;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+
+/**
+ * @author Geng Zhang
+ */
+public abstract class BaseH2Test {
+    
+    static BasicDataSource dataSource = null;
+
+    static Connection connection = null;
+
+    static TableMeta tableMeta = null;
+    
+    @BeforeAll
+    public static void start() throws SQLException {
+        dataSource = new BasicDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:./db_store/test_undo");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+
+        connection = dataSource.getConnection();
+
+        tableMeta = mockTableMeta();
+    }
+
+    @AfterAll
+    public static void stop() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+            }
+        }
+        if (dataSource != null) {
+            try {
+                dataSource.close();
+            } catch (SQLException e) {
+            }
+        }
+    }
+
+    @BeforeEach
+    private void prepareTable() {
+        execSQL("DROP TABLE table_name");
+        execSQL("CREATE TABLE table_name ( `id` int(8), `name` varchar(64), PRIMARY KEY (`id`))");
+    }
+
+    protected static void execSQL(String sql) {
+        Statement s = null;
+        try {
+            s = connection.createStatement();
+            s.execute(sql);
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (s != null) {
+                try {
+                    s.close();
+                } catch (SQLException e) {
+                }
+            }
+        }
+    }
+
+    protected static TableRecords execQuery(TableMeta tableMeta, String sql) throws SQLException {
+        Statement s = null;
+        ResultSet set = null;
+        try {
+            s = connection.createStatement();
+            set = s.executeQuery(sql);
+            return TableRecords.buildRecords(tableMeta, set);
+        } finally {
+            if (set != null) {
+                try {
+                    set.close();
+                } catch (Exception e) {
+                }
+            }
+            if (s != null) {
+                try {
+                    s.close();
+                } catch (SQLException e) {
+                }
+            }
+        }
+    }
+
+    protected static TableMeta mockTableMeta() {
+        TableMeta tableMeta = Mockito.mock(TableMeta.class);
+        Mockito.when(tableMeta.getPkName()).thenReturn("ID");
+        Mockito.when(tableMeta.getTableName()).thenReturn("table_name");
+        ColumnMeta meta0 = Mockito.mock(ColumnMeta.class);
+        Mockito.when(meta0.getDataType()).thenReturn(Types.INTEGER);
+        Mockito.when(meta0.getColumnName()).thenReturn("ID");
+        Mockito.when(tableMeta.getColumnMeta("ID")).thenReturn(meta0);
+        ColumnMeta meta1 = Mockito.mock(ColumnMeta.class);
+        Mockito.when(meta1.getDataType()).thenReturn(Types.VARCHAR);
+        Mockito.when(meta1.getColumnName()).thenReturn("NAME");
+        Mockito.when(tableMeta.getColumnMeta("NAME")).thenReturn(meta1);
+        return tableMeta;
+    }
+
+    protected static Field addField(Row row, String name, int type, Object value) {
+        Field field = new Field(name, type, value);
+        if (name.equalsIgnoreCase("id")) {
+            field.setKeyType(KeyType.PrimaryKey);
+        }
+        row.add(field);
+        return field;
+    }
+}

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BaseUndoLogParserTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BaseUndoLogParserTest.java
@@ -1,0 +1,149 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo;
+
+import io.seata.rm.datasource.DataCompareUtils;
+import io.seata.rm.datasource.sql.SQLType;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Geng Zhang
+ */
+public abstract class BaseUndoLogParserTest extends BaseH2Test{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseUndoLogParserTest.class);
+    
+    public abstract UndoLogParser getParser();
+    
+    @Test
+    void testEncodeAndDecode() throws SQLException {
+
+        execSQL("INSERT INTO table_name(id, name) VALUES (12345,'aaa');");
+        execSQL("INSERT INTO table_name(id, name) VALUES (12346,'aaa');");
+
+        TableRecords beforeImage = execQuery(tableMeta, "SELECT * FROM table_name WHERE id IN (12345, 12346);");
+        execSQL("update table_name set name = 'xxx' where id in (12345, 12346);");
+        TableRecords afterImage = execQuery(tableMeta, "SELECT * FROM table_name WHERE id IN (12345, 12346);");
+
+        TableRecords beforeImage2 = execQuery(tableMeta, "SELECT * FROM table_name WHERE id IN (12345, 12346);");
+        execSQL("INSERT INTO table_name(id, name) VALUES (12347,'aaa');");
+        execSQL("INSERT INTO table_name(id, name) VALUES (12348,'aaa');");
+        TableRecords afterImage2 = execQuery(tableMeta, "SELECT * FROM table_name WHERE id IN (12345, 12346);");
+
+        SQLUndoLog sqlUndoLog00 = new SQLUndoLog();
+        sqlUndoLog00.setSqlType(SQLType.UPDATE);
+        sqlUndoLog00.setTableMeta(tableMeta);
+        sqlUndoLog00.setTableName("table_name");
+        sqlUndoLog00.setBeforeImage(beforeImage);
+        sqlUndoLog00.setAfterImage(afterImage);
+
+        SQLUndoLog sqlUndoLog01 = new SQLUndoLog();
+        sqlUndoLog01.setSqlType(SQLType.UPDATE);
+        sqlUndoLog01.setTableMeta(tableMeta);
+        sqlUndoLog01.setTableName("table_name");
+        sqlUndoLog01.setBeforeImage(beforeImage2);
+        sqlUndoLog01.setAfterImage(afterImage2);
+
+        BranchUndoLog originLog = new BranchUndoLog();
+        originLog.setBranchId(123456L);
+        originLog.setXid("xiddddddddddd");
+        List<SQLUndoLog> logList = new ArrayList<>();
+        logList.add(sqlUndoLog00);
+        logList.add(sqlUndoLog01);
+        originLog.setSqlUndoLogs(logList);
+        
+        // start test
+        byte[] bs = getParser().encode(originLog);
+
+        Assertions.assertNotNull(bs);
+
+        LOGGER.info("data size:{}", bs.length);
+
+        BranchUndoLog dstLog = getParser().decode(bs);
+
+        Assertions.assertEquals(originLog.getBranchId(), dstLog.getBranchId());
+        Assertions.assertEquals(originLog.getXid(), dstLog.getXid());
+        Assertions.assertEquals(originLog.getSqlUndoLogs().size(), dstLog.getSqlUndoLogs().size());
+        List<SQLUndoLog> logList2 = dstLog.getSqlUndoLogs();
+        SQLUndoLog sqlUndoLog10 = logList2.get(0);
+        SQLUndoLog sqlUndoLog11 = logList2.get(1);
+        Assertions.assertEquals(sqlUndoLog00.getSqlType(), sqlUndoLog10.getSqlType());
+        Assertions.assertEquals(sqlUndoLog00.getTableName(), sqlUndoLog10.getTableName());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(sqlUndoLog00.getBeforeImage(), sqlUndoLog10.getBeforeImage()));
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(sqlUndoLog00.getAfterImage(), sqlUndoLog10.getAfterImage()));
+        Assertions.assertEquals(sqlUndoLog01.getSqlType(), sqlUndoLog11.getSqlType());
+        Assertions.assertEquals(sqlUndoLog01.getTableName(), sqlUndoLog11.getTableName());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(sqlUndoLog01.getBeforeImage(), sqlUndoLog11.getBeforeImage()));
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(sqlUndoLog01.getAfterImage(), sqlUndoLog11.getAfterImage()));
+    }
+
+    @Test
+    void testPerformance() throws SQLException {
+
+        execSQL("INSERT INTO table_name(id, name) VALUES (12345,'aaa');");
+        execSQL("INSERT INTO table_name(id, name) VALUES (12346,'aaa');");
+
+        TableRecords beforeImage = execQuery(tableMeta, "SELECT * FROM table_name WHERE id IN (12345, 12346);");
+        execSQL("update table_name set name = 'xxx' where id in (12345, 12346);");
+        TableRecords afterImage = execQuery(tableMeta, "SELECT * FROM table_name WHERE id IN (12345, 12346);");
+
+        TableRecords beforeImage2 = execQuery(tableMeta, "SELECT * FROM table_name WHERE id IN (12345, 12346);");
+        execSQL("INSERT INTO table_name(id, name) VALUES (12347,'aaa');");
+        execSQL("INSERT INTO table_name(id, name) VALUES (12348,'aaa');");
+        TableRecords afterImage2 = execQuery(tableMeta, "SELECT * FROM table_name WHERE id IN (12345, 12346);");
+
+        SQLUndoLog sqlUndoLog00 = new SQLUndoLog();
+        sqlUndoLog00.setSqlType(SQLType.UPDATE);
+        sqlUndoLog00.setTableMeta(tableMeta);
+        sqlUndoLog00.setTableName("table_name");
+        sqlUndoLog00.setBeforeImage(beforeImage);
+        sqlUndoLog00.setAfterImage(afterImage);
+
+        SQLUndoLog sqlUndoLog01 = new SQLUndoLog();
+        sqlUndoLog01.setSqlType(SQLType.UPDATE);
+        sqlUndoLog01.setTableMeta(tableMeta);
+        sqlUndoLog01.setTableName("table_name");
+        sqlUndoLog01.setBeforeImage(beforeImage2);
+        sqlUndoLog01.setAfterImage(afterImage2);
+
+        BranchUndoLog originLog = new BranchUndoLog();
+        originLog.setBranchId(123456L);
+        originLog.setXid("xiddddddddddd");
+        List<SQLUndoLog> logList = new ArrayList<>();
+        logList.add(sqlUndoLog00);
+        logList.add(sqlUndoLog01);
+        originLog.setSqlUndoLogs(logList);
+
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < 100000; i++) {
+            byte[] bs = getParser().encode(originLog);
+            Assertions.assertNotNull(bs);
+            BranchUndoLog dstLog = getParser().decode(bs);
+            Assertions.assertEquals(originLog.getBranchId(), dstLog.getBranchId());
+        }
+        long end = System.currentTimeMillis();
+        LOGGER.info("elapsed time {} ms.", (end - start));
+    }
+    
+}

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BranchUndoLogTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BranchUndoLogTest.java
@@ -68,10 +68,9 @@ public class BranchUndoLogTest {
 
         branchUndoLog.setSqlUndoLogs(items);
 
-        String encodeString = UndoLogParserFactory.getInstance().encode(branchUndoLog);
-        System.out.println(encodeString);
+        byte[] bs = UndoLogParserFactory.getInstance().encode(branchUndoLog);
 
-        BranchUndoLog decodeObj = UndoLogParserFactory.getInstance().decode(encodeString);
+        BranchUndoLog decodeObj = UndoLogParserFactory.getInstance().decode(bs);
         Assertions.assertEquals(decodeObj.getBranchId(), branchUndoLog.getBranchId());
 
     }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/JSONBasedUndoLogParserTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/JSONBasedUndoLogParserTest.java
@@ -16,26 +16,14 @@
 package io.seata.rm.datasource.undo;
 
 /**
- * The interface Undo log parser.
- *
- * @author sharajava
  * @author Geng Zhang
  */
-public interface UndoLogParser {
+public class JSONBasedUndoLogParserTest extends BaseUndoLogParserTest {
 
-    /**
-     * Encode branch undo log to byte array.
-     *
-     * @param branchUndoLog the branch undo log
-     * @return the byte array
-     */
-    byte[] encode(BranchUndoLog branchUndoLog);
+    JSONBasedUndoLogParser parser = new JSONBasedUndoLogParser();
 
-    /**
-     * Decode byte array to branch undo log.
-     *
-     * @param bytes the byte array
-     * @return the branch undo log
-     */
-    BranchUndoLog decode(byte[] bytes);
+    @Override
+    public UndoLogParser getParser() {
+        return parser;
+    }
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

- change the method definition of UndoLogParser.
  - String encode(BranchUndoLog branchUndoLog) -> byte[] encode(BranchUndoLog branchUndoLog)
  - BranchUndoLog decode(String data) -> BranchUndoLog decode(byte[] bytes)
- Use `transient` instead of `@JSONField(serialize = false)` for ignore serialization of field `tableMeta`
- Refactor test case for more abstract.

### Ⅱ. Does this pull request fix one issue?

Fix #1088 
