### PR TITLE
bugfix: thread unsafe issue of MySQLKeywordChecker initialization

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/mysql/keyword/MySQLKeywordChecker.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/mysql/keyword/MySQLKeywordChecker.java
@@ -29,9 +29,10 @@ import java.util.stream.Collectors;
  */
 public class MySQLKeywordChecker implements KeywordChecker {
     private static volatile KeywordChecker keywordChecker = null;
-    private static volatile Set<String> keywordSet = null;
+    private Set<String> keywordSet;
 
     private MySQLKeywordChecker() {
+        keywordSet = Arrays.stream(MySQLKeyword.values()).map(MySQLKeyword::name).collect(Collectors.toSet());
     }
 
     /**
@@ -44,7 +45,6 @@ public class MySQLKeywordChecker implements KeywordChecker {
             synchronized (MySQLKeywordChecker.class) {
                 if (keywordChecker == null) {
                     keywordChecker = new MySQLKeywordChecker();
-                    keywordSet = Arrays.stream(MySQLKeyword.values()).map(MySQLKeyword::name).collect(Collectors.toSet());
                 }
             }
         }


### PR DESCRIPTION
> Performing additional initialization on an object after assignment to a shared variable guarded by double-checked locking is not thread-safe, and could result in unexpected behavior.

Potential race condition: this instance of `keywordChecker` is available to other threads before `keywordSet` are assign, which may causes NPE if other threads call '#check' method.

Below is code segment (the code comment is added by me):
```java
private static volatile KeywordChecker keywordChecker = null;
private static volatile Set<String> keywordSet = null;

public static KeywordChecker getInstance() {
    if (keywordChecker == null) {
        synchronized (MySQLKeywordChecker.class) {
            if (keywordChecker == null) {
                keywordChecker = new MySQLKeywordChecker();
                // additional initialization inside double-checked locking is not thread-safe!
                keywordSet = Arrays.stream(MySQLKeyword.values()).map(MySQLKeyword::name).collect(Collectors.toSet());
            }
        }
    }
    return keywordChecker;
}


@Override
public boolean check(String fieldOrTableName) {
    if (keywordSet.contains(fieldOrTableName)) {
        return true;
    }
    if (null != fieldOrTableName) {
        fieldOrTableName = fieldOrTableName.toUpperCase();
    }
    return keywordSet.contains(fieldOrTableName);

}
```

Since `MySQLKeywordChecker` is singleton, the field `keywordSet` doesn't need to be static,
the initialization of `keywordSet` can be moved to constructor, removing the additional initialization inside locking, which ensures thread safely.