### PR TITLE
Optimize RM side code structure：Restructure SQLRecognizer and UndoExecutor

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/SQLRecognizerGroup.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/SQLRecognizerGroup.java
@@ -1,0 +1,24 @@
+package io.seata.rm.datasource.sql;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+
+/**
+ * The interface SQLRecognizerGroup
+ *
+ * @author: Zhibei Hao丶
+ * @date: 2019/11/8 17:39
+ * @version: V1.0
+ */
+public interface SQLRecognizerGroup
+{
+  SQLRecognizer getDeleteRecognizer(String sql, SQLStatement ast);
+
+  SQLRecognizer getInsertRecognizer(String sql, SQLStatement ast);
+
+  SQLRecognizer getUpdateRecognizer(String sql, SQLStatement ast);
+
+  SQLRecognizer getSelectForUpdateRecognizer(String sql, SQLStatement ast);
+
+  String getDbType();
+
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/SQLRecognizerGroupFactory.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/SQLRecognizerGroupFactory.java
@@ -1,0 +1,40 @@
+package io.seata.rm.datasource.sql;
+
+import io.seata.common.loader.EnhancedServiceLoader;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+/**
+ * The SQLRecognizerGroupFactory
+ *
+ * @author: Zhibei Hao丶
+ * @date: 2019/11/8 17:37
+ * @version: V1.0
+ */
+public class SQLRecognizerGroupFactory
+{
+
+  private static Object lockObj = new Object();
+  private static Map<String, SQLRecognizerGroup> recognizerGroupMap;
+
+  public static SQLRecognizerGroup getSQLRecognizerGroup(String dbType) {
+
+    if (recognizerGroupMap == null) {
+      synchronized (lockObj) {
+        if (recognizerGroupMap == null) {
+          recognizerGroupMap = new HashMap<>();
+          List<SQLRecognizerGroup> groupList =
+              EnhancedServiceLoader.loadAll(SQLRecognizerGroup.class);
+          for (SQLRecognizerGroup group : groupList) {
+            recognizerGroupMap.put(group.getDbType().toLowerCase(), group);
+          }
+        }
+      }
+    }
+    if (recognizerGroupMap.containsKey(dbType)) {
+      return recognizerGroupMap.get(dbType);
+    }
+    throw new RuntimeException(MessageFormat.format("now not support {0}", dbType));
+  }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/SQLVisitorFactory.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/SQLVisitorFactory.java
@@ -53,32 +53,18 @@ public class SQLVisitorFactory {
         }
         SQLRecognizer recognizer = null;
         SQLStatement ast = asts.get(0);
-        if (JdbcConstants.MYSQL.equalsIgnoreCase(dbType)) {
-            if (ast instanceof SQLInsertStatement) {
-                recognizer = new MySQLInsertRecognizer(sql, ast);
-            } else if (ast instanceof SQLUpdateStatement) {
-                recognizer = new MySQLUpdateRecognizer(sql, ast);
-            } else if (ast instanceof SQLDeleteStatement) {
-                recognizer = new MySQLDeleteRecognizer(sql, ast);
-            } else if (ast instanceof SQLSelectStatement) {
-                if (((SQLSelectStatement) ast).getSelect().getFirstQueryBlock().isForUpdate()) {
-                    recognizer = new MySQLSelectForUpdateRecognizer(sql, ast);
-                }
+        SQLRecognizerGroup recognizerGroup =
+            SQLRecognizerGroupFactory.getSQLRecognizerGroup(dbType.toLowerCase());
+        if (ast instanceof SQLInsertStatement) {
+            recognizer = recognizerGroup.getInsertRecognizer(sql, ast);
+        } else if (ast instanceof SQLUpdateStatement) {
+            recognizer = recognizerGroup.getUpdateRecognizer(sql, ast);
+        } else if (ast instanceof SQLDeleteStatement) {
+            recognizer = recognizerGroup.getDeleteRecognizer(sql, ast);
+        } else if (ast instanceof SQLSelectStatement) {
+            if (((SQLSelectStatement) ast).getSelect().getFirstQueryBlock().isForUpdate()) {
+                recognizer = recognizerGroup.getSelectForUpdateRecognizer(sql, ast);
             }
-        }  else if (JdbcConstants.ORACLE.equalsIgnoreCase(dbType)) {
-            if (ast instanceof SQLInsertStatement) {
-                recognizer = new OracleInsertRecognizer(sql, ast);
-            } else if (ast instanceof SQLUpdateStatement) {
-                recognizer = new OracleUpdateRecognizer(sql, ast);
-            } else if (ast instanceof SQLDeleteStatement) {
-                recognizer = new OracleDeleteRecognizer(sql, ast);
-            } else if (ast instanceof SQLSelectStatement) {
-                if (((SQLSelectStatement) ast).getSelect().getQueryBlock().isForUpdate()) {
-                    recognizer = new OracleSelectForUpdateRecognizer(sql, ast);
-                }
-            }
-        }else {
-            throw new UnsupportedOperationException("Just support MySQL and Oracle by now!");
         }
         return recognizer;
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/druid/MySqlRecognizerGroup.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/druid/MySqlRecognizerGroup.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.sql.druid;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import io.seata.rm.datasource.sql.SQLRecognizer;
+import io.seata.rm.datasource.sql.SQLRecognizerGroup;
+
+/**
+ * MySqlRecognizerGroup
+ *
+ * @author: Zhibei Hao丶
+ * @date 2019/8/15 10:32
+ * @version: V1.0
+ */
+public class MySqlRecognizerGroup implements SQLRecognizerGroup {
+  private final String MYSQL = "mysql";
+
+  @Override
+  public SQLRecognizer getDeleteRecognizer(String sql, SQLStatement ast) {
+    return new MySQLDeleteRecognizer(sql, ast);
+  }
+
+  @Override
+  public SQLRecognizer getInsertRecognizer(String sql, SQLStatement ast) {
+    return new MySQLInsertRecognizer(sql, ast);
+  }
+
+  @Override
+  public SQLRecognizer getUpdateRecognizer(String sql, SQLStatement ast) {
+    return new MySQLUpdateRecognizer(sql, ast);
+  }
+
+  @Override
+  public SQLRecognizer getSelectForUpdateRecognizer(String sql, SQLStatement ast) {
+    return new MySQLSelectForUpdateRecognizer(sql, ast);
+  }
+
+  @Override
+  public String getDbType() {
+    return MYSQL;
+  }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/druid/oracle/OracleRecognizerGroup.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/druid/oracle/OracleRecognizerGroup.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.sql.druid.oracle;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import io.seata.rm.datasource.sql.SQLRecognizer;
+import io.seata.rm.datasource.sql.SQLRecognizerGroup;
+
+/**
+ * 功能描述:
+ *
+ * @author: Zhibei Hao丶
+ * @date: 2019/8/23 9:59
+ * @version: V1.0
+ */
+public class OracleRecognizerGroup implements SQLRecognizerGroup
+{
+  private final String ORACLE = "oracle";
+  @Override
+  public SQLRecognizer getDeleteRecognizer(String sql, SQLStatement ast)
+  {
+    return new OracleDeleteRecognizer(sql,ast);
+  }
+
+  @Override
+  public SQLRecognizer getInsertRecognizer(String sql, SQLStatement ast)
+  {
+    return new OracleInsertRecognizer(sql,ast);
+  }
+
+  @Override
+  public SQLRecognizer getUpdateRecognizer(String sql, SQLStatement ast)
+  {
+    return new OracleUpdateRecognizer(sql,ast);
+  }
+
+  @Override
+  public SQLRecognizer getSelectForUpdateRecognizer(String sql, SQLStatement ast)
+  {
+    return new OracleSelectForUpdateRecognizer(sql,ast);
+  }
+
+  @Override
+  public String getDbType()
+  {
+    return ORACLE;
+  }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoExecutorFactory.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoExecutorFactory.java
@@ -18,12 +18,7 @@ package io.seata.rm.datasource.undo;
 import com.alibaba.druid.util.JdbcConstants;
 import io.seata.common.exception.NotSupportYetException;
 import io.seata.common.exception.ShouldNeverHappenException;
-import io.seata.rm.datasource.undo.mysql.MySQLUndoDeleteExecutor;
-import io.seata.rm.datasource.undo.mysql.MySQLUndoInsertExecutor;
-import io.seata.rm.datasource.undo.mysql.MySQLUndoUpdateExecutor;
-import io.seata.rm.datasource.undo.oracle.OracleUndoDeleteExecutor;
-import io.seata.rm.datasource.undo.oracle.OracleUndoInsertExecutor;
-import io.seata.rm.datasource.undo.oracle.OracleUndoUpdateExecutor;
+
 
 /**
  * The type Undo executor factory.
@@ -40,31 +35,24 @@ public class UndoExecutorFactory {
      * @return the undo executor
      */
     public static AbstractUndoExecutor getUndoExecutor(String dbType, SQLUndoLog sqlUndoLog) {
-        if (!dbType.equalsIgnoreCase(JdbcConstants.MYSQL)&&!dbType.equalsIgnoreCase(JdbcConstants.ORACLE)) {
-            throw new NotSupportYetException(dbType);
-        }
-          if(dbType.equalsIgnoreCase(JdbcConstants.ORACLE)) {
-            switch (sqlUndoLog.getSqlType()) {
-                case INSERT:
-                    return new OracleUndoInsertExecutor(sqlUndoLog);
-                case UPDATE:
-                    return new OracleUndoUpdateExecutor(sqlUndoLog);
-                case DELETE:
-                    return new OracleUndoDeleteExecutor(sqlUndoLog);
-                default:
-                    throw new ShouldNeverHappenException();
-            }
-        } else {
-              switch (sqlUndoLog.getSqlType()) {
-                  case INSERT:
-                      return new MySQLUndoInsertExecutor(sqlUndoLog);
-                  case UPDATE:
-                      return new MySQLUndoUpdateExecutor(sqlUndoLog);
-                  case DELETE:
-                      return new MySQLUndoDeleteExecutor(sqlUndoLog);
-                  default:
-                      throw new ShouldNeverHappenException();
-              }
-          }
+      if (!dbType.equals(JdbcConstants.MYSQL) && !dbType.equals(JdbcConstants.POSTGRESQL)) {
+        throw new NotSupportYetException(dbType);
+      }
+      AbstractUndoExecutor result = null;
+      UndoExecutorGroup group = UndoExecutorGroupFactory.getUndoExecutorGroup(dbType.toLowerCase());
+      switch ((sqlUndoLog.getSqlType())) {
+        case INSERT:
+          result = group.getInsertExecutor(sqlUndoLog);
+          break;
+        case UPDATE:
+          result = group.getUpdateExecutor(sqlUndoLog);
+          break;
+        case DELETE:
+          result = group.getDeleteExecutor(sqlUndoLog);
+          break;
+        default:
+          throw new ShouldNeverHappenException();
+      }
+      return result;
     }
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoExecutorGroup.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoExecutorGroup.java
@@ -1,0 +1,12 @@
+package io.seata.rm.datasource.undo;
+
+public interface UndoExecutorGroup
+{
+  AbstractUndoExecutor getInsertExecutor(SQLUndoLog sqlUndoLog);
+
+  AbstractUndoExecutor getUpdateExecutor(SQLUndoLog sqlUndoLog);
+
+  AbstractUndoExecutor getDeleteExecutor(SQLUndoLog sqlUndoLog);
+
+  String getDbType();
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoExecutorGroupFactory.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoExecutorGroupFactory.java
@@ -1,0 +1,38 @@
+package io.seata.rm.datasource.undo;
+
+import io.seata.common.loader.EnhancedServiceLoader;
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+/**
+ * 功能描述:
+ *
+ * @author: Zhibei Hao丶
+ * @date: 2019/11/9 10:30
+ * @version: V1.0
+ */
+public class UndoExecutorGroupFactory
+{
+  private static Map<String, UndoExecutorGroup> executorGroupMap;
+
+  public static UndoExecutorGroup getUndoExecutorGroup(String dbType) {
+
+    if (executorGroupMap == null) {
+      synchronized (UndoExecutorGroupFactory.class) {
+        if (executorGroupMap == null) {
+          executorGroupMap = new HashMap<>();
+          List<UndoExecutorGroup> groupList =
+              EnhancedServiceLoader.loadAll(UndoExecutorGroup.class);
+          for (UndoExecutorGroup group : groupList) {
+            executorGroupMap.put(group.getDbType().toLowerCase(), group);
+          }
+        }
+      }
+    }
+    if (executorGroupMap.containsKey(dbType)) {
+      return executorGroupMap.get(dbType);
+    }
+    throw new RuntimeException(MessageFormat.format("now not support {0}", dbType));
+  }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/mysql/MySQLUndoExecutorGroup.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/mysql/MySQLUndoExecutorGroup.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo.mysql;
+
+import io.seata.rm.datasource.undo.AbstractUndoExecutor;
+import io.seata.rm.datasource.undo.KeywordChecker;
+import io.seata.rm.datasource.undo.SQLUndoLog;
+import io.seata.rm.datasource.undo.UndoExecutorGroup;
+import io.seata.rm.datasource.undo.mysql.keyword.MySQLKeywordChecker;
+
+/**
+ *
+ * @author: Zhibei Hao丶
+ * @date: 2019/8/15 10:57
+ * @version: V1.0
+ */
+public class MySQLUndoExecutorGroup implements UndoExecutorGroup {
+  private final String MYSQL = "mysql";
+
+  @Override
+  public AbstractUndoExecutor getInsertExecutor(SQLUndoLog sqlUndoLog) {
+    return new MySQLUndoInsertExecutor(sqlUndoLog);
+  }
+
+  @Override
+  public AbstractUndoExecutor getUpdateExecutor(SQLUndoLog sqlUndoLog) {
+    return new MySQLUndoUpdateExecutor(sqlUndoLog);
+  }
+
+  @Override
+  public AbstractUndoExecutor getDeleteExecutor(SQLUndoLog sqlUndoLog) {
+    return new MySQLUndoDeleteExecutor(sqlUndoLog);
+  }
+
+
+  @Override
+  public String getDbType() {
+    return MYSQL;
+  }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/oracle/OracleUndoExecutorGroup.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/oracle/OracleUndoExecutorGroup.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo.oracle;
+
+import io.seata.rm.datasource.undo.AbstractUndoExecutor;
+import io.seata.rm.datasource.undo.KeywordChecker;
+import io.seata.rm.datasource.undo.SQLUndoLog;
+import io.seata.rm.datasource.undo.UndoExecutorGroup;
+import io.seata.rm.datasource.undo.oracle.keyword.OracleKeywordChecker;
+
+/**
+ *
+ * @author: Zhibei Hao丶
+ * @date: 2019/8/23 10:03
+ * @version: V1.0
+ */
+public class OracleUndoExecutorGroup implements UndoExecutorGroup
+{
+  private final String ORACLE = "oracle";
+  @Override
+  public AbstractUndoExecutor getInsertExecutor(SQLUndoLog sqlUndoLog)
+  {
+    return new OracleUndoInsertExecutor(sqlUndoLog);
+  }
+
+  @Override
+  public AbstractUndoExecutor getUpdateExecutor(SQLUndoLog sqlUndoLog)
+  {
+    return new OracleUndoUpdateExecutor(sqlUndoLog);
+  }
+
+  @Override
+  public AbstractUndoExecutor getDeleteExecutor(SQLUndoLog sqlUndoLog)
+  {
+    return new OracleUndoDeleteExecutor(sqlUndoLog);
+  }
+
+
+  @Override
+  public String getDbType()
+  {
+    return ORACLE;
+  }
+}

--- a/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.sql.SQLRecognizerGroup
+++ b/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.sql.SQLRecognizerGroup
@@ -1,0 +1,2 @@
+io.seata.rm.datasource.sql.druid.MySqlRecognizerGroup
+io.seata.rm.datasource.sql.druid.oracle.OracleRecognizerGroup

--- a/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.UndoExecutorGroup
+++ b/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.UndoExecutorGroup
@@ -1,0 +1,2 @@
+io.seata.rm.datasource.undo.mysql.MySQLUndoExecutorGroup
+io.seata.rm.datasource.undo.oracle.OracleUndoExecutorGroup


### PR DESCRIPTION
<! -- make sure you have read and understood the contribution guide -- >

###I. describe what this PR has done
On the side of RM,

1. Add UndoExecutorGroupand and its corresponding factory. The UndoExecutorGroup interface abstracts executor that all kinds of databases need to provide (currently implemented by MySQL and Oracle)

2. Add SqlRecognizerGroup and its corresponding factory. SqlRecognizerGroup abstracts the recognizer (currently mqsql and Oracle) that all kinds of databases need to provide,

The benefits of this reconstruction are as follows:

1. Eliminate redundant code.

2. Enhance the scalability of the project (a new type of database can be added on RM side through resource configuration file)

3. When a new database type is to be added in the future, the capabilities it needs to provide will be roughly divided into three dimensions:

(1) extend AbstractUndoLogManager. (An existing abstraction provided in a previous PR,)

(2) implement UndoExecutorGroup.

(3) implement SQLRecognizerGroup.

To sum up, after refactoring, For the provider (the adaptation of each database type), will be defined and abstracted more clearly and cleanly; For the user (where to get the instance of executor or recognizer), it will be more convenient by calling factory methods directly.

###Does this request solve a problem?



<! -- if so, add "fixesාxxx" to the next line, for example, fixes񖓿97.

###III. why not add test cases (unit test / integration test)?

This PR is only for the adjustment of code structure, not involving the change of specific logic. 

###IV. describe how to verify

It only adjusts the internal abstraction level and calling mode, without any specific logical changes. After pulling the latest code, test the official Seata demo project, and conduct overall verification.


###V. special notes for review

Note that in this submission, the two factories I provided (undoexecutor groupfactory and sqlrecognizergroupfactory) are the instances created directly by using the EnhancedServiceLoader to load specific implementation classes from the resource file,

This is mainly to consider: Although there are only two kinds of database adaptations now: mqsql and Oracle, in the future, when other developer expand other types of databases, they can directly add resource file to provide their implemention without changing the existing code.