### PR TITLE
add warn log when fail to get auto-generated keys. (#1259)

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/InsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/InsertExecutor.java
@@ -25,6 +25,8 @@ import io.seata.rm.datasource.sql.struct.ColumnMeta;
 import io.seata.rm.datasource.sql.struct.Null;
 import io.seata.rm.datasource.sql.struct.TableMeta;
 import io.seata.rm.datasource.sql.struct.TableRecords;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -43,6 +45,7 @@ import java.util.Map;
  * @date 2019-03-21 21:30:02
  */
 public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecutor<T, S> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InsertExecutor.class);
 
     protected static final String ERR_SQL_STATE = "S1009";
 
@@ -134,6 +137,7 @@ public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
             // specify Statement.RETURN_GENERATED_KEYS to
             // Statement.executeUpdate() or Connection.prepareStatement().
             if (ERR_SQL_STATE.equalsIgnoreCase(e.getSQLState())) {
+                LOGGER.warn("Fail to get auto-generated keys, use \'SELECT LAST_INSERT_ID()\' instead. Be cautious, statement could be polluted. Recommend you set the statement to return generated keys.");
                 genKeys = statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
             } else {
                 throw e;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/InsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/InsertExecutor.java
@@ -45,8 +45,8 @@ import java.util.Map;
  * @date 2019-03-21 21:30:02
  */
 public class InsertExecutor<T, S extends Statement> extends AbstractDMLBaseExecutor<T, S> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(InsertExecutor.class);
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(InsertExecutor.class);
     protected static final String ERR_SQL_STATE = "S1009";
 
     /**

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/exec/InsertExecutorTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/exec/InsertExecutorTest.java
@@ -219,6 +219,23 @@ public class InsertExecutorTest {
     }
 
     @Test
+    public void testGetPkValuesByAuto_SQLException_WarnLog() throws SQLException {
+        doReturn(tableMeta).when(insertExecutor).getTableMeta();
+        ColumnMeta columnMeta = mock(ColumnMeta.class);
+        Map<String, ColumnMeta> columnMetaMap = new HashMap<>();
+        columnMetaMap.put(ID_COLUMN, columnMeta);
+        when(columnMeta.isAutoincrement()).thenReturn(true);
+        when(tableMeta.getPrimaryKeyMap()).thenReturn(columnMetaMap);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(statementProxy.getTargetStatement()).thenReturn(preparedStatement);
+        SQLException e = new SQLException("test warn log", InsertExecutor.ERR_SQL_STATE, 1);
+        when(preparedStatement.getGeneratedKeys()).thenThrow(e);
+        ResultSet genKeys = mock(ResultSet.class);
+        when(statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()")).thenReturn(genKeys);
+        Assertions.assertTrue(insertExecutor.getPkValuesByAuto().isEmpty());
+    }
+
+    @Test
     public void testGetPkValuesByAuto_GeneratedKeys_NoResult() throws SQLException {
         doReturn(tableMeta).when(insertExecutor).getTableMeta();
         ColumnMeta columnMeta = mock(ColumnMeta.class);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
修复issue 1259，在插入数据时，如果未显式指定PreparedStatement返回自动生成的key 使用Select last_insert_id()代替时，打印warn日志，提醒用户Statement状态可能被污染的风险。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1259

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
有测试用例，是InsertExecutorTest#testGetPkValuesByAuto_SQLException_WarnLog

### Ⅳ. Describe how to verify it
通过测试用例验证，或者 issue 1259 中的复现case验证

### Ⅴ. Special notes for reviews

