### PR TITLE
feature:support new parameter option "-e" used for setting name of configuration.

### DIFF
--- a/config/seata-config-core/src/main/java/io/seata/config/ConfigurationFactory.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/ConfigurationFactory.java
@@ -15,10 +15,10 @@
  */
 package io.seata.config;
 
+import java.util.Objects;
+
 import io.seata.common.exception.NotSupportYetException;
 import io.seata.common.loader.EnhancedServiceLoader;
-
-import java.util.Objects;
 
 /**
  * The type Configuration factory.
@@ -30,7 +30,7 @@ public final class ConfigurationFactory {
     private static final String REGISTRY_CONF_PREFIX = "registry";
     private static final String REGISTRY_CONF_SUFFIX = ".conf";
     private static final String ENV_SYSTEM_KEY = "SEATA_ENV";
-    private static final String ENV_PROPERTY_KEY = "seataEnv";
+    public static final String ENV_PROPERTY_KEY = "seataEnv";
 
     private static final String SYSTEM_PROPERTY_SEATA_CONFIG_NAME = "seata.config.name";
 
@@ -51,7 +51,7 @@ public final class ConfigurationFactory {
             envValue = System.getenv(ENV_SYSTEM_KEY);
         }
         CURRENT_FILE_INSTANCE = (null == envValue) ? new FileConfiguration(seataConfigName + REGISTRY_CONF_SUFFIX)
-                : new FileConfiguration(seataConfigName + "-" + envValue + REGISTRY_CONF_SUFFIX);
+            : new FileConfiguration(seataConfigName + "-" + envValue + REGISTRY_CONF_SUFFIX);
     }
 
     private static final String NAME_KEY = "name";

--- a/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemotingServer.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/AbstractRpcRemotingServer.java
@@ -167,7 +167,7 @@ public abstract class AbstractRpcRemotingServer extends AbstractRpcRemoting impl
     public void shutdown() {
         try {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Shuting server down. ");
+                LOGGER.debug("Shutting server down. ");
             }
             if (initialized.get()) {
                 RegistryFactory.getInstance().unregister(new InetSocketAddress(XID.getIpAddress(), XID.getPort()));

--- a/server/src/main/java/io/seata/server/ParameterParser.java
+++ b/server/src/main/java/io/seata/server/ParameterParser.java
@@ -18,9 +18,11 @@ package io.seata.server;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
-import io.seata.config.Configuration;
+import io.seata.common.util.StringUtils;
 import io.seata.config.ConfigurationFactory;
 import io.seata.core.constants.ConfigurationKeys;
+
+import static io.seata.config.ConfigurationFactory.ENV_PROPERTY_KEY;
 
 /**
  * The type Parameter parser.
@@ -33,10 +35,6 @@ public class ParameterParser {
     private static final int SERVER_DEFAULT_PORT = 8091;
     private static final String SERVER_DEFAULT_STORE_MODE = "file";
     private static final int SERVER_DEFAULT_NODE = 1;
-    /**
-     * The constant CONFIG.
-     */
-    protected static final Configuration CONFIG = ConfigurationFactory.getInstance();
 
     @Parameter(names = "--help", help = true)
     private boolean help;
@@ -45,9 +43,11 @@ public class ParameterParser {
     @Parameter(names = {"--port", "-p"}, description = "The port to listen.", order = 2)
     private int port = SERVER_DEFAULT_PORT;
     @Parameter(names = {"--storeMode", "-m"}, description = "log store mode : file、db", order = 3)
-    private String storeMode = CONFIG.getConfig(ConfigurationKeys.STORE_MODE, SERVER_DEFAULT_STORE_MODE);
+    private String storeMode;
     @Parameter(names = {"--serverNode", "-n"}, description = "server node id, such as 1, 2, 3. default is 1", order = 4)
     private int serverNode = SERVER_DEFAULT_NODE;
+    @Parameter(names = {"--seataEnv", "-e"}, description = "The name used for multi-configuration isolation.", order = 5)
+    private String seataEnv;
 
     /**
      * Instantiates a new Parameter parser.
@@ -66,6 +66,12 @@ public class ParameterParser {
                 jCommander.setProgramName(PROGRAM_NAME);
                 jCommander.usage();
                 System.exit(0);
+            }
+            if (StringUtils.isNotBlank(seataEnv)) {
+                System.setProperty(ENV_PROPERTY_KEY, seataEnv);
+            }
+            if(StringUtils.isBlank(storeMode)){
+                storeMode= ConfigurationFactory.getInstance().getConfig(ConfigurationKeys.STORE_MODE, SERVER_DEFAULT_STORE_MODE);
             }
         } catch (ParameterException e) {
             printError(e);
@@ -123,5 +129,14 @@ public class ParameterParser {
      */
     public int getServerNode() {
         return serverNode;
+    }
+
+    /**
+     * Gets seata env
+     *
+     * @return the name used for multi-configuration isolation.
+     */
+    public String getSeataEnv() {
+        return seataEnv;
     }
 }

--- a/server/src/main/java/io/seata/server/Server.java
+++ b/server/src/main/java/io/seata/server/Server.java
@@ -53,11 +53,13 @@ public class Server {
      * @throws IOException the io exception
      */
     public static void main(String[] args) throws IOException {
+        //initialize the parameter parser
+        //Note that the parameter parser should always be the first line to execute.
+        //Because, here we need to parse the parameters needed for startup.
+        ParameterParser parameterParser = new ParameterParser(args);
+
         //initialize the metrics
         MetricsManager.get().init();
-
-        //initialize the parameter parser
-        ParameterParser parameterParser = new ParameterParser(args);
 
         System.setProperty(ConfigurationKeys.STORE_MODE, parameterParser.getStoreMode());
 

--- a/server/src/test/java/io/seata/server/ParameterParserTest.java
+++ b/server/src/test/java/io/seata/server/ParameterParserTest.java
@@ -34,7 +34,7 @@ public class ParameterParserTest {
      */
     @BeforeEach
     private void init() {
-        String[] args = new String[] {"-h", "127.0.0.1", "-p", "8088", "-m", "file"};
+        String[] args = new String[] {"-h", "127.0.0.1", "-p", "8088", "-m", "file","-e","test"};
         parameterParser = new ParameterParser(args);
     }
 
@@ -71,6 +71,14 @@ public class ParameterParserTest {
     @Test
     public void testGetStoreMode() {
         Assertions.assertEquals("file", parameterParser.getStoreMode());
+    }
+
+    /**
+     * test get seata env
+     */
+    @Test
+    public void testGetSeataEnv() {
+        Assertions.assertEquals("test", parameterParser.getSeataEnv());
     }
 
     /**


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
As described in issue #1683,So i added a new parameter option "-e" to fix it.
And this is only available on the server side,for the client side,you can still use JVM parameter to set
the name of multi-configuration isolation directly.
```
Usage: sh seata-server.sh(for linux and mac) or cmd seata-server.bat(for 
      windows) [options]
  Options:
    --host, -h
      The ip to register to registry center.
    --port, -p
      The port to listen.
      Default: 8091
    --storeMode, -m
      log store mode : file、db
    --serverNode, -n
      server node id, such as 1, 2, 3. default is 1
      Default: 1
    --seataEnv, -e
      The name used for multi-configuration isolation.
    --help
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1683 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
UT provided,i've tested it.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
After this PR merged,i will update wiki as well.

