### PR TITLE
bugfix:fix CME in ZK discovery implementation.

### DIFF
--- a/discovery/seata-discovery-zk/src/main/java/io/seata/discovery/registry/zk/ZookeeperRegisterServiceImpl.java
+++ b/discovery/seata-discovery-zk/src/main/java/io/seata/discovery/registry/zk/ZookeeperRegisterServiceImpl.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static io.seata.common.Constants.IP_PORT_SPLIT_CHAR;
 
@@ -113,7 +114,7 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
             }
         }
     }
-    
+
     private boolean checkExists(String path) {
         return getClientInstance().exists(path);
     }
@@ -138,7 +139,7 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
             getClientInstance().createPersistent(path);
         }
         getClientInstance().subscribeChildChanges(path, listener);
-        LISTENER_SERVICE_MAP.putIfAbsent(cluster, new ArrayList<>());
+        LISTENER_SERVICE_MAP.putIfAbsent(cluster, new CopyOnWriteArrayList<>());
         LISTENER_SERVICE_MAP.get(cluster).add(listener);
     }
 
@@ -207,17 +208,17 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
             synchronized (ZookeeperRegisterServiceImpl.class) {
                 if (null == zkClient) {
                     zkClient = buildZkClient(FILE_CONFIG.getConfig(FILE_CONFIG_KEY_PREFIX + SERVER_ADDR_KEY),
-                            FILE_CONFIG.getInt(FILE_CONFIG_KEY_PREFIX + SESSION_TIME_OUT_KEY),
-                            FILE_CONFIG.getInt(FILE_CONFIG_KEY_PREFIX + CONNECT_TIME_OUT_KEY));
+                        FILE_CONFIG.getInt(FILE_CONFIG_KEY_PREFIX + SESSION_TIME_OUT_KEY),
+                        FILE_CONFIG.getInt(FILE_CONFIG_KEY_PREFIX + CONNECT_TIME_OUT_KEY));
                 }
             }
         }
         return zkClient;
     }
-    
+
     // visible for test.
     ZkClient buildZkClient(String address, int sessionTimeout, int connectTimeout) {
-        ZkClient zkClient = new ZkClient(address, sessionTimeout,connectTimeout);
+        ZkClient zkClient = new ZkClient(address, sessionTimeout, connectTimeout);
         if (!zkClient.exists(ROOT_PATH_WITHOUT_SUFFIX)) {
             zkClient.createPersistent(ROOT_PATH_WITHOUT_SUFFIX, true);
         }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
fix ConcurrentModificationException in Zookeeper discovery implementation.
Here, while traversing iZkChildListeners, new listener may be added, so CopyOnWriteArraylist must be used here to avoid CME.
![image](https://user-images.githubusercontent.com/24457941/60082498-6fd1f580-9766-11e9-8023-544ed35fd17d.png)

![image](https://user-images.githubusercontent.com/24457941/60082640-be7f8f80-9766-11e9-90e2-92f993f92ca1.png)


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixex #1234 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

