### PR TITLE
feature: isolate druid used in rm-datasource to solve druid compatibility issue

### DIFF
--- a/common/src/main/java/io/seata/common/loader/EnhancedServiceLoader.java
+++ b/common/src/main/java/io/seata/common/loader/EnhancedServiceLoader.java
@@ -184,7 +184,7 @@ public class EnhancedServiceLoader {
      * @return all extension class
      */
     @SuppressWarnings("rawtypes")
-    public static <S> List<Class> getAllExtensionClass(Class<S> service) {
+    static <S> List<Class> getAllExtensionClass(Class<S> service) {
         return findAllExtensionClass(service, null, findClassLoader());
     }
 
@@ -197,7 +197,7 @@ public class EnhancedServiceLoader {
      * @return all extension class
      */
     @SuppressWarnings("rawtypes")
-    public static <S> List<Class> getAllExtensionClass(Class<S> service, ClassLoader loader) {
+    static <S> List<Class> getAllExtensionClass(Class<S> service, ClassLoader loader) {
         return findAllExtensionClass(service, null, loader);
     }
 

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/SQLVisitorFactoryTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/SQLVisitorFactoryTest.java
@@ -46,17 +46,17 @@ public class SQLVisitorFactoryTest {
         //test for mysql insert
         String sql = "insert into t(id) values (1)";
         SQLRecognizer recognizer = SQLVisitorFactory.get(sql, JdbcConstants.MYSQL);
-        Assertions.assertTrue(recognizer instanceof MySQLInsertRecognizer);
+        Assertions.assertEquals(recognizer.getClass().getName(), MySQLInsertRecognizer.class.getName());
 
         //test for mysql delete
         sql = "delete from t";
         recognizer = SQLVisitorFactory.get(sql, JdbcConstants.MYSQL);
-        Assertions.assertTrue(recognizer instanceof MySQLDeleteRecognizer);
+        Assertions.assertEquals(recognizer.getClass().getName(), MySQLDeleteRecognizer.class.getName());
 
         //test for mysql update
         sql = "update t set a = a";
         recognizer = SQLVisitorFactory.get(sql, JdbcConstants.MYSQL);
-        Assertions.assertTrue(recognizer instanceof MySQLUpdateRecognizer);
+        Assertions.assertEquals(recognizer.getClass().getName(), MySQLUpdateRecognizer.class.getName());
 
         //test for mysql select
         sql = "select * from t";
@@ -66,22 +66,22 @@ public class SQLVisitorFactoryTest {
         //test for mysql select for update
         sql = "select * from t for update";
         recognizer = SQLVisitorFactory.get(sql, JdbcConstants.MYSQL);
-        Assertions.assertTrue(recognizer instanceof MySQLSelectForUpdateRecognizer);
+        Assertions.assertEquals(recognizer.getClass().getName(), MySQLSelectForUpdateRecognizer.class.getName());
 
         //test for oracle insert
         sql = "insert into t(id) values (1)";
         recognizer = SQLVisitorFactory.get(sql, JdbcConstants.ORACLE);
-        Assertions.assertTrue(recognizer instanceof OracleInsertRecognizer);
+        Assertions.assertEquals(recognizer.getClass().getName(), OracleInsertRecognizer.class.getName());
 
         //test for oracle delete
         sql = "delete from t";
         recognizer = SQLVisitorFactory.get(sql, JdbcConstants.ORACLE);
-        Assertions.assertTrue(recognizer instanceof OracleDeleteRecognizer);
+        Assertions.assertEquals(recognizer.getClass().getName(), OracleDeleteRecognizer.class.getName());
 
         //test for oracle update
         sql = "update t set a = a";
         recognizer = SQLVisitorFactory.get(sql, JdbcConstants.ORACLE);
-        Assertions.assertTrue(recognizer instanceof OracleUpdateRecognizer);
+        Assertions.assertEquals(recognizer.getClass().getName(), OracleUpdateRecognizer.class.getName());
 
         //test for oracle select
         sql = "select * from t";
@@ -91,7 +91,7 @@ public class SQLVisitorFactoryTest {
         //test for oracle select for update
         sql = "select * from t for update";
         recognizer = SQLVisitorFactory.get(sql, JdbcConstants.ORACLE);
-        Assertions.assertTrue(recognizer instanceof OracleSelectForUpdateRecognizer);
+        Assertions.assertEquals(recognizer.getClass().getName(), OracleSelectForUpdateRecognizer.class.getName());
 
         //test for do not support db
         Assertions.assertThrows(EnhancedServiceNotFoundException.class, () -> SQLVisitorFactory.get("select * from t", JdbcConstants.DB2));

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/druid/postgresql/PostgresqlDeleteRecognizerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/druid/postgresql/PostgresqlDeleteRecognizerTest.java
@@ -16,8 +16,8 @@
 package io.seata.rm.datasource.sql.druid.postgresql;
 
 import io.seata.sqlparser.ParametersHolder;
+import io.seata.sqlparser.SQLDeleteRecognizer;
 import io.seata.sqlparser.SQLType;
-import io.seata.sqlparser.druid.postgresql.PostgresqlDeleteRecognizer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +39,7 @@ public class PostgresqlDeleteRecognizerTest {
     public void testGetSqlType() {
         String sql = "delete from t where id = ?";
 
-        PostgresqlDeleteRecognizer recognizer = (PostgresqlDeleteRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.DELETE);
     }
 
@@ -47,7 +47,7 @@ public class PostgresqlDeleteRecognizerTest {
     public void testGetTableAlias() {
         String sql = "delete from t where id = ?";
 
-        PostgresqlDeleteRecognizer recognizer = (PostgresqlDeleteRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -56,7 +56,7 @@ public class PostgresqlDeleteRecognizerTest {
         String sql = "delete from t where id = ?";
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, DB_TYPE);
 
-        PostgresqlDeleteRecognizer recognizer = (PostgresqlDeleteRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -64,7 +64,7 @@ public class PostgresqlDeleteRecognizerTest {
     public void testGetWhereCondition_0() {
         String sql = "delete from t";
 
-        PostgresqlDeleteRecognizer recognizer = (PostgresqlDeleteRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public ArrayList<Object>[] getParameters() {
@@ -80,7 +80,7 @@ public class PostgresqlDeleteRecognizerTest {
     public void testGetWhereCondition_1() {
         String sql = "delete from t";
 
-        PostgresqlDeleteRecognizer recognizer = (PostgresqlDeleteRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLDeleteRecognizer recognizer = (SQLDeleteRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         String whereCondition = recognizer.getWhereCondition();
 
         //test for no condition

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/druid/postgresql/PostgresqlInsertRecognizerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/druid/postgresql/PostgresqlInsertRecognizerTest.java
@@ -15,6 +15,7 @@
  */
 package io.seata.rm.datasource.sql.druid.postgresql;
 
+import io.seata.sqlparser.SQLInsertRecognizer;
 import io.seata.sqlparser.SQLParsingException;
 import io.seata.sqlparser.SQLType;
 import io.seata.sqlparser.druid.postgresql.PostgresqlInsertRecognizer;
@@ -39,7 +40,7 @@ public class PostgresqlInsertRecognizerTest {
     public void testGetSqlType() {
         String sql = "insert into t(id) values (?)";
 
-        PostgresqlInsertRecognizer recognizer = (PostgresqlInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLInsertRecognizer recognizer = (SQLInsertRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.INSERT);
     }
 
@@ -47,7 +48,7 @@ public class PostgresqlInsertRecognizerTest {
     public void testGetTableAlias() {
         String sql = "insert into t(id) values (?)";
 
-        PostgresqlInsertRecognizer recognizer = (PostgresqlInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLInsertRecognizer recognizer = (SQLInsertRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
@@ -55,7 +56,7 @@ public class PostgresqlInsertRecognizerTest {
     public void testGetTableName() {
         String sql = "insert into t(id) values (?)";
 
-        PostgresqlInsertRecognizer recognizer = (PostgresqlInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLInsertRecognizer recognizer = (SQLInsertRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 
@@ -65,14 +66,14 @@ public class PostgresqlInsertRecognizerTest {
         //test for no column
         String sql = "insert into t values (?)";
 
-        PostgresqlInsertRecognizer recognizer = (PostgresqlInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLInsertRecognizer recognizer = (SQLInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
         List<String> insertColumns = recognizer.getInsertColumns();
         Assertions.assertNull(insertColumns);
 
         //test for normal
         sql = "insert into t(a) values (?)";
 
-        recognizer = (PostgresqlInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        recognizer = (SQLInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
         insertColumns = recognizer.getInsertColumns();
         Assertions.assertEquals(1, insertColumns.size());
 
@@ -93,7 +94,7 @@ public class PostgresqlInsertRecognizerTest {
         //test for null value
         String sql = "insert into t(id, no, name, age, time) values (nextval('id_seq'), null, 'a', ?, now())";
 
-        PostgresqlInsertRecognizer recognizer = (PostgresqlInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLInsertRecognizer recognizer = (SQLInsertRecognizer)SQLVisitorFactory.get(sql, DB_TYPE);
         List<List<Object>> insertRows = recognizer.getInsertRows();
         Assertions.assertTrue(insertRows.size() == 1);
 

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/druid/postgresql/PostgresqlSelectForUpdateRecognizerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/druid/postgresql/PostgresqlSelectForUpdateRecognizerTest.java
@@ -17,8 +17,8 @@ package io.seata.rm.datasource.sql.druid.postgresql;
 
 import io.seata.rm.datasource.sql.SQLVisitorFactory;
 import io.seata.sqlparser.ParametersHolder;
+import io.seata.sqlparser.SQLSelectRecognizer;
 import io.seata.sqlparser.SQLType;
-import io.seata.sqlparser.druid.postgresql.PostgresqlSelectForUpdateRecognizer;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ public class PostgresqlSelectForUpdateRecognizerTest {
     public void testGetSqlType() {
         String sql = "select * from t where id = ? for update";
 
-        PostgresqlSelectForUpdateRecognizer recognizer = (PostgresqlSelectForUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.SELECT_FOR_UPDATE);
     }
 
@@ -42,7 +42,7 @@ public class PostgresqlSelectForUpdateRecognizerTest {
     public void testGetWhereCondition_0() {
         String sql = "select * from t for update";
 
-        PostgresqlSelectForUpdateRecognizer recognizer = (PostgresqlSelectForUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public ArrayList<Object>[] getParameters() {
@@ -56,7 +56,7 @@ public class PostgresqlSelectForUpdateRecognizerTest {
     public void testGetWhereCondition_1() {
         String sql = "select * from t for update";
 
-        PostgresqlSelectForUpdateRecognizer recognizer = (PostgresqlSelectForUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -65,14 +65,14 @@ public class PostgresqlSelectForUpdateRecognizerTest {
     @Test
     public void testGetTableAlias() {
         String sql = "select * from t where id = ? for update";
-        PostgresqlSelectForUpdateRecognizer recognizer = (PostgresqlSelectForUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "select * from t where id = ? for update";
-        PostgresqlSelectForUpdateRecognizer recognizer = (PostgresqlSelectForUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLSelectRecognizer recognizer = (SQLSelectRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/druid/postgresql/PostgresqlUpdateRecognizerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/druid/postgresql/PostgresqlUpdateRecognizerTest.java
@@ -24,6 +24,7 @@ import io.seata.rm.datasource.sql.SQLVisitorFactory;
 import io.seata.sqlparser.ParametersHolder;
 import io.seata.sqlparser.SQLParsingException;
 import io.seata.sqlparser.SQLType;
+import io.seata.sqlparser.SQLUpdateRecognizer;
 import io.seata.sqlparser.druid.postgresql.PostgresqlUpdateRecognizer;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +42,7 @@ public class PostgresqlUpdateRecognizerTest {
     public void testGetSqlType() {
         String sql = "update t set n = ?";
 
-        PostgresqlUpdateRecognizer recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertEquals(recognizer.getSQLType(), SQLType.UPDATE);
     }
 
@@ -49,13 +50,13 @@ public class PostgresqlUpdateRecognizerTest {
     public void testGetUpdateColumns() {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
-        PostgresqlUpdateRecognizer recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         List<String> updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
         // test with alias
         sql = "update t set a.a = ?, a.b = ?, a.c = ?";
-        recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         updateColumns = recognizer.getUpdateColumns();
         Assertions.assertEquals(updateColumns.size(), 3);
 
@@ -77,13 +78,13 @@ public class PostgresqlUpdateRecognizerTest {
     public void testGetUpdateValues() {
         // test with normal
         String sql = "update t set a = ?, b = ?, c = ?";
-        PostgresqlUpdateRecognizer recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         List<Object> updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
         // test with values
         sql = "update t set a = 1, b = 2, c = 3";
-        recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         updateValues = recognizer.getUpdateValues();
         Assertions.assertEquals(updateValues.size(), 3);
 
@@ -104,7 +105,7 @@ public class PostgresqlUpdateRecognizerTest {
     @Test
     public void testGetWhereCondition_0() {
         String sql = "update t set a = 1";
-        PostgresqlUpdateRecognizer recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         String whereCondition = recognizer.getWhereCondition(new ParametersHolder() {
             @Override
             public ArrayList<Object>[] getParameters() {
@@ -119,7 +120,7 @@ public class PostgresqlUpdateRecognizerTest {
     public void testGetWhereCondition_1() {
 
         String sql = "update t set a = 1";
-        PostgresqlUpdateRecognizer recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         String whereCondition = recognizer.getWhereCondition();
 
         Assertions.assertEquals("", whereCondition);
@@ -128,14 +129,14 @@ public class PostgresqlUpdateRecognizerTest {
     @Test
     public void testGetTableAlias() {
         String sql = "update t set a = ?, b = ?, c = ?";
-        PostgresqlUpdateRecognizer recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertNull(recognizer.getTableAlias());
     }
 
     @Test
     public void testGetTableName() {
         String sql = "update t set a = ?, b = ?, c = ?";
-        PostgresqlUpdateRecognizer recognizer = (PostgresqlUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
+        SQLUpdateRecognizer recognizer = (SQLUpdateRecognizer) SQLVisitorFactory.get(sql, DB_TYPE);
         Assertions.assertEquals(recognizer.getTableName(), "t");
     }
 

--- a/sqlparser/seata-sqlparser-druid/pom.xml
+++ b/sqlparser/seata-sqlparser-druid/pom.xml
@@ -35,6 +35,34 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <id>copy-druid</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>com.alibaba</includeGroupIds>
+                            <includeArtifactIds>druid</includeArtifactIds>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>
+                                ${project.build.outputDirectory}/lib/sqlparser
+                            </outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DefaultDruidLoader.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DefaultDruidLoader.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.security.CodeSource;
+
+/**
+ * @author ggndnn
+ */
+class DefaultDruidLoader implements DruidLoader {
+    /**
+     * Default druid location in classpath
+     */
+    private final static String DRUID_LOCATION = "lib/sqlparser/druid.jar";
+
+    private final static DefaultDruidLoader DRUID_LOADER = new DefaultDruidLoader(DRUID_LOCATION);
+
+    private final URL druidUrl;
+
+    /**
+     * @param druidLocation druid location in classpath
+     */
+    private DefaultDruidLoader(String druidLocation) {
+        if (druidLocation == null) {
+            druidLocation = DRUID_LOCATION;
+        }
+        URL url = DefaultDruidLoader.class.getClassLoader().getResource(druidLocation);
+        if (url != null) {
+            try {
+                // extract druid.jar to temp file
+                // TODO use URLStreamHandler to handle nested jar loading in the future
+                File tempFile = File.createTempFile("seata", "sqlparser");
+                try (InputStream input = url.openStream()) {
+                    byte[] buf = new byte[1024];
+                    try (OutputStream output = new FileOutputStream(tempFile)) {
+                        while (true) {
+                            int readCnt = input.read(buf);
+                            if (readCnt < 0) {
+                                break;
+                            }
+                            output.write(buf, 0, readCnt);
+                        }
+                        output.flush();
+                    }
+                }
+                tempFile.deleteOnExit();
+                druidUrl = tempFile.toURI().toURL();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            // try to find druid in class code source if it's not in classpath which should usually happen in unit test
+            Class<?> clazz = null;
+            try {
+                clazz = DefaultDruidLoader.class.getClassLoader().loadClass("com.alibaba.druid.util.StringUtils");
+            } catch (ClassNotFoundException ignore) {
+            }
+            if (clazz != null) {
+                CodeSource cs = clazz.getProtectionDomain().getCodeSource();
+                if (cs == null) {
+                    throw new IllegalStateException("Can not find druid code source");
+                }
+                druidUrl = cs.getLocation();
+            } else {
+                druidUrl = null;
+            }
+        }
+    }
+
+    /**
+     * Get default druid loader
+     *
+     * @return default druid loader
+     */
+    static DruidLoader get() {
+        return DRUID_LOADER;
+    }
+
+    @Override
+    public URL getEmbeddedDruidLocation() {
+        if (druidUrl == null) {
+            throw new IllegalStateException("Can not find embedded druid");
+        }
+        return druidUrl;
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DefaultDruidLoader.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DefaultDruidLoader.java
@@ -48,18 +48,16 @@ class DefaultDruidLoader implements DruidLoader {
                 // extract druid.jar to temp file
                 // TODO use URLStreamHandler to handle nested jar loading in the future
                 File tempFile = File.createTempFile("seata", "sqlparser");
-                try (InputStream input = url.openStream()) {
+                try (InputStream input = url.openStream(); OutputStream output = new FileOutputStream(tempFile)) {
                     byte[] buf = new byte[1024];
-                    try (OutputStream output = new FileOutputStream(tempFile)) {
-                        while (true) {
-                            int readCnt = input.read(buf);
-                            if (readCnt < 0) {
-                                break;
-                            }
-                            output.write(buf, 0, readCnt);
+                    while (true) {
+                        int readCnt = input.read(buf);
+                        if (readCnt < 0) {
+                            break;
                         }
-                        output.flush();
+                        output.write(buf, 0, readCnt);
                     }
+                    output.flush();
                 }
                 tempFile.deleteOnExit();
                 druidUrl = tempFile.toURI().toURL();

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidDbTypeParserImpl.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidDbTypeParserImpl.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid;
+
+import com.alibaba.druid.util.JdbcUtils;
+import io.seata.sqlparser.util.DbTypeParser;
+
+/**
+ * @author ggndnn
+ */
+class DruidDbTypeParserImpl implements DbTypeParser {
+    @Override
+    public String parseFromJdbcUrl(String jdbcUrl) {
+        return JdbcUtils.getDbType(jdbcUrl, null);
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidDelegatingDbTypeParser.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidDelegatingDbTypeParser.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid;
+
+import io.seata.common.loader.LoadLevel;
+import io.seata.sqlparser.SqlParserType;
+import io.seata.sqlparser.util.DbTypeParser;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * @author ggndnn
+ */
+@LoadLevel(name = SqlParserType.SQL_PARSER_TYPE_DRUID)
+public class DruidDelegatingDbTypeParser implements DbTypeParser {
+    private DbTypeParser dbTypeParserImpl;
+
+    public DruidDelegatingDbTypeParser() {
+        setClassLoader(DruidIsolationClassLoader.get());
+    }
+
+    /**
+     * Only for unit test
+     *
+     * @param classLoader classLoader
+     */
+    void setClassLoader(ClassLoader classLoader) {
+        try {
+            Class<?> druidDbTypeParserImplClass = classLoader.loadClass("io.seata.sqlparser.druid.DruidDbTypeParserImpl");
+            Constructor<?> implConstructor = druidDbTypeParserImplClass.getDeclaredConstructor();
+            implConstructor.setAccessible(true);
+            try {
+                dbTypeParserImpl = (DbTypeParser) implConstructor.newInstance();
+            } finally {
+                implConstructor.setAccessible(false);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String parseFromJdbcUrl(String jdbcUrl) {
+        return dbTypeParserImpl.parseFromJdbcUrl(jdbcUrl);
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidDelegatingSQLRecognizerFactory.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidDelegatingSQLRecognizerFactory.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid;
+
+import io.seata.common.loader.LoadLevel;
+import io.seata.sqlparser.SQLParsingException;
+import io.seata.sqlparser.SQLRecognizer;
+import io.seata.sqlparser.SQLRecognizerFactory;
+import io.seata.sqlparser.SqlParserType;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * @author ggndnn
+ */
+@LoadLevel(name = SqlParserType.SQL_PARSER_TYPE_DRUID)
+public class DruidDelegatingSQLRecognizerFactory implements SQLRecognizerFactory {
+    private volatile SQLRecognizerFactory recognizerFactoryImpl;
+
+    public DruidDelegatingSQLRecognizerFactory() {
+        setClassLoader(DruidIsolationClassLoader.get());
+    }
+
+    /**
+     * Only for unit test
+     *
+     * @param classLoader classLoader
+     */
+    void setClassLoader(ClassLoader classLoader) {
+        try {
+            Class<?> recognizerFactoryImplClass = classLoader.loadClass("io.seata.sqlparser.druid.DruidSQLRecognizerFactoryImpl");
+            Constructor<?> implConstructor = recognizerFactoryImplClass.getDeclaredConstructor();
+            implConstructor.setAccessible(true);
+            try {
+                recognizerFactoryImpl = (SQLRecognizerFactory) implConstructor.newInstance();
+            } finally {
+                implConstructor.setAccessible(false);
+            }
+        } catch (Exception e) {
+            throw new SQLParsingException(e);
+        }
+    }
+
+    @Override
+    public SQLRecognizer create(String sql, String dbType) {
+        return recognizerFactoryImpl.create(sql, dbType);
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidIsolationClassLoader.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidIsolationClassLoader.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Used for druid isolation.
+ *
+ * @author ggndnn
+ */
+class DruidIsolationClassLoader extends URLClassLoader {
+    private final static String[] DRUID_CLASS_PREFIX = new String[]{"com.alibaba.druid.", "io.seata.sqlparser.druid."};
+
+    private final static DruidIsolationClassLoader INSTANCE = new DruidIsolationClassLoader(DefaultDruidLoader.get());
+
+    DruidIsolationClassLoader(DruidLoader druidLoader) {
+        super(getDruidUrls(druidLoader), DruidIsolationClassLoader.class.getClassLoader());
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        for (String prefix : DRUID_CLASS_PREFIX) {
+            if (name.startsWith(prefix)) {
+                return loadInternalClass(name, resolve);
+            }
+        }
+        return super.loadClass(name, resolve);
+    }
+
+    private Class<?> loadInternalClass(String name, boolean resolve) throws ClassNotFoundException {
+        Class<?> c;
+        synchronized (getClassLoadingLock(name)) {
+            c = findLoadedClass(name);
+            if (c == null) {
+                c = findClass(name);
+            }
+        }
+        if (c == null) {
+            throw new ClassNotFoundException(name);
+        }
+        if (resolve) {
+            resolveClass(c);
+        }
+        return c;
+    }
+
+    private static URL[] getDruidUrls(DruidLoader druidLoader) {
+        List<URL> urls = new ArrayList<>();
+        urls.add(findClassLocation(DruidIsolationClassLoader.class));
+        urls.add(druidLoader.getEmbeddedDruidLocation());
+        return urls.toArray(new URL[0]);
+    }
+
+    private static URL findClassLocation(Class<?> clazz) {
+        CodeSource cs = clazz.getProtectionDomain().getCodeSource();
+        if (cs == null) {
+            throw new IllegalStateException("Not a normal druid startup environment");
+        }
+        return cs.getLocation();
+    }
+
+    static DruidIsolationClassLoader get() {
+        return INSTANCE;
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidLoader.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidLoader.java
@@ -15,18 +15,16 @@
  */
 package io.seata.sqlparser.druid;
 
-import com.alibaba.druid.util.JdbcUtils;
-import io.seata.common.loader.LoadLevel;
-import io.seata.sqlparser.SqlParserType;
-import io.seata.sqlparser.util.DbTypeParser;
+import java.net.URL;
 
 /**
- * @author ggndnn
+ * ggndnn
  */
-@LoadLevel(name = SqlParserType.SQL_PARSER_TYPE_DRUID)
-public class DruidDbTypeParser implements DbTypeParser {
-    @Override
-    public String parseFromJdbcUrl(String jdbcUrl) {
-        return JdbcUtils.getDbType(jdbcUrl, null);
-    }
+interface DruidLoader {
+    /**
+     * Gets embedded druid.jar
+     *
+     * @return embedded druid.jar url
+     */
+    URL getEmbeddedDruidLocation();
 }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/DruidSQLRecognizerFactoryImpl.java
@@ -21,21 +21,18 @@ import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
 import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
 import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
-import io.seata.common.loader.LoadLevel;
 import io.seata.sqlparser.SQLRecognizer;
 import io.seata.sqlparser.SQLRecognizerFactory;
-import io.seata.sqlparser.SqlParserType;
 
 import java.util.List;
 
 /**
- * DruidSQLRecognizerFactory
+ * DruidSQLRecognizerFactoryImpl
  *
  * @author sharajava
  * @author ggndnn
  */
-@LoadLevel(name = SqlParserType.SQL_PARSER_TYPE_DRUID)
-public class DruidSQLRecognizerFactory implements SQLRecognizerFactory {
+class DruidSQLRecognizerFactoryImpl implements SQLRecognizerFactory {
     @Override
     public SQLRecognizer create(String sql, String dbType) {
         List<SQLStatement> asts = SQLUtils.parseStatements(sql, dbType);

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/SQLOperateRecognizerHolderFactory.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/SQLOperateRecognizerHolderFactory.java
@@ -39,7 +39,7 @@ public class SQLOperateRecognizerHolderFactory {
         if (RECOGNIZER_HOLDER_MAP.get(dbType) != null) {
             return RECOGNIZER_HOLDER_MAP.get(dbType);
         }
-        SQLOperateRecognizerHolder recognizerHolder = EnhancedServiceLoader.load(SQLOperateRecognizerHolder.class, dbType);
+        SQLOperateRecognizerHolder recognizerHolder = EnhancedServiceLoader.load(SQLOperateRecognizerHolder.class, dbType, SQLOperateRecognizerHolderFactory.class.getClassLoader());
         RECOGNIZER_HOLDER_MAP.putIfAbsent(dbType, recognizerHolder);
         return recognizerHolder;
     }

--- a/sqlparser/seata-sqlparser-druid/src/main/resources/META-INF/services/io.seata.sqlparser.SQLRecognizerFactory
+++ b/sqlparser/seata-sqlparser-druid/src/main/resources/META-INF/services/io.seata.sqlparser.SQLRecognizerFactory
@@ -1,1 +1,1 @@
-io.seata.sqlparser.druid.DruidSQLRecognizerFactory
+io.seata.sqlparser.druid.DruidDelegatingSQLRecognizerFactory

--- a/sqlparser/seata-sqlparser-druid/src/main/resources/META-INF/services/io.seata.sqlparser.util.DbTypeParser
+++ b/sqlparser/seata-sqlparser-druid/src/main/resources/META-INF/services/io.seata.sqlparser.util.DbTypeParser
@@ -1,1 +1,1 @@
-io.seata.sqlparser.druid.DruidDbTypeParser
+io.seata.sqlparser.druid.DruidDelegatingDbTypeParser

--- a/sqlparser/seata-sqlparser-druid/src/test/java/io/seata/sqlparser/druid/DruidDbTypeParserTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/io/seata/sqlparser/druid/DruidDbTypeParserTest.java
@@ -22,15 +22,20 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * ggndnn
+ * @author ggndnn
  */
 public class DruidDbTypeParserTest {
     @Test
-    public void testDruidDbTypeParser() {
+    public void testDruidDbTypeParserLoading() {
         String jdbcUrl = "jdbc:mysql://127.0.0.1:3306/seata";
-        DbTypeParser dbTypeParser = EnhancedServiceLoader.load(DbTypeParser.class, SqlParserType.SQL_PARSER_TYPE_DRUID);
+        DruidDelegatingDbTypeParser dbTypeParser = (DruidDelegatingDbTypeParser) EnhancedServiceLoader.load(DbTypeParser.class, SqlParserType.SQL_PARSER_TYPE_DRUID);
         Assertions.assertNotNull(dbTypeParser);
+        Assertions.assertEquals(DruidDelegatingDbTypeParser.class, dbTypeParser.getClass());
         String dbType = dbTypeParser.parseFromJdbcUrl(jdbcUrl);
         Assertions.assertEquals("mysql", dbType);
+
+        DruidLoader druidLoaderForTest = new DruidLoaderForTest();
+        dbTypeParser.setClassLoader(new DruidIsolationClassLoader(druidLoaderForTest));
+        Assertions.assertThrows(NoClassDefFoundError.class, () -> dbTypeParser.parseFromJdbcUrl(jdbcUrl));
     }
 }

--- a/sqlparser/seata-sqlparser-druid/src/test/java/io/seata/sqlparser/druid/DruidIsolationTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/io/seata/sqlparser/druid/DruidIsolationTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid;
+
+import io.seata.common.loader.EnhancedServiceLoader;
+import io.seata.sqlparser.SQLRecognizer;
+import io.seata.sqlparser.SQLRecognizerFactory;
+import io.seata.sqlparser.SqlParserType;
+import io.seata.sqlparser.util.JdbcConstants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author ggndnn
+ */
+public class DruidIsolationTest {
+    private final static String TEST_SQL = "insert into t_table_1 values(?, ?)";
+
+    @Test
+    public void testDruidIsolation() throws Exception {
+        DruidDelegatingSQLRecognizerFactory recognizerFactory = (DruidDelegatingSQLRecognizerFactory) EnhancedServiceLoader.load(SQLRecognizerFactory.class, SqlParserType.SQL_PARSER_TYPE_DRUID);
+        Assertions.assertNotNull(recognizerFactory);
+        SQLRecognizer sqlRecognizer = recognizerFactory.create(TEST_SQL, JdbcConstants.MYSQL);
+        Assertions.assertNotNull(sqlRecognizer);
+        DruidLoader druidLoaderForTest = new DruidLoaderForTest();
+        recognizerFactory.setClassLoader(new DruidIsolationClassLoader(druidLoaderForTest));
+        // because druid-test.jar not exists, so NoClassDefFoundError should be threw
+        Assertions.assertThrows(NoClassDefFoundError.class, () -> recognizerFactory.create(TEST_SQL, JdbcConstants.MYSQL));
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/test/java/io/seata/sqlparser/druid/DruidLoaderForTest.java
+++ b/sqlparser/seata-sqlparser-druid/src/test/java/io/seata/sqlparser/druid/DruidLoaderForTest.java
@@ -1,0 +1,16 @@
+package io.seata.sqlparser.druid;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+class DruidLoaderForTest implements DruidLoader {
+    @Override
+    public URL getEmbeddedDruidLocation() {
+        try {
+            return URI.create("file://druid-test.jar").toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
This PR was created to to solve druid compatibility issue, because druid was only used to do sql parser,  so all druid related code were isolated from users' druid by a separate class loader. All imports from druid in rm-datasource were removed except unit test code. In addition, sql parser part was extracted to several new projects as SPI, e.g., seata-sqlparser-core and seata-sqlparser-druid.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

