### PR TITLE
Refactor of the logics of Multi-configuration Isolation

### DIFF
--- a/config/seata-config-core/src/main/java/io/seata/config/ConfigurationFactory.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/ConfigurationFactory.java
@@ -15,10 +15,10 @@
  */
 package io.seata.config;
 
-import java.util.Objects;
-
 import io.seata.common.exception.NotSupportYetException;
 import io.seata.common.loader.EnhancedServiceLoader;
+
+import java.util.Objects;
 
 /**
  * The type Configuration factory.
@@ -31,25 +31,21 @@ public final class ConfigurationFactory {
     private static final String REGISTRY_CONF_SUFFIX = ".conf";
     private static final String ENV_SYSTEM_KEY = "SEATA_CONFIG_ENV";
     private static final String ENV_PROPERTY_KEY = "seataConfigEnv";
-    private static final String DEFAULT_ENV_VALUE = "default";
     /**
-     * The constant FILE_INSTANCE.
+     * the name of env
      */
     private static String envValue;
 
     static {
-        String env = System.getenv(ENV_SYSTEM_KEY);
-        if (env != null && System.getProperty(ENV_PROPERTY_KEY) == null) {
-            //Help users get
-            System.setProperty(ENV_PROPERTY_KEY, env);
-        }
         envValue = System.getProperty(ENV_PROPERTY_KEY);
+        if (null == envValue) {
+            envValue = System.getenv(ENV_SYSTEM_KEY);
+        }
     }
 
     private static final Configuration DEFAULT_FILE_INSTANCE = new FileConfiguration(
         REGISTRY_CONF_PREFIX + REGISTRY_CONF_SUFFIX);
-    public static final Configuration CURRENT_FILE_INSTANCE = (envValue == null || DEFAULT_ENV_VALUE.equals(envValue))
-        ? DEFAULT_FILE_INSTANCE : new FileConfiguration(REGISTRY_CONF_PREFIX + "-" + envValue
+    public static final Configuration CURRENT_FILE_INSTANCE = null == envValue ? DEFAULT_FILE_INSTANCE : new FileConfiguration(REGISTRY_CONF_PREFIX + "-" + envValue
         + REGISTRY_CONF_SUFFIX);
     private static final String NAME_KEY = "name";
     private static final String FILE_TYPE = "file";

--- a/config/seata-config-core/src/main/java/io/seata/config/ConfigurationFactory.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/ConfigurationFactory.java
@@ -29,8 +29,8 @@ import java.util.Objects;
 public final class ConfigurationFactory {
     private static final String REGISTRY_CONF_PREFIX = "registry";
     private static final String REGISTRY_CONF_SUFFIX = ".conf";
-    private static final String ENV_SYSTEM_KEY = "SEATA_CONFIG_ENV";
-    private static final String ENV_PROPERTY_KEY = "seataConfigEnv";
+    private static final String ENV_SYSTEM_KEY = "SEATA_ENV";
+    private static final String ENV_PROPERTY_KEY = "seataEnv";
     /**
      * the name of env
      */


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
For the current logics of loading different configuration,it's a bit complicated to understand.So,i'm gonna improve it,and make it clearly.So,the new logics will be like:
At first,will try to read the name from JVM parameters(when use -Dxxx=xx),if reads nothing,will try to read the name from system environment,if reads nothing again,then will ues default configuration:file.conf,registry.conf.
For example,if we have a testing environment called "test",then these conf files should be in the following format:
`
file-test.conf
registry-test.conf
`


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1532

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
I've done integration testing.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

