### PR TITLE
bugfix: BufferOverflow when BranchSession size too large

### DIFF
--- a/server/src/main/java/io/seata/server/store/file/FileTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/store/file/FileTransactionStoreManager.java
@@ -416,9 +416,9 @@ public class FileTransactionStoreManager extends AbstractTransactionStoreManager
         }
         ByteBuffer byteBuffer = null;
 
-        if (bs.length > MAX_WRITE_BUFFER_SIZE) {
+        if (bs.length + 4 > MAX_WRITE_BUFFER_SIZE) {
             //allocateNew
-            byteBuffer = ByteBuffer.allocateDirect(bs.length);
+            byteBuffer = ByteBuffer.allocateDirect(bs.length + 4);
         } else {
             byteBuffer = writeBuffer;
             //recycle

--- a/server/src/main/java/io/seata/server/store/file/FileTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/store/file/FileTransactionStoreManager.java
@@ -411,7 +411,7 @@ public class FileTransactionStoreManager extends AbstractTransactionStoreManager
     }
 
     private boolean writeDataFile(byte[] bs) {
-        if (bs == null) {
+        if (bs == null || bs.length >= Integer.MAX_VALUE - 3) {
             return false;
         }
         ByteBuffer byteBuffer = null;


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

fix BufferOverflowException when FileTransactionStoreManager write a big BranchSession(size > 16KB).

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1551

https://github.com/seata/seata/issues/1551#issue-486308391

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
```
public class FileTransactionStoreManagerTest {

    FileTransactionStoreManager fileTransactionStoreManager;

    @BeforeEach
    public void beforeAll() throws IOException {
        fileTransactionStoreManager = new FileTransactionStoreManager("~/my/tmp/test/seata", null);
    }

    @Test
    public void writeBigBytes() {
        BranchSession branchSession = new BranchSession();
        branchSession.setApplicationData(createBigStr(1024 * 16 - 36));
        fileTransactionStoreManager.writeSession(TransactionStoreManager.LogOperation.BRANCH_ADD, branchSession);
    }

    public String createBigStr(int size){
        byte[] bytes = new byte[size];
        for (int i = 0; i < size; i++) {
            bytes[i] = 'a';
        }
        return new String(bytes);
    }
}
```

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

