### PR TITLE
add enabled configuration for metrics

### DIFF
--- a/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
+++ b/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
@@ -220,6 +220,11 @@ public class ConfigurationKeys {
     public static final String METRICS_PREFIX = "metrics.";
 
     /**
+     * The constant METRICS_ENABLED.
+     */
+    public static final String METRICS_ENABLED = "enabled";
+
+    /**
      * The constant METRICS_REGISTRY_TYPE.
      */
     public static final String METRICS_REGISTRY_TYPE = "registry-type";

--- a/server/src/main/java/io/seata/server/metrics/MetricsManager.java
+++ b/server/src/main/java/io/seata/server/metrics/MetricsManager.java
@@ -17,6 +17,8 @@ package io.seata.server.metrics;
 
 import java.util.List;
 
+import io.seata.config.ConfigurationFactory;
+import io.seata.core.constants.ConfigurationKeys;
 import io.seata.metrics.exporter.Exporter;
 import io.seata.metrics.exporter.ExporterFactory;
 import io.seata.metrics.registry.Registry;
@@ -44,13 +46,17 @@ public class MetricsManager {
     }
 
     public void init() {
-        registry = RegistryFactory.getInstance();
-        if (registry != null) {
-            List<Exporter> exporters = ExporterFactory.getInstanceList();
-            //only at least one metrics exporter implement had imported in pom then need register MetricsSubscriber
-            if (exporters.size() != 0) {
-                exporters.forEach(exporter -> exporter.setRegistry(registry));
-                EventBusManager.get().register(new MetricsSubscriber(registry));
+        boolean enabled = ConfigurationFactory.getInstance().getBoolean(
+            ConfigurationKeys.METRICS_PREFIX + ConfigurationKeys.METRICS_ENABLED, false);
+        if (enabled) {
+            registry = RegistryFactory.getInstance();
+            if (registry != null) {
+                List<Exporter> exporters = ExporterFactory.getInstanceList();
+                //only at least one metrics exporter implement had imported in pom then need register MetricsSubscriber
+                if (exporters.size() != 0) {
+                    exporters.forEach(exporter -> exporter.setRegistry(registry));
+                    EventBusManager.get().register(new MetricsSubscriber(registry));
+                }
             }
         }
     }

--- a/server/src/main/resources/file.conf
+++ b/server/src/main/resources/file.conf
@@ -111,9 +111,10 @@ transaction {
 }
 
 ## metrics settings
-#metrics {
-#  registry-type = "compact"
-#  # multi exporters use comma divided
-#  exporter-list = "prometheus"
-#  exporter-prometheus-port = 9898
-#}
+metrics {
+  enabled = false
+  registry-type = "compact"
+  # multi exporters use comma divided
+  exporter-list = "prometheus"
+  exporter-prometheus-port = 9898
+}

--- a/server/src/test/resources/file.conf
+++ b/server/src/test/resources/file.conf
@@ -6,6 +6,7 @@ recovery {
 
 ## metrics settings
 metrics {
+  enabled = true
   registry-type = "compact"
   # multi exporters use comma divided
   exporter-list = "prometheus"


### PR DESCRIPTION
Signed-off-by: zhengyangyong <yangyong.zheng@qq.com>
### Ⅰ. Describe what this PR did

add a new configuration `enabled` for metrics:

```
## metrics settings
metrics {
  enabled = true                                          <-------- new
  registry-type = "compact"
  # multi exporters use comma divided
  exporter-list = "prometheus"
  exporter-prometheus-port = 9898
}
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

