### PR TITLE
optimize: eliminate the possibility of allocating too much direct memory

### DIFF
--- a/server/src/main/java/io/seata/server/store/file/FileTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/store/file/FileTransactionStoreManager.java
@@ -182,7 +182,7 @@ public class FileTransactionStoreManager extends AbstractTransactionStoreManager
                 return saveHistory();
             }
         } catch (Exception exx) {
-            LOGGER.error("writeSession error," + exx.getMessage());
+            LOGGER.error("writeSession error, {}", exx.getMessage(), exx);
             return false;
         } finally {
             writeSessionLock.unlock();
@@ -215,12 +215,55 @@ public class FileTransactionStoreManager extends AbstractTransactionStoreManager
             writeDataFileRunnable.putRequest(new CloseFileRequest(currFileChannel, currRaf));
             Files.move(currDataFile.toPath(), new File(hisFullFileName).toPath(), StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException exx) {
-            LOGGER.error("save history data file error," + exx.getMessage());
+            LOGGER.error("save history data file error, {}", exx.getMessage(), exx);
             result = false;
         } finally {
             initFile(currFullFileName);
         }
         return result;
+    }
+
+    private boolean writeDataFrame(byte[] data) {
+        if (data == null || data.length <= 0) {
+            return true;
+        }
+        int dataLength = data.length;
+        int bufferRemainingSize = writeBuffer.remaining();
+        if (bufferRemainingSize <= INT_BYTE_SIZE) {
+            if (!flushWriteBuffer(writeBuffer)) {
+                return false;
+            }
+        }
+        bufferRemainingSize = writeBuffer.remaining();
+        if (bufferRemainingSize <= INT_BYTE_SIZE) {
+            throw new IllegalStateException(String.format("Write buffer remaining size %d was too small", bufferRemainingSize));
+        }
+        writeBuffer.putInt(dataLength);
+        bufferRemainingSize = writeBuffer.remaining();
+        int dataPos = 0;
+        while (dataPos < dataLength) {
+            int dataLengthToWrite = dataLength - dataPos;
+            dataLengthToWrite = Math.min(dataLengthToWrite, bufferRemainingSize);
+            writeBuffer.put(data, dataPos, dataLengthToWrite);
+            bufferRemainingSize = writeBuffer.remaining();
+            if (bufferRemainingSize == 0) {
+                if (!flushWriteBuffer(writeBuffer)) {
+                    return false;
+                }
+                bufferRemainingSize = writeBuffer.remaining();
+            }
+            dataPos += dataLengthToWrite;
+        }
+        return true;
+    }
+
+    private boolean flushWriteBuffer(ByteBuffer writeBuffer) {
+        writeBuffer.flip();
+        if (!writeDataFileByBuffer(writeBuffer)) {
+            return false;
+        }
+        writeBuffer.clear();
+        return true;
     }
 
     private boolean findTimeoutAndSave() throws IOException {
@@ -229,32 +272,25 @@ public class FileTransactionStoreManager extends AbstractTransactionStoreManager
         if (CollectionUtils.isEmpty(globalSessionsOverMaxTimeout)) {
             return true;
         }
-        List<byte[]> listBytes = new ArrayList<>();
-        int totalSize = 0;
-        // 1. find all data and merge
         for (GlobalSession globalSession : globalSessionsOverMaxTimeout) {
             TransactionWriteStore globalWriteStore = new TransactionWriteStore(globalSession, LogOperation.GLOBAL_ADD);
             byte[] data = globalWriteStore.encode();
-            listBytes.add(data);
-            totalSize += data.length + INT_BYTE_SIZE;
+            if(!writeDataFrame(data)) {
+                return false;
+            }
             List<BranchSession> branchSessIonsOverMaXTimeout = globalSession.getSortedBranches();
             if (null != branchSessIonsOverMaXTimeout) {
                 for (BranchSession branchSession : branchSessIonsOverMaXTimeout) {
                     TransactionWriteStore branchWriteStore =
                         new TransactionWriteStore(branchSession, LogOperation.BRANCH_ADD);
                     data = branchWriteStore.encode();
-                    listBytes.add(data);
-                    totalSize += data.length + INT_BYTE_SIZE;
+                    if(!writeDataFrame(data)) {
+                        return false;
+                    }
                 }
             }
         }
-        // 2. batch write
-        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(totalSize);
-        for (byte[] bytes : listBytes) {
-            byteBuffer.putInt(bytes.length);
-            byteBuffer.put(bytes);
-        }
-        if (writeDataFileByBuffer(byteBuffer)) {
+        if (flushWriteBuffer(writeBuffer)) {
             currFileChannel.force(false);
             return true;
         }
@@ -414,24 +450,13 @@ public class FileTransactionStoreManager extends AbstractTransactionStoreManager
         if (bs == null || bs.length >= Integer.MAX_VALUE - 3) {
             return false;
         }
-        ByteBuffer byteBuffer = null;
-
-        if (bs.length + 4 > MAX_WRITE_BUFFER_SIZE) {
-            //allocateNew
-            byteBuffer = ByteBuffer.allocateDirect(bs.length + 4);
-        } else {
-            byteBuffer = writeBuffer;
-            //recycle
-            byteBuffer.clear();
+        if (!writeDataFrame(bs)) {
+            return false;
         }
-
-        byteBuffer.putInt(bs.length);
-        byteBuffer.put(bs);
-        return writeDataFileByBuffer(byteBuffer);
+        return flushWriteBuffer(writeBuffer);
     }
 
     private boolean writeDataFileByBuffer(ByteBuffer byteBuffer) {
-        byteBuffer.flip();
         for (int retry = 0; retry < MAX_WRITE_RETRY; retry++) {
             try {
                 while (byteBuffer.hasRemaining()) {

--- a/server/src/test/java/io/seata/server/store/file/FileTransactionStoreManagerTest.java
+++ b/server/src/test/java/io/seata/server/store/file/FileTransactionStoreManagerTest.java
@@ -1,0 +1,166 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.server.store.file;
+
+import io.seata.server.UUIDGenerator;
+import io.seata.server.session.BranchSession;
+import io.seata.server.session.GlobalSession;
+import io.seata.server.session.SessionManager;
+import io.seata.server.session.file.FileBasedSessionManager;
+import io.seata.server.store.StoreConfig;
+import io.seata.server.store.TransactionStoreManager;
+import io.seata.server.store.TransactionWriteStore;
+import org.assertj.core.util.Files;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author ggndnn
+ */
+public class FileTransactionStoreManagerTest {
+    @Test
+    public void testBigDataWrite() throws Exception {
+        File seataFile = Files.newTemporaryFile();
+        try {
+            FileTransactionStoreManager fileTransactionStoreManager = new FileTransactionStoreManager(seataFile.getAbsolutePath(), null);
+            BranchSession branchSessionA = Mockito.mock(BranchSession.class);
+            GlobalSession global = new GlobalSession();
+            Mockito.when(branchSessionA.encode())
+                    .thenReturn(createBigBranchSessionData(global, (byte) 'A'));
+            Mockito.when(branchSessionA.getApplicationData())
+                    .thenReturn(new String(createBigApplicationData((byte) 'A')));
+            BranchSession branchSessionB = Mockito.mock(BranchSession.class);
+            Mockito.when(branchSessionB.encode())
+                    .thenReturn(createBigBranchSessionData(global, (byte) 'B'));
+            Mockito.when(branchSessionB.getApplicationData())
+                    .thenReturn(new String(createBigApplicationData((byte) 'B')));
+            Assertions.assertTrue(fileTransactionStoreManager.writeSession(TransactionStoreManager.LogOperation.BRANCH_ADD, branchSessionA));
+            Assertions.assertTrue(fileTransactionStoreManager.writeSession(TransactionStoreManager.LogOperation.BRANCH_ADD, branchSessionB));
+            List<TransactionWriteStore> list = fileTransactionStoreManager.readWriteStore(2000, false);
+            Assertions.assertNotNull(list);
+            Assertions.assertEquals(2, list.size());
+            BranchSession loadedBranchSessionA = (BranchSession) list.get(0).getSessionRequest();
+            Assertions.assertEquals(branchSessionA.getApplicationData(), loadedBranchSessionA.getApplicationData());
+            BranchSession loadedBranchSessionB = (BranchSession) list.get(1).getSessionRequest();
+            Assertions.assertEquals(branchSessionB.getApplicationData(), loadedBranchSessionB.getApplicationData());
+        } finally {
+            Assertions.assertTrue(seataFile.delete());
+        }
+    }
+
+    @Test
+    public void testFindTimeoutAndSave() throws Exception {
+        File seataFile = Files.newTemporaryFile();
+        Method findTimeoutAndSaveMethod = FileTransactionStoreManager.class.getDeclaredMethod("findTimeoutAndSave");
+        findTimeoutAndSaveMethod.setAccessible(true);
+        try {
+            List<GlobalSession> timeoutSessions = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                GlobalSession globalSession = new GlobalSession("", "", "", 60000);
+                BranchSession branchSessionA = Mockito.mock(BranchSession.class);
+                Mockito.when(branchSessionA.encode())
+                        .thenReturn(createBigBranchSessionData(globalSession, (byte) 'A'));
+                Mockito.when(branchSessionA.getApplicationData())
+                        .thenReturn(new String(createBigApplicationData((byte) 'A')));
+                globalSession.addBranch(branchSessionA);
+                BranchSession branchSessionB = Mockito.mock(BranchSession.class);
+                Mockito.when(branchSessionB.encode())
+                        .thenReturn(createBigBranchSessionData(globalSession, (byte) 'B'));
+                Mockito.when(branchSessionB.getApplicationData())
+                        .thenReturn(new String(createBigApplicationData((byte) 'B')));
+                globalSession.addBranch(branchSessionB);
+                timeoutSessions.add(globalSession);
+            }
+            SessionManager sessionManagerMock = Mockito.mock(SessionManager.class);
+            Mockito.when(sessionManagerMock.findGlobalSessions(Mockito.any()))
+                    .thenReturn(timeoutSessions);
+            FileTransactionStoreManager fileTransactionStoreManager = new FileTransactionStoreManager(seataFile.getAbsolutePath(), sessionManagerMock);
+            Assertions.assertTrue((boolean) findTimeoutAndSaveMethod.invoke(fileTransactionStoreManager));
+
+            FileBasedSessionManager sessionManager = new FileBasedSessionManager(seataFile.getName(), seataFile.getParent());
+            sessionManager.reload();
+            Collection<GlobalSession> globalSessions = sessionManager.allSessions();
+            Assertions.assertNotNull(globalSessions);
+            globalSessions.forEach(g -> {
+                Assertions.assertNotNull(g);
+                List<BranchSession> branches = g.getBranchSessions();
+                Assertions.assertEquals(2, branches.size());
+                Assertions.assertEquals(new String(createBigApplicationData((byte) 'A')), branches.get(0).getApplicationData());
+                Assertions.assertEquals(new String(createBigApplicationData((byte) 'B')), branches.get(1).getApplicationData());
+            });
+        } finally {
+            findTimeoutAndSaveMethod.setAccessible(false);
+            Assertions.assertTrue(seataFile.delete());
+        }
+    }
+
+    private byte[] createBigBranchSessionData(GlobalSession global, byte c) {
+        int bufferSize = StoreConfig.getFileWriteBufferCacheSize() // applicationDataBytes
+                + 8 // trascationId
+                + 8 // branchId
+                + 4 // resourceIdBytes.length
+                + 4 // lockKeyBytes.length
+                + 2 // clientIdBytes.length
+                + 4 // applicationDataBytes.length
+                + 4 // xidBytes.size
+                + 1 // statusCode
+                + 1; //branchType
+        String xid = global.getXid();
+        byte[] xidBytes = null;
+        if (xid != null) {
+            xidBytes = xid.getBytes();
+            bufferSize += xidBytes.length;
+        }
+        ByteBuffer byteBuffer = ByteBuffer.allocate(bufferSize);
+        byteBuffer.putLong(global.getTransactionId());
+        byteBuffer.putLong(UUIDGenerator.generateUUID());
+        byteBuffer.putInt(0);
+        byteBuffer.putInt(0);
+        byteBuffer.putShort((short) 0);
+        byte[] applicationDataBytes = createBigApplicationData(c);
+        byteBuffer.putInt(applicationDataBytes.length);
+        byteBuffer.put(applicationDataBytes);
+        if (xidBytes != null) {
+            byteBuffer.putInt(xidBytes.length);
+            byteBuffer.put(xidBytes);
+        } else {
+            byteBuffer.putInt(0);
+        }
+        byteBuffer.put((byte) 0);
+        byteBuffer.put((byte) 0);
+        byteBuffer.flip();
+        byte[] bytes = new byte[byteBuffer.limit()];
+        byteBuffer.get(bytes);
+        return bytes;
+    }
+
+    private byte[] createBigApplicationData(byte c) {
+        int applicationDataSize = StoreConfig.getFileWriteBufferCacheSize();
+        byte[] applicationDataBytes = new byte[applicationDataSize];
+        for (int i = 0; i < applicationDataSize; i++) {
+            applicationDataBytes[i] = c;
+        }
+        return applicationDataBytes;
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
In FileTransactionStoreManager, sometimes, data buffer size was not under control. For example when data size to write was bigger than writerBuffer:

```
...
ByteBuffer byteBuffer = null;

if (bs.length + 4 > MAX_WRITE_BUFFER_SIZE) {
    //allocateNew
    byteBuffer = ByteBuffer.allocateDirect(bs.length + 4);
} else {
...
```
Or in function findTimeoutAndSave:
```
...
ByteBuffer byteBuffer = ByteBuffer.allocateDirect(totalSize);
for (byte[] bytes : listBytes) {
    byteBuffer.putInt(bytes.length);
    byteBuffer.put(bytes);
}
...
```
Those buffers' size was out of control, unlimited, that may be a hidden danger. 

This PR makes fully use of the writerBuffer, eliminate the possibility of allocating too much memory.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Did.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

