### PR TITLE
bugfix: fix in which SQL and database field names are inconsistent#1217

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
@@ -180,7 +180,7 @@ public class TableRecords {
                 ColumnMeta col = tmeta.getColumnMeta(colName);
                 Field field = new Field();
                 field.setName(col.getColumnName());
-                if (tmeta.getPkName().equals(field.getName())) {
+                if (tmeta.getPkName().equalsIgnoreCase(field.getName())) {
                     field.setKeyType(KeyType.PrimaryKey);
                 }
                 field.setType(col.getDataType());


### PR DESCRIPTION
Fix Rm cannot find primary key when primary key is Uppercase in sql ,using MySQL.
fixes #1217



