### PR TITLE
feature: support custom config and registry type

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -94,6 +94,11 @@
         </dependency>
         <dependency>
             <groupId>io.seata</groupId>
+            <artifactId>seata-config-custom</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.seata</groupId>
             <artifactId>seata-config-apollo</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -125,6 +130,11 @@
         <dependency>
             <groupId>io.seata</groupId>
             <artifactId>seata-discovery-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.seata</groupId>
+            <artifactId>seata-discovery-custom</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -503,12 +513,14 @@
                                     <include>io.seata:seata-common</include>
                                     <include>io.seata:seata-core</include>
                                     <include>io.seata:seata-config-core</include>
+                                    <include>io.seata:seata-config-custom</include>
                                     <include>io.seata:seata-config-apollo</include>
                                     <include>io.seata:seata-config-nacos</include>
                                     <include>io.seata:seata-config-zk</include>
                                     <include>io.seata:seata-config-consul</include>
                                     <include>io.seata:seata-config-etcd3</include>
                                     <include>io.seata:seata-discovery-core</include>
+                                    <include>io.seata:seata-discovery-custom</include>
                                     <include>io.seata:seata-discovery-consul</include>
                                     <include>io.seata:seata-discovery-eureka</include>
                                     <include>io.seata:seata-discovery-nacos</include>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -28,6 +28,7 @@
     <name>seata-config ${project.version}</name>
     <modules>
         <module>seata-config-core</module>
+        <module>seata-config-custom</module>
         <module>seata-config-apollo</module>
         <module>seata-config-nacos</module>
         <module>seata-config-zk</module>

--- a/config/seata-config-core/src/main/java/io/seata/config/ConfigType.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/ConfigType.java
@@ -45,7 +45,11 @@ public enum ConfigType {
     /**
      * Etcd3 config type
      */
-    Etcd3;
+    Etcd3,
+    /**
+     * Custom config type
+     */
+    Custom;
 
     /**
      * Gets type.

--- a/config/seata-config-custom/pom.xml
+++ b/config/seata-config-custom/pom.xml
@@ -14,29 +14,22 @@
   ~  See the License for the specific language governing permissions and
   ~  limitations under the License.
   -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.seata</groupId>
-        <artifactId>seata-parent</artifactId>
+        <artifactId>seata-config</artifactId>
         <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <packaging>pom</packaging>
-    <artifactId>seata-discovery</artifactId>
-    <name>seata-discovery ${project.version}</name>
-    <modules>
-        <module>seata-discovery-consul</module>
-        <module>seata-discovery-core</module>
-        <module>seata-discovery-custom</module>
-        <module>seata-discovery-all</module>
-        <module>seata-discovery-eureka</module>
-        <module>seata-discovery-zk</module>
-        <module>seata-discovery-redis</module>
-        <module>seata-discovery-nacos</module>
-        <module>seata-discovery-etcd3</module>
-        <module>seata-discovery-sofa</module>
-    </modules>
+    <artifactId>seata-config-custom</artifactId>
+    <name>seata-config-custom ${project.version}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.seata</groupId>
+            <artifactId>seata-config-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/config/seata-config-custom/src/main/java/io/seata/config/custom/CustomConfigurationProvider.java
+++ b/config/seata-config-custom/src/main/java/io/seata/config/custom/CustomConfigurationProvider.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.config.custom;
+
+import io.seata.common.loader.EnhancedServiceLoader;
+import io.seata.common.loader.LoadLevel;
+import io.seata.common.util.StringUtils;
+import io.seata.config.ConfigType;
+import io.seata.config.Configuration;
+import io.seata.config.ConfigurationKeys;
+import io.seata.config.ConfigurationFactory;
+import io.seata.config.ConfigurationProvider;
+
+import java.util.stream.Stream;
+
+/**
+ * @author ggndnn
+ */
+@LoadLevel(name = "Custom")
+public class CustomConfigurationProvider implements ConfigurationProvider {
+    @Override
+    public Configuration provide() {
+        String pathDataId = ConfigurationKeys.FILE_ROOT_CONFIG + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
+                + ConfigType.Custom.name().toLowerCase() + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR
+                + "name";
+        String name = ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(pathDataId);
+        if (StringUtils.isBlank(name)) {
+            throw new IllegalArgumentException("name value of custom config type must not be blank");
+        }
+        if (Stream.of(ConfigType.values())
+                .anyMatch(ct -> ct.name().equalsIgnoreCase(name))) {
+            throw new IllegalArgumentException(String.format("custom config type name %s is not allowed", name));
+        }
+        return EnhancedServiceLoader.load(ConfigurationProvider.class, name).provide();
+    }
+}

--- a/config/seata-config-custom/src/main/resources/META-INF/services/io.seata.config.ConfigurationProvider
+++ b/config/seata-config-custom/src/main/resources/META-INF/services/io.seata.config.ConfigurationProvider
@@ -1,0 +1,1 @@
+io.seata.config.custom.CustomConfigurationProvider

--- a/config/seata-config-custom/src/test/java/io/seata/config/CustomConfigurationForTest.java
+++ b/config/seata-config-custom/src/test/java/io/seata/config/CustomConfigurationForTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Properties;
+
+public class CustomConfigurationForTest extends AbstractConfiguration<ConfigChangeListener> {
+    private Properties properties;
+
+    public CustomConfigurationForTest(String name) {
+        try (InputStream input = CustomConfigurationForTest.class.getClassLoader().getResourceAsStream(name)) {
+            properties = new Properties();
+            properties.load(input);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getTypeName() {
+        return "forTest";
+    }
+
+    @Override
+    public String getConfig(String dataId, String defaultValue, long timeoutMills) {
+        return properties.getProperty(dataId, defaultValue);
+    }
+
+    @Override
+    public boolean putConfig(String dataId, String content, long timeoutMills) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean putConfigIfAbsent(String dataId, String content, long timeoutMills) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeConfig(String dataId, long timeoutMills) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addConfigListener(String dataId, ConfigChangeListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeConfigListener(String dataId, ConfigChangeListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ConfigChangeListener> getConfigListeners(String dataId) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/config/seata-config-custom/src/test/java/io/seata/config/CustomConfigurationProviderForTest.java
+++ b/config/seata-config-custom/src/test/java/io/seata/config/CustomConfigurationProviderForTest.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.config;
+
+import io.seata.common.loader.LoadLevel;
+
+/**
+ * @author ggndnn
+ */
+@LoadLevel(name = "forTest")
+public class CustomConfigurationProviderForTest implements ConfigurationProvider {
+    @Override
+    public Configuration provide() {
+        return new CustomConfigurationForTest("custom_for_test.properties");
+    }
+}

--- a/config/seata-config-custom/src/test/java/io/seata/config/CustomConfigurationTest.java
+++ b/config/seata-config-custom/src/test/java/io/seata/config/CustomConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * @author ggndnn
+ */
+public class CustomConfigurationTest {
+    @Test
+    public void testCustomConfigLoad() throws Exception {
+        Configuration<?> configuration = ConfigurationFactory.getInstance();
+        Assertions.assertTrue(configuration instanceof CustomConfigurationForTest);
+        Properties properties;
+        try (InputStream input = CustomConfigurationForTest.class.getClassLoader().getResourceAsStream("custom_for_test.properties")) {
+            properties = new Properties();
+            properties.load(input);
+        }
+        Assertions.assertNotNull(properties);
+        for (String name : properties.stringPropertyNames()) {
+            String value = properties.getProperty(name);
+            Assertions.assertNotNull(value);
+            Assertions.assertEquals(value, configuration.getConfig(name));
+        }
+    }
+}

--- a/config/seata-config-custom/src/test/resources/META-INF/services/io.seata.config.ConfigurationProvider
+++ b/config/seata-config-custom/src/test/resources/META-INF/services/io.seata.config.ConfigurationProvider
@@ -1,0 +1,1 @@
+io.seata.config.CustomConfigurationProviderForTest

--- a/config/seata-config-custom/src/test/resources/custom_for_test.properties
+++ b/config/seata-config-custom/src/test/resources/custom_for_test.properties
@@ -1,0 +1,4 @@
+transport.type=TCP
+transport.server=NIO
+service.default.grouplist=127.0.0.1:8091
+client.lock.retry.internal=10

--- a/config/seata-config-custom/src/test/resources/registry.conf
+++ b/config/seata-config-custom/src/test/resources/registry.conf
@@ -1,0 +1,7 @@
+config {
+  type = "custom"
+  
+  custom {
+    name = "forTest"
+  }
+}

--- a/discovery/seata-discovery-all/pom.xml
+++ b/discovery/seata-discovery-all/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>seata-discovery-custom</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>seata-discovery-eureka</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/discovery/seata-discovery-core/src/main/java/io/seata/discovery/registry/RegistryFactory.java
+++ b/discovery/seata-discovery-core/src/main/java/io/seata/discovery/registry/RegistryFactory.java
@@ -17,13 +17,17 @@ package io.seata.discovery.registry;
 
 import io.seata.common.exception.NotSupportYetException;
 import io.seata.common.loader.EnhancedServiceLoader;
+import io.seata.common.util.StringUtils;
+import io.seata.config.ConfigType;
 import io.seata.config.ConfigurationFactory;
 import io.seata.config.ConfigurationKeys;
 
+import io.seata.config.ConfigurationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * The type Registry factory.

--- a/discovery/seata-discovery-core/src/main/java/io/seata/discovery/registry/RegistryType.java
+++ b/discovery/seata-discovery-core/src/main/java/io/seata/discovery/registry/RegistryType.java
@@ -55,7 +55,11 @@ public enum RegistryType {
     /**
      * Sofa registry type
      */
-    Sofa;
+    Sofa,
+    /**
+     * Sofa registry type
+     */
+    Custom;
 
     /**
      * Gets type.
@@ -80,6 +84,8 @@ public enum RegistryType {
             return Etcd3;
         } else if (Sofa.name().equalsIgnoreCase(name)) {
             return Sofa;
+        } else if (Custom.name().equalsIgnoreCase(name)) {
+            return Custom;
         } else {
             throw new NotSupportYetException("unsupported type:" + name);
         }

--- a/discovery/seata-discovery-custom/pom.xml
+++ b/discovery/seata-discovery-custom/pom.xml
@@ -14,29 +14,22 @@
   ~  See the License for the specific language governing permissions and
   ~  limitations under the License.
   -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.seata</groupId>
-        <artifactId>seata-parent</artifactId>
+        <artifactId>seata-discovery</artifactId>
         <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <packaging>pom</packaging>
-    <artifactId>seata-discovery</artifactId>
-    <name>seata-discovery ${project.version}</name>
-    <modules>
-        <module>seata-discovery-consul</module>
-        <module>seata-discovery-core</module>
-        <module>seata-discovery-custom</module>
-        <module>seata-discovery-all</module>
-        <module>seata-discovery-eureka</module>
-        <module>seata-discovery-zk</module>
-        <module>seata-discovery-redis</module>
-        <module>seata-discovery-nacos</module>
-        <module>seata-discovery-etcd3</module>
-        <module>seata-discovery-sofa</module>
-    </modules>
+    <artifactId>seata-discovery-custom</artifactId>
+    <name>seata-discovery-custom ${project.version}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.seata</groupId>
+            <artifactId>seata-discovery-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/discovery/seata-discovery-custom/src/main/java/io/seata/discovery/registry/custom/CustomRegistryProvider.java
+++ b/discovery/seata-discovery-custom/src/main/java/io/seata/discovery/registry/custom/CustomRegistryProvider.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.discovery.registry.custom;
+
+import io.seata.common.loader.EnhancedServiceLoader;
+import io.seata.common.loader.LoadLevel;
+import io.seata.common.util.StringUtils;
+import io.seata.config.ConfigurationFactory;
+import io.seata.discovery.registry.RegistryProvider;
+import io.seata.discovery.registry.RegistryService;
+import io.seata.discovery.registry.RegistryType;
+
+import java.util.stream.Stream;
+
+/**
+ * @author ggndnn
+ */
+@LoadLevel(name = "Custom")
+public class CustomRegistryProvider implements RegistryProvider {
+    private static final String FILE_CONFIG_KEY_PREFIX = "registry.custom.name";
+
+    private final String CUSTOM_NAME;
+
+    public CustomRegistryProvider() {
+        String name = ConfigurationFactory.CURRENT_FILE_INSTANCE.getConfig(FILE_CONFIG_KEY_PREFIX);
+        if (StringUtils.isBlank(name)) {
+            throw new IllegalArgumentException("name value of custom registry type must not be blank");
+        }
+        if (Stream.of(RegistryType.values())
+                .anyMatch(ct -> ct.name().equalsIgnoreCase(name))) {
+            throw new IllegalArgumentException(String.format("custom registry type name %s is not allowed", name));
+        }
+        CUSTOM_NAME = name;
+    }
+
+    @Override
+    public RegistryService provide() {
+        return EnhancedServiceLoader.load(RegistryProvider.class, CUSTOM_NAME).provide();
+    }
+}

--- a/discovery/seata-discovery-custom/src/main/resources/META-INF/services/io.seata.discovery.registry.RegistryProvider
+++ b/discovery/seata-discovery-custom/src/main/resources/META-INF/services/io.seata.discovery.registry.RegistryProvider
@@ -1,0 +1,1 @@
+io.seata.discovery.registry.custom.CustomRegistryProvider

--- a/discovery/seata-discovery-custom/src/test/java/io/seata/discovery/registry/custom/CustomRegistryProviderForTest.java
+++ b/discovery/seata-discovery-custom/src/test/java/io/seata/discovery/registry/custom/CustomRegistryProviderForTest.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.discovery.registry.custom;
+
+import io.seata.common.loader.LoadLevel;
+import io.seata.discovery.registry.RegistryProvider;
+import io.seata.discovery.registry.RegistryService;
+
+@LoadLevel(name = "forTest")
+public class CustomRegistryProviderForTest implements RegistryProvider {
+    @Override
+    public RegistryService provide() {
+        return new CustomRegistryServiceForTest();
+    }
+}

--- a/discovery/seata-discovery-custom/src/test/java/io/seata/discovery/registry/custom/CustomRegistryServiceForTest.java
+++ b/discovery/seata-discovery-custom/src/test/java/io/seata/discovery/registry/custom/CustomRegistryServiceForTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.discovery.registry.custom;
+
+import io.seata.config.ConfigChangeListener;
+import io.seata.discovery.registry.RegistryService;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public class CustomRegistryServiceForTest implements RegistryService<ConfigChangeListener> {
+    @Override
+    public void register(InetSocketAddress address) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unregister(InetSocketAddress address) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void subscribe(String cluster, ConfigChangeListener listener) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unsubscribe(String cluster, ConfigChangeListener listener) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<InetSocketAddress> lookup(String key) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() throws Exception {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/discovery/seata-discovery-custom/src/test/java/io/seata/discovery/registry/custom/CustomRegistryTest.java
+++ b/discovery/seata-discovery-custom/src/test/java/io/seata/discovery/registry/custom/CustomRegistryTest.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.discovery.registry.custom;
+
+import io.seata.discovery.registry.RegistryFactory;
+import io.seata.discovery.registry.RegistryService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CustomRegistryTest {
+    @Test
+    public void testCustomRegistryLoad() {
+        RegistryService registryService = RegistryFactory.getInstance();
+        Assertions.assertTrue(registryService instanceof CustomRegistryServiceForTest);
+    }
+}

--- a/discovery/seata-discovery-custom/src/test/resources/META-INF/services/io.seata.discovery.registry.RegistryProvider
+++ b/discovery/seata-discovery-custom/src/test/resources/META-INF/services/io.seata.discovery.registry.RegistryProvider
@@ -1,0 +1,1 @@
+io.seata.discovery.registry.custom.CustomRegistryProviderForTest

--- a/discovery/seata-discovery-custom/src/test/resources/registry.conf
+++ b/discovery/seata-discovery-custom/src/test/resources/registry.conf
@@ -1,0 +1,7 @@
+registry {
+  type = "custom"
+
+  custom {
+    name = "forTest"
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Add custom config and registry type, which can be used to help users create their own configuration loading mechanism. Mainly used in client side.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

