### PR TITLE
bugfix: seata-server.bat classpath too long

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -87,6 +87,8 @@
                     <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
                     <repositoryLayout>flat</repositoryLayout>
                     <repositoryName>lib</repositoryName>
+                    <encoding>UTF-8</encoding>
+                    <useWildcardClassPath>true</useWildcardClassPath>
                     <binFileExtensions>
                         <unix>.sh</unix>
                     </binFileExtensions>
@@ -101,6 +103,10 @@
                                     <extraArgument>-XX:MaxDirectMemorySize=1024M</extraArgument>
                                 </extraArguments>
                             </jvmSettings>
+                            <platforms>
+                                <platform>windows</platform>
+                                <platform>unix</platform>
+                            </platforms>
                         </program>
                     </programs>
                 </configuration>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -91,6 +91,7 @@
                     <useWildcardClassPath>true</useWildcardClassPath>
                     <binFileExtensions>
                         <unix>.sh</unix>
+                        <windows>.bat</windows>
                     </binFileExtensions>
                     <assembleDirectory>../distribution</assembleDirectory>
                     <programs>


### PR DESCRIPTION
Signed-off-by: slievrly <slievrly@163.com>

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

when the server is running in windows, the classpath is too long to failure start.


### Ⅱ. Does this pull request fix one issue?

fix #1136 


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

![image](https://user-images.githubusercontent.com/8758457/58616702-e5c27880-82f0-11e9-9d1b-f01bba471af7.png)
![image](https://user-images.githubusercontent.com/8758457/58616728-f541c180-82f0-11e9-80c4-930bf6581035.png)



### Ⅴ. Special notes for reviews

