### PR TITLE
optimize: reduce the number of lock conflict exception

### DIFF
--- a/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
+++ b/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
@@ -97,6 +97,12 @@ public class ConfigurationKeys {
      * The constant CLIENT_REPORT_RETRY_COUNT.
      */
     public static final String CLIENT_REPORT_RETRY_COUNT = CLIENT_PREFIX + "report.retry.count";
+
+    /**
+     * The constant CLIENT_LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT.
+     */
+    public static final String CLIENT_LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT = CLIENT_PREFIX + "lock.retry.policy.branch-rollback-on-conflict";
+
     /**
      * The constant CLIENT_TABLE_META_CHECK_ENABLE.
      */

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -17,6 +17,7 @@ package io.seata.rm.datasource;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.concurrent.Callable;
 
 import com.alibaba.druid.util.JdbcConstants;
 
@@ -28,6 +29,7 @@ import io.seata.core.model.BranchStatus;
 import io.seata.core.model.BranchType;
 import io.seata.rm.DefaultResourceManager;
 import io.seata.rm.datasource.exec.LockConflictException;
+import io.seata.rm.datasource.exec.LockRetryController;
 import io.seata.rm.datasource.undo.SQLUndoLog;
 import io.seata.rm.datasource.undo.UndoLogManager;
 import io.seata.rm.datasource.undo.UndoLogManagerOracle;
@@ -49,6 +51,8 @@ public class ConnectionProxy extends AbstractConnectionProxy {
 
     private static int REPORT_RETRY_COUNT = ConfigurationFactory.getInstance().getInt(
         ConfigurationKeys.CLIENT_REPORT_RETRY_COUNT, DEFAULT_REPORT_RETRY_COUNT);
+
+    private final static LockRetryPolicy LOCK_RETRY_POLICY = new LockRetryPolicy();
 
     /**
      * Instantiates a new Connection proxy.
@@ -158,6 +162,19 @@ public class ConnectionProxy extends AbstractConnectionProxy {
 
     @Override
     public void commit() throws SQLException {
+        try {
+            LOCK_RETRY_POLICY.execute(() -> {
+                doCommit();
+                return null;
+            });
+        } catch (SQLException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SQLException(e);
+        }
+    }
+
+    private void doCommit() throws SQLException {
         if (context.inGlobalTransaction()) {
             processGlobalTransactionCommit();
         } else if (context.isGlobalLockRequire()) {
@@ -224,7 +241,7 @@ public class ConnectionProxy extends AbstractConnectionProxy {
     public void setAutoCommit(boolean autoCommit) throws SQLException {
         if ((autoCommit) && !getAutoCommit()) {
             // change autocommit from false to true, we should commit() first according to JDBC spec.
-            commit();
+            doCommit();
         }
         targetConnection.setAutoCommit(autoCommit);
     }
@@ -245,6 +262,43 @@ public class ConnectionProxy extends AbstractConnectionProxy {
                     throw new SQLException("Failed to report branch status " + commitDone, ex);
                 }
             }
+        }
+    }
+
+    public static class LockRetryPolicy {
+        protected final static boolean LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT =
+                ConfigurationFactory.getInstance().getBoolean(ConfigurationKeys.CLIENT_LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT, true);
+
+        public <T> T execute(Callable<T> callable) throws Exception {
+            if (LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT) {
+                return callable.call();
+            } else {
+                return doRetryOnLockConflict(callable);
+            }
+        }
+
+        protected <T> T doRetryOnLockConflict(Callable<T> callable) throws Exception {
+            LockRetryController lockRetryController = new LockRetryController();
+            while (true) {
+                try {
+                    return callable.call();
+                } catch (LockConflictException lockConflict) {
+                    onException(lockConflict);
+                    lockRetryController.sleep(lockConflict);
+                } catch (Exception e) {
+                    onException(e);
+                    throw e;
+                }
+            }
+        }
+
+        /**
+         * Callback on exception in doLockRetryOnConflict.
+         *
+         * @param e invocation exception
+         * @throws Exception error
+         */
+        protected void onException(Exception e) throws Exception {
         }
     }
 }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/ConnectionProxyTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/ConnectionProxyTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource;
+
+import io.seata.core.exception.TransactionException;
+import io.seata.core.exception.TransactionExceptionCode;
+import io.seata.core.model.BranchType;
+import io.seata.core.model.ResourceManager;
+import io.seata.rm.DefaultResourceManager;
+import io.seata.rm.datasource.exec.LockConflictException;
+import io.seata.rm.datasource.exec.LockWaitTimeoutException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ * ConnectionProxy test
+ *
+ * @author ggndnn
+ */
+public class ConnectionProxyTest {
+    private DataSourceProxy dataSourceProxy;
+
+    private final static String TEST_RESOURCE_ID = "testResourceId";
+
+    private final static String TEST_XID = "testXid";
+
+    private Field branchRollbackFlagField;
+
+    @BeforeEach
+    public void initBeforeEach() throws Exception {
+        branchRollbackFlagField = ConnectionProxy.LockRetryPolicy.class.getDeclaredField("LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT");
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(branchRollbackFlagField, branchRollbackFlagField.getModifiers() & ~Modifier.FINAL);
+        branchRollbackFlagField.setAccessible(true);
+        boolean branchRollbackFlag = (boolean) branchRollbackFlagField.get(null);
+        Assertions.assertTrue(branchRollbackFlag);
+
+        dataSourceProxy = Mockito.mock(DataSourceProxy.class);
+        Mockito.when(dataSourceProxy.getResourceId())
+                .thenReturn(TEST_RESOURCE_ID);
+        ResourceManager rm = Mockito.mock(ResourceManager.class);
+        Mockito.when(rm.branchRegister(BranchType.AT, dataSourceProxy.getResourceId(), null, TEST_XID, null, null))
+                .thenThrow(new TransactionException(TransactionExceptionCode.LockKeyConflict));
+        DefaultResourceManager defaultResourceManager = DefaultResourceManager.get();
+        Assertions.assertNotNull(defaultResourceManager);
+        DefaultResourceManager.mockResourceManager(BranchType.AT, rm);
+    }
+
+    @Test
+    public void testLockRetryPolicyRollbackOnConflict() throws Exception {
+        boolean oldBranchRollbackFlag = (boolean) branchRollbackFlagField.get(null);
+        branchRollbackFlagField.set(null, true);
+        ConnectionProxy connectionProxy = new ConnectionProxy(dataSourceProxy, null);
+        connectionProxy.bind(TEST_XID);
+        Assertions.assertThrows(LockConflictException.class, connectionProxy::commit);
+        branchRollbackFlagField.set(null, oldBranchRollbackFlag);
+    }
+
+    @Test
+    public void testLockRetryPolicyNotRollbackOnConflict() throws Exception {
+        boolean oldBranchRollbackFlag = (boolean) branchRollbackFlagField.get(null);
+        branchRollbackFlagField.set(null, false);
+        ConnectionProxy connectionProxy = new ConnectionProxy(dataSourceProxy, null);
+        connectionProxy.bind(TEST_XID);
+        Assertions.assertThrows(LockWaitTimeoutException.class, connectionProxy::commit);
+        branchRollbackFlagField.set(null, oldBranchRollbackFlag);
+    }
+}

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutorTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutorTest.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.exec;
+
+import io.seata.rm.datasource.ConnectionContext;
+import io.seata.rm.datasource.ConnectionProxy;
+import io.seata.rm.datasource.PreparedStatementProxy;
+import io.seata.rm.datasource.sql.SQLInsertRecognizer;
+import io.seata.rm.datasource.sql.struct.TableMeta;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.sql.Connection;
+
+/**
+ * AbstractDMLBaseExecutor test
+ *
+ * @author ggndnn
+ */
+public class AbstractDMLBaseExecutorTest {
+    private ConnectionProxy connectionProxy;
+
+    private AbstractDMLBaseExecutor executor;
+
+    private Field branchRollbackFlagField;
+
+    @BeforeEach
+    public void initBeforeEach() throws Exception {
+        branchRollbackFlagField = ConnectionProxy.LockRetryPolicy.class.getDeclaredField("LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT");
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(branchRollbackFlagField, branchRollbackFlagField.getModifiers() & ~Modifier.FINAL);
+        branchRollbackFlagField.setAccessible(true);
+        boolean branchRollbackFlag = (boolean) branchRollbackFlagField.get(null);
+        Assertions.assertTrue(branchRollbackFlag);
+
+        Connection targetConnection = Mockito.mock(Connection.class);
+        connectionProxy = Mockito.mock(ConnectionProxy.class);
+        Mockito.doThrow(new LockConflictException())
+                .when(connectionProxy).commit();
+        Mockito.when(connectionProxy.getAutoCommit())
+                .thenReturn(Boolean.TRUE);
+        Mockito.when(connectionProxy.getTargetConnection())
+                .thenReturn(targetConnection);
+        Mockito.when(connectionProxy.getContext())
+                .thenReturn(new ConnectionContext());
+        PreparedStatementProxy statementProxy = Mockito.mock(PreparedStatementProxy.class);
+        Mockito.when(statementProxy.getConnectionProxy())
+                .thenReturn(connectionProxy);
+        StatementCallback statementCallback = Mockito.mock(StatementCallback.class);
+        SQLInsertRecognizer sqlInsertRecognizer = Mockito.mock(SQLInsertRecognizer.class);
+        TableMeta tableMeta = Mockito.mock(TableMeta.class);
+        executor = Mockito.spy(new InsertExecutor(statementProxy, statementCallback, sqlInsertRecognizer));
+        Mockito.doReturn(tableMeta)
+                .when(executor).getTableMeta();
+        TableRecords tableRecords = new TableRecords();
+        Mockito.doReturn(tableRecords)
+                .when(executor).beforeImage();
+        Mockito.doReturn(tableRecords)
+                .when(executor).afterImage(tableRecords);
+    }
+
+    @Test
+    public void testLockRetryPolicyRollbackOnConflict() throws Exception {
+        boolean oldBranchRollbackFlag = (boolean) branchRollbackFlagField.get(null);
+        branchRollbackFlagField.set(null, true);
+        Assertions.assertThrows(LockWaitTimeoutException.class, executor::execute);
+        Mockito.verify(connectionProxy, Mockito.times(1))
+                .rollback();
+        Mockito.verify(connectionProxy.getTargetConnection(), Mockito.atLeastOnce())
+                .rollback();
+        branchRollbackFlagField.set(null, oldBranchRollbackFlag);
+    }
+
+    @Test
+    public void testLockRetryPolicyNotRollbackOnConflict() throws Throwable {
+        boolean oldBranchRollbackFlag = (boolean) branchRollbackFlagField.get(null);
+        branchRollbackFlagField.set(null, false);
+        Assertions.assertThrows(LockConflictException.class, executor::execute);
+        Mockito.verify(connectionProxy, Mockito.times(1))
+                .rollback();
+        Mockito.verify(connectionProxy.getTargetConnection(), Mockito.never())
+                .rollback();
+        branchRollbackFlagField.set(null, oldBranchRollbackFlag);
+    }
+}

--- a/server/src/main/resources/nacos-config.txt
+++ b/server/src/main/resources/nacos-config.txt
@@ -19,6 +19,7 @@ service.max.rollback.retry.timeout=-1
 client.async.commit.buffer.limit=10000
 client.lock.retry.internal=10
 client.lock.retry.times=30
+client.lock.retry.policy.branch-rollback-on-conflict=true
 client.table.meta.check.enable=true
 store.mode=file
 store.file.dir=file_store/data


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Move lock retry loop into ConnectionProxy.commit, that the number of LockKeyConflict can be significantly reduced whether auto-commit is true or false. Related issue #1438.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

