### PR TITLE
bugfix: fix lock key npe bug, when tcc use protobuf

### DIFF
--- a/codec/seata-codec-protobuf/src/main/java/io/seata/codec/protobuf/convertor/BranchRegisterRequestConvertor.java
+++ b/codec/seata-codec-protobuf/src/main/java/io/seata/codec/protobuf/convertor/BranchRegisterRequestConvertor.java
@@ -15,12 +15,12 @@
  */
 package io.seata.codec.protobuf.convertor;
 
-import io.seata.core.model.BranchType;
 import io.seata.codec.protobuf.generated.AbstractMessageProto;
 import io.seata.codec.protobuf.generated.AbstractTransactionRequestProto;
 import io.seata.codec.protobuf.generated.BranchRegisterRequestProto;
 import io.seata.codec.protobuf.generated.BranchTypeProto;
 import io.seata.codec.protobuf.generated.MessageTypeProto;
+import io.seata.core.model.BranchType;
 import io.seata.core.protocol.transaction.BranchRegisterRequest;
 
 /**
@@ -40,11 +40,12 @@ public class BranchRegisterRequestConvertor implements PbConvertor<BranchRegiste
 
         final String applicationData = branchRegisterRequest.getApplicationData();
         final String resourceId = branchRegisterRequest.getResourceId();
+        final String lockKey = branchRegisterRequest.getLockKey();
         BranchRegisterRequestProto result = BranchRegisterRequestProto.newBuilder()
             .setAbstractTransactionRequest(abstractTransactionRequestProto)
-            .setApplicationData(applicationData==null?"":applicationData)
+            .setApplicationData(applicationData == null ? "" : applicationData)
             .setBranchType(BranchTypeProto.valueOf(branchRegisterRequest.getBranchType().name()))
-            .setLockKey(branchRegisterRequest.getLockKey())
+            .setLockKey(lockKey == null ? "" : lockKey)
             .setResourceId(resourceId == null ? "" : resourceId)
             .setXid(branchRegisterRequest.getXid())
             .build();

--- a/codec/seata-codec-protobuf/src/main/java/io/seata/codec/protobuf/convertor/GlobalLockQueryRequestConvertor.java
+++ b/codec/seata-codec-protobuf/src/main/java/io/seata/codec/protobuf/convertor/GlobalLockQueryRequestConvertor.java
@@ -15,13 +15,13 @@
  */
 package io.seata.codec.protobuf.convertor;
 
-import io.seata.core.model.BranchType;
 import io.seata.codec.protobuf.generated.AbstractMessageProto;
 import io.seata.codec.protobuf.generated.AbstractTransactionRequestProto;
 import io.seata.codec.protobuf.generated.BranchRegisterRequestProto;
 import io.seata.codec.protobuf.generated.BranchTypeProto;
 import io.seata.codec.protobuf.generated.GlobalLockQueryRequestProto;
 import io.seata.codec.protobuf.generated.MessageTypeProto;
+import io.seata.core.model.BranchType;
 import io.seata.core.protocol.transaction.GlobalLockQueryRequest;
 
 /**
@@ -41,11 +41,12 @@ public class GlobalLockQueryRequestConvertor
                 abstractMessage).build();
 
         final String applicationData = globalLockQueryRequest.getApplicationData();
+        final String lockKey = globalLockQueryRequest.getLockKey();
         BranchRegisterRequestProto branchRegisterRequestProto = BranchRegisterRequestProto.newBuilder()
             .setAbstractTransactionRequest(abstractTransactionRequestProto)
-            .setApplicationData(applicationData==null?"":applicationData)
+            .setApplicationData(applicationData == null ? "" : applicationData)
             .setBranchType(BranchTypeProto.valueOf(globalLockQueryRequest.getBranchType().name()))
-            .setLockKey(globalLockQueryRequest.getLockKey())
+            .setLockKey(lockKey == null ? "" : lockKey)
             .setResourceId(globalLockQueryRequest.getResourceId())
             .setXid(globalLockQueryRequest.getXid())
             .build();


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

tcc will not set lock key, when users use protobuf as serialize type, the setLockKey will fail.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

