### PR TITLE
bugfix:fix auto proxying of datasource which has final modifier

### DIFF
--- a/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionScanner.java
+++ b/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionScanner.java
@@ -42,11 +42,9 @@ import org.springframework.aop.TargetSource;
 import org.springframework.aop.framework.AdvisedSupport;
 import org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator;
 import org.springframework.aop.support.AopUtils;
-import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.cglib.proxy.Enhancer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -310,22 +308,7 @@ public class GlobalTransactionScanner extends AbstractAutoProxyCreator
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("Auto proxy of [{}]", beanName);
             }
-            DataSourceProxy dataSourceProxy = DataSourceProxyHolder.get().putDataSource((DataSource) bean);
-            return Enhancer.create(bean.getClass(), (org.springframework.cglib.proxy.MethodInterceptor) (o, method, args, methodProxy) -> {
-                Method m = BeanUtils.findDeclaredMethod(DataSourceProxy.class, method.getName(), method.getParameterTypes());
-                if (null != m) {
-                    return m.invoke(dataSourceProxy, args);
-                } else {
-                    boolean oldAccessible = method.isAccessible();
-                    try {
-                        method.setAccessible(true);
-                        return method.invoke(bean, args);
-                    } finally {
-                        //recover the original accessible for security reason
-                        method.setAccessible(oldAccessible);
-                    }
-                }
-            });
+            return DataSourceProxyHolder.get().putDataSource((DataSource) bean);
         }
         return super.postProcessAfterInitialization(bean, beanName);
     }

--- a/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionScanner.java
+++ b/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionScanner.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Proxy;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.common.util.StringUtils;
 import io.seata.config.ConfigurationFactory;
 import io.seata.core.rpc.netty.RmRpcClient;
@@ -303,6 +304,15 @@ public class GlobalTransactionScanner extends AbstractAutoProxyCreator
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
         this.setBeanFactory(applicationContext);
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) {
+        if (bean instanceof DataSourceProxy && ConfigurationFactory.getInstance().getBoolean(DATASOURCE_AUTOPROXY, false)) {
+            throw new ShouldNeverHappenException("Auto proxy of DataSource can't be enabled as you've created a DataSourceProxy bean." +
+                "Please consider removing DataSourceProxy bean or disabling auto proxy of DataSource.");
+        }
+        return super.postProcessBeforeInitialization(bean, beanName);
     }
 
     @Override


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
When enable auto proxying of datasouce which has final modifier,it will cause a Exception means the class can't be proxied by using cglib.This PR will use JDK proxy instead of cglib to avoid this problem.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1995 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
I've done integration testing with following scenes:
1.Specific init-method for a datasource bean defination.
2.A datasource class that with final modifier.
3.A datasource that extends AbstractRoutingDataSource.

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews

