### PR TITLE
bugfix: cross lock un acquired#1247

### DIFF
--- a/core/src/main/java/io/seata/core/store/db/LockStoreDataBaseDAO.java
+++ b/core/src/main/java/io/seata/core/store/db/LockStoreDataBaseDAO.java
@@ -31,9 +31,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -97,7 +98,7 @@ public class LockStoreDataBaseDAO implements LockStore, Initialize {
         PreparedStatement ps = null;
         ResultSet rs = null;
         List<LockDO> unrepeatedLockDOs = null;
-        List<String> dbExistedRowKeys = new ArrayList<>();
+        Set<String> dbExistedRowKeys = new HashSet<>();
         try {
             conn = logStoreDataSource.getConnection();
             conn.setAutoCommit(false);

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/DataCompareUtils.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/DataCompareUtils.java
@@ -42,7 +42,7 @@ public class DataCompareUtils {
      * Is field equals.
      *
      * @param f0 the f0
-     * @param f1  the f1
+     * @param f1 the f1
      * @return the boolean
      */
     public static boolean isFieldEquals(Field f0, Field f1) {
@@ -104,13 +104,16 @@ public class DataCompareUtils {
         } else {
             if (afterImage == null) {
                 return false;
-            } else {
-                if (beforeImage.getTableName().equalsIgnoreCase(afterImage.getTableName())
-                        && CollectionUtils.isSizeEquals(beforeImage.getRows(), afterImage.getRows())) {
-                    return compareRows(beforeImage.getTableMeta(), beforeImage.getRows(), afterImage.getRows());
-                } else {
-                    return false;
+            }
+            if (beforeImage.getTableName().equalsIgnoreCase(afterImage.getTableName())
+                    && CollectionUtils.isSizeEquals(beforeImage.getRows(), afterImage.getRows())) {
+                //when image is EmptyTableRecords, getTableMeta will throw an exception
+                if (CollectionUtils.isEmpty(beforeImage.getRows())) {
+                    return true;
                 }
+                return compareRows(beforeImage.getTableMeta(), beforeImage.getRows(), afterImage.getRows());
+            } else {
+                return false;
             }
         }
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogManager.java
@@ -239,8 +239,8 @@ public final class UndoLogManager {
                         LOGGER.warn("Failed to close JDBC resource while undo ... ", rollbackEx);
                     }
                 }
-                throw new TransactionException(BranchRollbackFailed_Retriable, String.format("%s/%s", branchId, xid),
-                    e);
+                throw new TransactionException(BranchRollbackFailed_Retriable, String.format("%s/%s %s", branchId, xid, e.getMessage()),
+                        e);
 
             } finally {
                 try {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
bugfix: when RM try to acquire lock including the ones are acquired and the other are not acquired at the same time. TC find there exist relock so it jump out without acquring the other lock.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1247 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

