### PR TITLE
optimize: get oracle primary index

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableMetaCacheOracle.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableMetaCacheOracle.java
@@ -170,9 +170,7 @@ public class TableMetaCacheOracle {
                     index.setAscOrDesc(rsIndex.getString("ASC_OR_DESC"));
                     index.setCardinality(rsIndex.getInt("CARDINALITY"));
                     index.getValues().add(col);
-                    if ("PRIMARY".equalsIgnoreCase(indexName)) {
-                        index.setIndextype(IndexType.PRIMARY);
-                    } else if (!index.isNonUnique()) {
+                    if (!index.isNonUnique()) {
                         index.setIndextype(IndexType.Unique);
                     } else {
                         index.setIndextype(IndexType.Normal);
@@ -183,7 +181,7 @@ public class TableMetaCacheOracle {
             }
 
             while (rsPrimary.next()) {
-                String pkIndexName = rsPrimary.getObject(6).toString();
+                String pkIndexName = rsPrimary.getString("PK_NAME");
                 if (tm.getAllIndexes().containsKey(pkIndexName)) {
                     IndexMeta index = tm.getAllIndexes().get(pkIndexName);
                     index.setIndextype(IndexType.PRIMARY);


### PR DESCRIPTION
Signed-off-by: slievrly <slievrly@163.com>

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
optimize oracle index:
1. "PRIMARY" is used for mysql primary indexName but not for oracle
2. get primary index should always used the columnName，avoid to different oracle version index  offset changed



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

