### PR TITLE
 When using annotation @service to register a service，which the service has annotations @TwoPhaseBusinessAction，tcc bean discriminate fail 

### DIFF
--- a/spring/src/main/java/io/seata/spring/util/TCCBeanParserUtils.java
+++ b/spring/src/main/java/io/seata/spring/util/TCCBeanParserUtils.java
@@ -48,6 +48,10 @@ public class TCCBeanParserUtils {
             if (remotingDesc != null && remotingDesc.getProtocol() == Protocols.IN_JVM) {
                 //LocalTCC
                 return isTccProxyTargetBean(remotingDesc);
+            } else if(remotingDesc != null && (remotingDesc.getProtocol() == Protocols.SOFA_RPC
+                                                || remotingDesc.getProtocol() == Protocols.DUBBO)){
+                //sofa:service  dubbo:service
+                return isTccProxyTargetBean(remotingDesc);
             } else {
                 // sofa:reference / dubbo:reference, factory bean
                 return false;


### PR DESCRIPTION


Ⅰ. Describe what this PR did
 When using annotation @service to register a service which  has annotations @TwoPhaseBusinessAction.The method isTccAutoProxy, which was originally intended to return true, now returns false


Ⅱ. Does this pull request fix one issue?
Ⅲ. Why don't you add test cases (unit test/integration test)?
Ⅳ. Describe how to verify it
Ⅴ. Special notes for reviews