### PR TITLE
Reset initialized flag & instance while destroy(). split PR #1105

### DIFF
--- a/core/src/main/java/io/seata/core/rpc/netty/RmRpcClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmRpcClient.java
@@ -496,5 +496,11 @@ public final class RmRpcClient extends AbstractRpcRemotingClient {
             LOGGER.error("return channel to rmPool error:" + exx.getMessage());
         }
     }
-
+    
+    @Override
+    public void destroy() {
+        super.destroy();
+        initialized.getAndSet(false);
+        instance = null;
+    }
 }

--- a/core/src/main/java/io/seata/core/rpc/netty/TmRpcClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/TmRpcClient.java
@@ -157,7 +157,7 @@ public final class TmRpcClient extends AbstractRpcRemotingClient {
             }
         }, healthCheckDelay, healthCheckPeriod, TimeUnit.SECONDS);
     }
-
+    
     @Override
     public Object sendMsgWithResponse(Object msg, long timeout) throws TimeoutException {
         String validAddress = loadBalance(transactionServiceGroup);
@@ -407,6 +407,13 @@ public final class TmRpcClient extends AbstractRpcRemotingClient {
         } catch (Exception exx) {
             LOGGER.error("return channel to rpcPool error:" + exx.getMessage());
         }
+    }
+    
+    @Override
+    public void destroy() {
+        super.destroy();
+        initialized.getAndSet(false);
+        instance = null;
     }
 
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
reset initialized flag & instance when destroy RpcClient.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix #983

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
unit test is included in another PR, for splitting #1105 into 2 PRs.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
