### PR TITLE
optimize: fix wrong usage of Slf4j

### DIFF
--- a/core/src/main/java/io/seata/core/rpc/DefaultServerMessageListenerImpl.java
+++ b/core/src/main/java/io/seata/core/rpc/DefaultServerMessageListenerImpl.java
@@ -15,15 +15,30 @@
  */
 package io.seata.core.rpc;
 
-import io.netty.channel.ChannelHandlerContext;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import io.seata.common.thread.NamedThreadFactory;
 import io.seata.common.util.NetUtil;
-import io.seata.core.protocol.*;
+import io.seata.core.protocol.AbstractMessage;
+import io.seata.core.protocol.AbstractResultMessage;
+import io.seata.core.protocol.HeartbeatMessage;
+import io.seata.core.protocol.MergeResultMessage;
+import io.seata.core.protocol.MergedWarpMessage;
+import io.seata.core.protocol.RegisterRMRequest;
+import io.seata.core.protocol.RegisterRMResponse;
+import io.seata.core.protocol.RegisterTMRequest;
+import io.seata.core.protocol.RegisterTMResponse;
+import io.seata.core.protocol.RpcMessage;
+import io.seata.core.protocol.Version;
 import io.seata.core.rpc.netty.RegisterCheckAuthHandler;
+
+import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.*;
 
 /**
  * The type Default server message listener.
@@ -132,7 +147,7 @@ public class DefaultServerMessageListenerImpl implements ServerMessageListener {
         try {
             sender.sendResponse(request, ctx.channel(), HeartbeatMessage.PONG);
         } catch (Throwable throwable) {
-            LOGGER.error("send response error", throwable);
+            LOGGER.error("send response error: {}", throwable.getMessage(), throwable);
         }
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("received PING from " + ctx.channel().remoteAddress());

--- a/core/src/main/java/io/seata/core/rpc/DefaultServerMessageListenerImpl.java
+++ b/core/src/main/java/io/seata/core/rpc/DefaultServerMessageListenerImpl.java
@@ -15,30 +15,15 @@
  */
 package io.seata.core.rpc;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
+import io.netty.channel.ChannelHandlerContext;
 import io.seata.common.thread.NamedThreadFactory;
 import io.seata.common.util.NetUtil;
-import io.seata.core.protocol.AbstractMessage;
-import io.seata.core.protocol.AbstractResultMessage;
-import io.seata.core.protocol.HeartbeatMessage;
-import io.seata.core.protocol.MergeResultMessage;
-import io.seata.core.protocol.MergedWarpMessage;
-import io.seata.core.protocol.RegisterRMRequest;
-import io.seata.core.protocol.RegisterRMResponse;
-import io.seata.core.protocol.RegisterTMRequest;
-import io.seata.core.protocol.RegisterTMResponse;
-import io.seata.core.protocol.RpcMessage;
-import io.seata.core.protocol.Version;
+import io.seata.core.protocol.*;
 import io.seata.core.rpc.netty.RegisterCheckAuthHandler;
-
-import io.netty.channel.ChannelHandlerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.*;
 
 /**
  * The type Default server message listener.
@@ -147,7 +132,7 @@ public class DefaultServerMessageListenerImpl implements ServerMessageListener {
         try {
             sender.sendResponse(request, ctx.channel(), HeartbeatMessage.PONG);
         } catch (Throwable throwable) {
-            LOGGER.error("", "send response error", throwable);
+            LOGGER.error("send response error", throwable);
         }
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("received PING from " + ctx.channel().remoteAddress());

--- a/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemoting.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemoting.java
@@ -427,7 +427,7 @@ public abstract class AbstractRpcRemoting extends ChannelDuplexHandler implement
         try {
             destroyChannel(ctx.channel());
         } catch (Exception e) {
-            LOGGER.error("close channel" + ctx.channel() + " fail.", e);
+            LOGGER.error("failed to close channel {}: {}", ctx.channel(), e.getMessage(), e);
         }
     }
 

--- a/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemoting.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemoting.java
@@ -427,7 +427,7 @@ public abstract class AbstractRpcRemoting extends ChannelDuplexHandler implement
         try {
             destroyChannel(ctx.channel());
         } catch (Exception e) {
-            LOGGER.error("", "close channel" + ctx.channel() + " fail.", e);
+            LOGGER.error("close channel" + ctx.channel() + " fail.", e);
         }
     }
 

--- a/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemotingClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemotingClient.java
@@ -15,16 +15,6 @@
  */
 package io.seata.core.rpc.netty;
 
-import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.timeout.IdleState;
@@ -34,18 +24,18 @@ import io.seata.common.exception.FrameworkErrorCode;
 import io.seata.common.exception.FrameworkException;
 import io.seata.common.thread.NamedThreadFactory;
 import io.seata.common.util.NetUtil;
-import io.seata.core.protocol.AbstractMessage;
-import io.seata.core.protocol.HeartbeatMessage;
-import io.seata.core.protocol.MergeResultMessage;
-import io.seata.core.protocol.MergedWarpMessage;
-import io.seata.core.protocol.MessageFuture;
-import io.seata.core.protocol.RpcMessage;
+import io.seata.core.protocol.*;
 import io.seata.core.rpc.ClientMessageListener;
 import io.seata.core.rpc.ClientMessageSender;
 import io.seata.discovery.loadbalance.LoadBalanceFactory;
 import io.seata.discovery.registry.RegistryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.function.Function;
 
 import static io.seata.common.exception.FrameworkErrorCode.NoAvailableService;
 
@@ -203,7 +193,7 @@ public abstract class AbstractRpcRemotingClient extends AbstractRpcRemoting
                     }
                     sendRequest(ctx.channel(), HeartbeatMessage.PING);
                 } catch (Throwable throwable) {
-                    LOGGER.error("", "send request error", throwable);
+                    LOGGER.error("send request error", throwable);
                 }
             }
         }
@@ -330,7 +320,7 @@ public abstract class AbstractRpcRemotingClient extends AbstractRpcRemoting
                                 messageFuture.setResultMessage(null);
                             }
                         }
-                        LOGGER.error("", "client merge call failed", e);
+                        LOGGER.error("client merge call failed", e);
                     }
                 }
                 isSending = false;

--- a/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemotingClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemotingClient.java
@@ -15,6 +15,16 @@
  */
 package io.seata.core.rpc.netty;
 
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.timeout.IdleState;
@@ -24,18 +34,18 @@ import io.seata.common.exception.FrameworkErrorCode;
 import io.seata.common.exception.FrameworkException;
 import io.seata.common.thread.NamedThreadFactory;
 import io.seata.common.util.NetUtil;
-import io.seata.core.protocol.*;
+import io.seata.core.protocol.AbstractMessage;
+import io.seata.core.protocol.HeartbeatMessage;
+import io.seata.core.protocol.MergeResultMessage;
+import io.seata.core.protocol.MergedWarpMessage;
+import io.seata.core.protocol.MessageFuture;
+import io.seata.core.protocol.RpcMessage;
 import io.seata.core.rpc.ClientMessageListener;
 import io.seata.core.rpc.ClientMessageSender;
 import io.seata.discovery.loadbalance.LoadBalanceFactory;
 import io.seata.discovery.registry.RegistryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.concurrent.*;
-import java.util.function.Function;
 
 import static io.seata.common.exception.FrameworkErrorCode.NoAvailableService;
 
@@ -193,7 +203,7 @@ public abstract class AbstractRpcRemotingClient extends AbstractRpcRemoting
                     }
                     sendRequest(ctx.channel(), HeartbeatMessage.PING);
                 } catch (Throwable throwable) {
-                    LOGGER.error("send request error", throwable);
+                    LOGGER.error("send request error: {}", throwable.getMessage(), throwable);
                 }
             }
         }
@@ -320,7 +330,7 @@ public abstract class AbstractRpcRemotingClient extends AbstractRpcRemoting
                                 messageFuture.setResultMessage(null);
                             }
                         }
-                        LOGGER.error("client merge call failed", e);
+                        LOGGER.error("client merge call failed: {}", e.getMessage(), e);
                     }
                 }
                 isSending = false;

--- a/core/src/main/java/io/seata/core/rpc/netty/RmMessageListener.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmMessageListener.java
@@ -85,7 +85,7 @@ public class RmMessageListener implements ClientMessageListener {
         try {
             sender.sendResponse(request, serverAddress, resultMessage);
         } catch (Throwable throwable) {
-            LOGGER.error("send response error", throwable);
+            LOGGER.error("send response error: {}", throwable.getMessage(), throwable);
         }
     }
 

--- a/core/src/main/java/io/seata/core/rpc/netty/RmMessageListener.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmMessageListener.java
@@ -85,7 +85,7 @@ public class RmMessageListener implements ClientMessageListener {
         try {
             sender.sendResponse(request, serverAddress, resultMessage);
         } catch (Throwable throwable) {
-            LOGGER.error("", "send response error", throwable);
+            LOGGER.error("send response error", throwable);
         }
     }
 

--- a/core/src/main/java/io/seata/core/rpc/netty/RmRpcClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmRpcClient.java
@@ -251,7 +251,7 @@ public final class RmRpcClient extends AbstractRpcRemotingClient {
                     LOGGER.info("remove channel:" + channel);
                 }
             } else {
-                LOGGER.error("register failed", e);
+                LOGGER.error("register failed: {}", e.getMessage(), e);
             }
         } catch (TimeoutException e) {
             LOGGER.error(e.getMessage());

--- a/core/src/main/java/io/seata/core/rpc/netty/RmRpcClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmRpcClient.java
@@ -251,7 +251,7 @@ public final class RmRpcClient extends AbstractRpcRemotingClient {
                     LOGGER.info("remove channel:" + channel);
                 }
             } else {
-                LOGGER.error("", "register failed", e);
+                LOGGER.error("register failed", e);
             }
         } catch (TimeoutException e) {
             LOGGER.error(e.getMessage());


### PR DESCRIPTION
There are several places that are not correct for the use of Slf4j.

They log error log like this:
```
LOGGER.error("", "send response error", throwable);
```
It will print log like below, missing the log message:
```
[main] ERROR TmpTest -
java.lang.RuntimeException: xx
	at TmpTest.<init>(TmpTest.java:28)
	...... ignore exception stack ......
```

I correct it like this:
```
LOGGER.error("send response error", throwable);
```
So, it will print the expected log content:
```
[main] ERROR TmpTest - send response error
java.lang.RuntimeException: xx
	at TmpTest.<init>(TmpTest.java:28)
	...... ignore exception stack ......
```
