### PR TITLE
bugfix: throw NPE when the rpcMessage's body is null (#1556)

### DIFF
--- a/core/src/main/java/io/seata/core/rpc/netty/RpcServer.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RpcServer.java
@@ -322,7 +322,7 @@ public class RpcServer extends AbstractRpcRemotingServer implements ServerMessag
     public void channelRead(final ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof RpcMessage) {
             RpcMessage rpcMessage = (RpcMessage) msg;
-            debugLog("read:" + rpcMessage.getBody().toString());
+            debugLog("read:" + rpcMessage.getBody());
             if (rpcMessage.getBody() instanceof RegisterTMRequest) {
                 serverMessageListener.onRegTmMessage(rpcMessage, ctx, this, checkAuthHandler);
                 return;


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

