### PR TITLE
optimize the name of seata config environment.

### DIFF
--- a/config/seata-config-core/src/main/java/io/seata/config/ConfigurationFactory.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/ConfigurationFactory.java
@@ -27,19 +27,19 @@ import java.util.Objects;
  * @author Geng Zhang
  */
 public final class ConfigurationFactory {
-    private static final String REGISTRY_CONF = "registry.conf";
     private static final String REGISTRY_CONF_PREFIX = "registry";
     private static final String REGISTRY_CONF_SUFFIX = ".conf";
     private static final String ENV_SYSTEM_KEY = "SEATA_CONFIG_ENV";
-    private static final String ENV_PROPERTY_KEY = "env";
+    private static final String ENV_PROPERTY_KEY = "seataConfigEnv";
     private static final String DEFAULT_ENV_VALUE = "default";
     /**
      * The constant FILE_INSTANCE.
      */
     private static String ENV_VALUE;
+
     static {
         String env = System.getenv(ENV_SYSTEM_KEY);
-        if(env != null && System.getProperty(ENV_PROPERTY_KEY) == null){
+        if (env != null && System.getProperty(ENV_PROPERTY_KEY) == null) {
             //Help users get
             System.setProperty(ENV_PROPERTY_KEY, env);
         }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Currently "env" is used as the parameter name of environment isolation, but it is too general and may conflict with the parameter name of other components.
So,i modify the env to seataConfigEnv,so it will be like:
`-DseataConfigEnv=test`


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1209

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
i have done the integration testing.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
after this PR merged,i will update the wiki page.
