### PR TITLE
bugfix: calculate BranchSession size missing xidBytes.length

### DIFF
--- a/server/src/main/java/io/seata/server/session/BranchSession.java
+++ b/server/src/main/java/io/seata/server/session/BranchSession.java
@@ -375,6 +375,7 @@ public class BranchSession implements Lockable, Comparable<BranchSession>, Sessi
             + 4 // lockKeyBytes.length
             + 2 // clientIdBytes.length
             + 4 // applicationDataBytes.length
+            + 4 // xidBytes.size
             + 1 // statusCode
             + (resourceIdBytes == null ? 0 : resourceIdBytes.length)
             + (lockKeyBytes == null ? 0 : lockKeyBytes.length)


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

fix BranchSession.calBranchSessionSize return missing xidBytes.length.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes 1549
https://github.com/seata/seata/issues/1549#issue-486287065

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

