### PR TITLE
bugfix:the buffer may cause overflows when sql statement is long

### DIFF
--- a/core/src/main/java/io/seata/core/protocol/MergedWarpMessage.java
+++ b/core/src/main/java/io/seata/core/protocol/MergedWarpMessage.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MergedWarpMessage extends AbstractMessage implements Serializable, MergeMessage {
     private static final long serialVersionUID = -5758802337446717090L;
+
     /**
      * The Msgs.
      */
@@ -51,7 +52,7 @@ public class MergedWarpMessage extends AbstractMessage implements Serializable, 
 
     @Override
     public byte[] encode() {
-        final ByteBuf buffer = Unpooled.buffer();
+        final ByteBuf buffer = Unpooled.buffer(1024);
         buffer.writeInt(0); // write placeholder for content length
 
         buffer.writeShort((short) msgs.size());

--- a/core/src/main/java/io/seata/core/protocol/MergedWarpMessage.java
+++ b/core/src/main/java/io/seata/core/protocol/MergedWarpMessage.java
@@ -15,16 +15,15 @@
  */
 package io.seata.core.protocol;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The type Merged warp message.
@@ -37,11 +36,11 @@ public class MergedWarpMessage extends AbstractMessage implements Serializable, 
     /**
      * The Msgs.
      */
-    public List<AbstractMessage> msgs = new ArrayList<AbstractMessage>();
+    public List<AbstractMessage> msgs = new ArrayList<>();
     /**
      * The Msg ids.
      */
-    public List<Long> msgIds = new ArrayList<Long>();
+    public List<Long> msgIds = new ArrayList<>();
     private static final Logger LOGGER = LoggerFactory.getLogger(MergedWarpMessage.class);
 
     @Override

--- a/core/src/main/java/io/seata/core/protocol/MergedWarpMessage.java
+++ b/core/src/main/java/io/seata/core/protocol/MergedWarpMessage.java
@@ -15,15 +15,16 @@
  */
 package io.seata.core.protocol;
 
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Serializable;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * The type Merged warp message.


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Due to the `java.nio.ByteBuffer` can not grow dynamically, its size is hardcoded now, this patch replaces `java.nio.ByteBuffer` with `io.netty.buffer.ByteBuf`, which can grow on demand.

### Ⅱ. Does this pull request fix one issue?
fixes issue #976 


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
There is already tests upon this method.

### Ⅳ. Describe how to verify it
CI passes

### Ⅴ. Special notes for reviews
null