### PR TITLE
UndoLogParser change to SPI.

### DIFF
--- a/config/seata-config-core/src/main/resources/file.conf
+++ b/config/seata-config-core/src/main/resources/file.conf
@@ -73,4 +73,5 @@ client {
 
 transaction {
   undo.data.validation = true
+  undo.log.serialization = fastjson
 }

--- a/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
+++ b/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
@@ -189,14 +189,17 @@ public class ConfigurationKeys {
      */
     public static final String  TIMEOUT_RETRY_DELAY = "recovery.timeout-retry-delay";
 
-
     /**
      * The constant TRANSACTION_PREFIX.
      */
     public static final String TRANSACTION_PREFIX = "transaction.";
 
     /**
-     * The constant RM_DATASOURCE_UNOD_VALIDATION.
+     * The constant TRANSACTION_UNDO_DATA_VALIDATION.
      */
-    public static final String TRANSACTION_UNOD_DATA_VALIDATION = TRANSACTION_PREFIX + "undo.data.validation";
+    public static final String TRANSACTION_UNDO_DATA_VALIDATION = TRANSACTION_PREFIX + "undo.data.validation";
+    /**
+     * The constant TRANSACTION_UNDO_LOG_SERIALIZATION.
+     */
+    public static final String TRANSACTION_UNDO_LOG_SERIALIZATION = TRANSACTION_PREFIX + "undo.log.serialization";
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoExecutor.java
@@ -59,7 +59,7 @@ public abstract class AbstractUndoExecutor {
      * Switch of undo data validation
      */
     public static final boolean IS_UNDO_DATA_VALIDATION_ENABLE = ConfigurationFactory.getInstance()
-            .getBoolean(ConfigurationKeys.TRANSACTION_UNOD_DATA_VALIDATION, true);
+            .getBoolean(ConfigurationKeys.TRANSACTION_UNDO_DATA_VALIDATION, true);
 
     /**
      * The Sql undo log.

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogParserFactory.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogParserFactory.java
@@ -28,12 +28,9 @@ import io.seata.core.constants.ConfigurationKeys;
 public class UndoLogParserFactory {
 
     private static class SingletonHolder {
-        private static UndoLogParser INSTANCE;
-        static {
-            String st = ConfigurationFactory.getInstance().getConfig(
-                    ConfigurationKeys.TRANSACTION_UNDO_LOG_SERIALIZATION, "fastjson");
-            INSTANCE = EnhancedServiceLoader.load(UndoLogParser.class, st);
-        }
+        private static final UndoLogParser INSTANCE = 
+                EnhancedServiceLoader.load(UndoLogParser.class, ConfigurationFactory.getInstance()
+                        .getConfig(ConfigurationKeys.TRANSACTION_UNDO_LOG_SERIALIZATION, "fastjson"));
     }
 
     /**

--- a/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.UndoLogParser
+++ b/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.UndoLogParser
@@ -1,0 +1,1 @@
+io.seata.rm.datasource.undo.JSONBasedUndoLogParser

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/UndoLogParserFactoryTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/UndoLogParserFactoryTest.java
@@ -15,25 +15,16 @@
  */
 package io.seata.rm.datasource.undo;
 
-import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.serializer.SerializerFeature;
-import io.seata.common.loader.LoadLevel;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
- * The type Json based undo log parser.
- *
- * @author sharajava
+ * @author Geng Zhang
  */
-@LoadLevel(name = "fastjson")
-public class JSONBasedUndoLogParser implements UndoLogParser {
+class UndoLogParserFactoryTest {
 
-    @Override
-    public String encode(BranchUndoLog branchUndoLog) {
-        return JSON.toJSONString(branchUndoLog, SerializerFeature.WriteDateUseDateFormat);
-    }
-
-    @Override
-    public BranchUndoLog decode(String text) {
-        return JSON.parseObject(text, BranchUndoLog.class);
+    @Test
+    void getInstance() {
+        Assertions.assertTrue(UndoLogParserFactory.getInstance() instanceof JSONBasedUndoLogParser);
     }
 }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/UndoLogParserProviderTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/UndoLogParserProviderTest.java
@@ -16,33 +16,26 @@
 package io.seata.rm.datasource.undo;
 
 import io.seata.common.loader.EnhancedServiceLoader;
-import io.seata.config.ConfigurationFactory;
-import io.seata.core.constants.ConfigurationKeys;
+import io.seata.common.loader.EnhancedServiceNotFoundException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
- * The type Undo log parser factory.
- *
- * @author sharajava
  * @author Geng Zhang
  */
-public class UndoLogParserFactory {
+class UndoLogParserProviderTest {
 
-    private static class SingletonHolder {
-        private static UndoLogParser INSTANCE;
-        static {
-            String st = ConfigurationFactory.getInstance().getConfig(
-                    ConfigurationKeys.TRANSACTION_UNDO_LOG_SERIALIZATION, "fastjson");
-            INSTANCE = EnhancedServiceLoader.load(UndoLogParser.class, st);
+    @Test
+    void testError(){
+        UndoLogParser parser = EnhancedServiceLoader.load(UndoLogParser.class, "fastjson");
+        Assertions.assertNotNull(parser);
+        Assertions.assertTrue(parser instanceof JSONBasedUndoLogParser);
+        
+        try {
+            EnhancedServiceLoader.load(UndoLogParser.class, "adadad");
+            Assertions.fail();
+        } catch (Exception e) {
+            Assertions.assertTrue(e instanceof EnhancedServiceNotFoundException);
         }
     }
-
-    /**
-     * Gets instance.
-     *
-     * @return the instance
-     */
-    public static UndoLogParser getInstance() {
-        return SingletonHolder.INSTANCE;
-    }
-
 }

--- a/server/src/main/resources/file.conf
+++ b/server/src/main/resources/file.conf
@@ -106,4 +106,5 @@ recovery{
 
 transaction {
   undo.data.validation = true
+  undo.log.serialization = fastjson
 }

--- a/server/src/main/resources/nacos-config.txt
+++ b/server/src/main/resources/nacos-config.txt
@@ -37,10 +37,10 @@ store.db.branch.table=branch_table
 store.db.query-limit=100
 lock.mode=memory
 lock.db.lock-table=lock_table
-recovery.committing-retry-delay = 5
-recovery.asyn-committing-retry-delay = 5
-recovery.rollbacking-retry-delay = 5
-recovery.timeout-retry-delay = 5
+recovery.committing-retry-delay=5
+recovery.asyn-committing-retry-delay=5
+recovery.rollbacking-retry-delay=5
+recovery.timeout-retry-delay=5
 transaction.undo.data.validation=true
 transaction.undo.log.serialization=fastjson
 

--- a/server/src/main/resources/nacos-config.txt
+++ b/server/src/main/resources/nacos-config.txt
@@ -42,4 +42,5 @@ recovery.asyn-committing-retry-delay = 5
 recovery.rollbacking-retry-delay = 5
 recovery.timeout-retry-delay = 5
 transaction.undo.data.validation=true
+transaction.undo.log.serialization=fastjson
 

--- a/test/src/test/resources/file.conf
+++ b/test/src/test/resources/file.conf
@@ -73,4 +73,5 @@ client {
 
 transaction {
   undo.data.validation = true
+  undo.log.serialization = fastjson
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
- `UndoLogParser` change to SPI mode and make `fastjson` as default implement.
- Add config `transaction.undo.log.serialization`
- Fix one typo.
- Add test cases.

### Ⅱ. Does this pull request fix one issue?

Fix #1010 

