### PR TITLE
Add unit tests for io.seata.common.util CompressUtil, DurationUtil, ReflectionUtil

### DIFF
--- a/common/src/test/java/io/seata/common/util/CompressUtilTest.java
+++ b/common/src/test/java/io/seata/common/util/CompressUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.common.util;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CompressUtilTest {
+
+    @Test
+    public void testCompress() throws IOException {
+        byte[] bytes = new byte[]{31, -117, 8, 0, 0, 0, 0, 0, 0, 0,
+                99, 100, 98, 6, 0, 29, -128, -68, 85, 3, 0, 0, 0};
+
+        Assertions.assertArrayEquals(bytes,
+                CompressUtil.compress(new byte[]{1, 2, 3}));
+    }
+
+    @Test
+    public void testUncompress() throws IOException {
+        byte[] bytes = new byte[]{31, -117, 8, 0, 0, 0, 0, 0, 0, 0,
+                99, 100, 98, 6, 0, 29, -128, -68, 85, 3, 0, 0, 0};
+
+        Assertions.assertArrayEquals(new byte[]{1, 2, 3},
+                CompressUtil.uncompress(bytes));
+    }
+
+    @Test
+    public void testIsCompressData() {
+        Assertions.assertFalse(CompressUtil.isCompressData(null));
+        Assertions.assertFalse(CompressUtil.isCompressData(new byte[0]));
+        Assertions.assertFalse(CompressUtil.isCompressData(new byte[]{31, 11}));
+        Assertions.assertFalse(
+                CompressUtil.isCompressData(new byte[]{31, 11, 0}));
+
+        Assertions.assertTrue(
+                CompressUtil.isCompressData(new byte[]{31, -117, 0}));
+    }
+}

--- a/common/src/test/java/io/seata/common/util/DurationUtilTest.java
+++ b/common/src/test/java/io/seata/common/util/DurationUtilTest.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.common.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DurationUtilTest {
+
+    @Test
+    public void testParse() {
+        Assertions.assertNull(DurationUtil.parse("d"));
+        Assertions.assertNull(DurationUtil.parse("h"));
+        Assertions.assertNull(DurationUtil.parse("m"));
+        Assertions.assertNull(DurationUtil.parse("s"));
+        Assertions.assertNull(DurationUtil.parse("ms"));
+
+        Assertions.assertEquals(-1L, DurationUtil.parse("").getSeconds());
+        Assertions.assertEquals(0L, DurationUtil.parse("8").getSeconds());
+        Assertions.assertEquals(0L, DurationUtil.parse("8ms").getSeconds());
+        Assertions.assertEquals(8L, DurationUtil.parse("8s").getSeconds());
+        Assertions.assertEquals(480L, DurationUtil.parse("8m").getSeconds());
+        Assertions.assertEquals(28800L, DurationUtil.parse("8h").getSeconds());
+        Assertions.assertEquals(691200L,
+                DurationUtil.parse("8d").getSeconds());
+    }
+
+    @Test
+    public void testParseThrowException() {
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> DurationUtil.parse("a"));
+
+        Assertions.assertThrows(UnsupportedOperationException.class,
+                () -> DurationUtil.parse("as"));
+
+    }
+}

--- a/common/src/test/java/io/seata/common/util/ReflectionUtilTest.java
+++ b/common/src/test/java/io/seata/common/util/ReflectionUtilTest.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.common.util;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ReflectionUtilTest {
+
+    @Test
+    public void testGetClassByName() throws ClassNotFoundException {
+        Assertions.assertEquals(String.class,
+                ReflectionUtil.getClassByName("java.lang.String"));
+    }
+
+    @Test
+    public void testGetFieldValue() throws
+            NoSuchFieldException, IllegalAccessException {
+        Assertions.assertEquals("d",
+                ReflectionUtil.getFieldValue(new DurationUtil(), "DAY_UNIT"));
+
+        Assertions.assertThrows(NoSuchFieldException.class,
+                () -> ReflectionUtil.getFieldValue(new Object(), "A1B2C3"));
+    }
+
+    @Test
+    public void testInvokeMethod() throws NoSuchMethodException,
+            IllegalAccessException, InvocationTargetException {
+        Assertions.assertEquals(0, ReflectionUtil.invokeMethod("", "length"));
+        Assertions.assertEquals(3,
+                ReflectionUtil.invokeMethod("foo", "length"));
+
+        Assertions.assertThrows(NoSuchMethodException.class,
+                () -> ReflectionUtil.invokeMethod(new String(), "size"));
+    }
+
+    @Test
+    public void testInvokeMethod2() throws NoSuchMethodException,
+            IllegalAccessException, InvocationTargetException {
+        Assertions.assertEquals(0, ReflectionUtil
+                .invokeMethod("", "length", null, null));
+        Assertions.assertEquals(3, ReflectionUtil
+                .invokeMethod("foo", "length", null, null));
+
+        Assertions.assertThrows(NoSuchMethodException.class, () -> ReflectionUtil
+                .invokeMethod(new String(), "size", null, null));
+    }
+
+    @Test
+    public void testInvokeMethod3() throws NoSuchMethodException,
+            IllegalAccessException, InvocationTargetException {
+        Assertions.assertEquals("0", ReflectionUtil.invokeStaticMethod(
+                String.class, "valueOf",
+                new Class<?>[]{int.class}, new Object[]{0}));
+        Assertions.assertEquals("123", ReflectionUtil.invokeStaticMethod(
+                String.class, "valueOf",
+                new Class<?>[]{int.class}, new Object[]{123}));
+
+        Assertions.assertThrows(NoSuchMethodException.class, () -> ReflectionUtil
+                .invokeStaticMethod(String.class, "size", null, null));
+    }
+
+    @Test
+    public void testGetMethod() throws NoSuchMethodException {
+        Assertions.assertEquals("public int java.lang.String.length()",
+                ReflectionUtil.getMethod(String.class, "length", null)
+                        .toString());
+        Assertions.assertEquals("public char java.lang.String.charAt(int)",
+                ReflectionUtil.getMethod(String.class, "charAt",
+                        new Class<?>[]{int.class}).toString());
+
+        Assertions.assertThrows(NoSuchMethodException.class,
+                () -> ReflectionUtil.getMethod(String.class, "size", null));
+    }
+
+    @Test
+    public void testGetInterfaces() {
+        Assertions.assertArrayEquals(new Object[]{Serializable.class},
+                ReflectionUtil.getInterfaces(Serializable.class).toArray());
+
+        Assertions.assertArrayEquals(new Object[]{
+                        Serializable.class, Comparable.class, CharSequence.class},
+                ReflectionUtil.getInterfaces(String.class).toArray());
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `io.seata.common.util CompressUtil, DurationUtil, ReflectionUtil` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important.