### PR TITLE
Remove deprecated JVM arguments in Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dependency-reduced-pom.xml
 /distribution/bin
 /distribution/conf
 /distribution/lib
+/distribution/logs
 /server/*root.*
 /server/.root.*
 /server/sessionStore/

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -114,6 +114,7 @@
                         <windows>.bat</windows>
                     </binFileExtensions>
                     <assembleDirectory>../distribution</assembleDirectory>
+                    <logsDirectory>logs</logsDirectory>
                     <programs>
                         <program>
                             <mainClass>io.seata.server.Server</mainClass>
@@ -130,27 +131,16 @@
                                     <extraArgument>-XX:MaxMetaspaceSize=256m</extraArgument>
                                     <extraArgument>-XX:MaxDirectMemorySize=1024m</extraArgument>
                                     <extraArgument>-XX:-OmitStackTraceInFastThrow</extraArgument>
-                                    <extraArgument>-XX:+AggressiveOpts</extraArgument>
-                                    <extraArgument>-XX:+UseFastAccessorMethods</extraArgument>
                                     <extraArgument>-XX:-UseAdaptiveSizePolicy</extraArgument>
                                     <extraArgument>-XX:+HeapDumpOnOutOfMemoryError</extraArgument>
-                                    <extraArgument>-XX:HeapDumpPath=${BASEDIR}/logs/java_heapdump.hprof</extraArgument>
+                                    <extraArgument>-XX:HeapDumpPath=@BASEDIR@/logs/java_heapdump.hprof</extraArgument>
                                     <!--gc-->
                                     <extraArgument>-XX:+DisableExplicitGC</extraArgument>
-                                    <extraArgument>-XX:+UseParNewGC</extraArgument>
-                                    <extraArgument>-XX:+UseConcMarkSweepGC</extraArgument>
                                     <extraArgument>-XX:+CMSParallelRemarkEnabled</extraArgument>
-                                    <extraArgument>-XX:+UseCMSCompactAtFullCollection</extraArgument>
                                     <extraArgument>-XX:+UseCMSInitiatingOccupancyOnly</extraArgument>
                                     <extraArgument>-XX:CMSInitiatingOccupancyFraction=75</extraArgument>
-                                    <extraArgument>-Xloggc:${BASEDIR}/logs/seata_gc.log</extraArgument>
+                                    <extraArgument>-Xloggc:@BASEDIR@/logs/seata_gc.log</extraArgument>
                                     <extraArgument>-verbose:gc</extraArgument>
-                                    <extraArgument>-XX:+PrintGCDetails</extraArgument>
-                                    <extraArgument>-XX:+PrintGCDateStamps</extraArgument>
-                                    <extraArgument>-XX:+PrintGCTimeStamps</extraArgument>
-                                    <extraArgument>-XX:+UseGCLogFileRotation</extraArgument>
-                                    <extraArgument>-XX:NumberOfGCLogFiles=10</extraArgument>
-                                    <extraArgument>-XX:GCLogFileSize=100M</extraArgument>
                                     <!--netty-->
                                     <extraArgument>-Dio.netty.leakDetectionLevel=advanced</extraArgument>
                                 </extraArguments>


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Remove deprecated JVM arguments in Java 11

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

#1819 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
There is no test for server script

### Ⅳ. Describe how to verify it
1. Change JRE to 8, startup server in Mac/Linux/Win
2. Change JRE to 11, startup server in Mac/Linux/Win

All environment should be startup normally.

### Ⅴ. Special notes for reviews

Need to make sure removed argument is not affect performance of server
