### PR TITLE
bugfix: check null channel

### DIFF
--- a/core/src/main/java/io/seata/core/rpc/netty/NettyClientChannelManager.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/NettyClientChannelManager.java
@@ -233,7 +233,7 @@ class NettyClientChannelManager {
                     LOGGER.error(exx.getMessage());
                 }
                 rmChannel = channels.get(serverAddress);
-                if (null == rmChannel || rmChannel.isActive()) {
+                if (null != rmChannel && rmChannel.isActive()) {
                     return rmChannel;
                 }
             }


### PR DESCRIPTION
Ⅰ. Describe what this PR did
`                if (null == rmChannel || rmChannel.isActive()) {
                    return rmChannel;
                }`
Our goal is to get a active rmChannel,So when null == rmChannel ,we can not return,Otherwise it will be called in a loop.

### Ⅱ. Does this pull request fix one issue?
I dont know.


### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it
review maybe

### Ⅴ. Special notes for reviews

