### PR TITLE
optimize: increase the oracle table meta cache code coverage

### DIFF
--- a/rm-datasource/src/test/java/io/seata/rm/datasource/mock/MockDatabaseMetaData.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/mock/MockDatabaseMetaData.java
@@ -64,9 +64,15 @@ public class MockDatabaseMetaData implements DatabaseMetaData {
         "CARDINALITY"
     );
 
+    private static List<String> pkMetaColumnLabels = Arrays.asList(
+        "PK_NAME"
+    );
+
     private Object[][] columnsMetasReturnValue;
 
     private Object[][] indexMetasReturnValue;
+
+    private Object[][] pkMetasReturnValue;
 
     /**
      * Instantiate a new MockDatabaseMetaData
@@ -75,6 +81,7 @@ public class MockDatabaseMetaData implements DatabaseMetaData {
         this.connection = connection;
         this.columnsMetasReturnValue = connection.getDriver().getMockColumnsMetasReturnValue();
         this.indexMetasReturnValue = connection.getDriver().getMockIndexMetasReturnValue();
+        this.pkMetasReturnValue = connection.getDriver().getMockPkMetasReturnValue();
     }
 
     @Override
@@ -732,7 +739,7 @@ public class MockDatabaseMetaData implements DatabaseMetaData {
 
     @Override
     public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
-        return null;
+        return new MockResultSet(this.connection.createStatement()).mockResultSet(pkMetaColumnLabels, pkMetasReturnValue);
     }
 
     @Override

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/mock/MockDriver.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/mock/MockDriver.java
@@ -55,22 +55,36 @@ public class MockDriver extends com.alibaba.druid.mock.MockDriver {
     private Object[][] mockIndexMetasReturnValue;
 
     /**
+     * the mock value of pk meta return value
+     */
+    private Object[][] mockPkMetasReturnValue;
+
+    /**
      * the mock execute handler
      */
     private MockExecuteHandler mockExecuteHandler;
 
     public MockDriver(Object[][] mockColumnsMetasReturnValue, Object[][] mockIndexMetasReturnValue) {
-        this(Lists.newArrayList(), new Object[][]{}, mockColumnsMetasReturnValue, mockIndexMetasReturnValue);
+        this(Lists.newArrayList(), new Object[][]{}, mockColumnsMetasReturnValue, mockIndexMetasReturnValue,  new Object[][]{});
+    }
+
+    public MockDriver(Object[][] mockColumnsMetasReturnValue, Object[][] mockIndexMetasReturnValue, Object[][] mockPkMetasReturnValue) {
+        this(Lists.newArrayList(), new Object[][]{}, mockColumnsMetasReturnValue, mockIndexMetasReturnValue, mockPkMetasReturnValue);
+    }
+
+    public MockDriver(List<String> mockReturnValueColumnLabels, Object[][] mockReturnValue, Object[][] mockColumnsMetasReturnValue, Object[][] mockIndexMetasReturnValue) {
+        this(mockReturnValueColumnLabels, mockReturnValue, mockColumnsMetasReturnValue, mockIndexMetasReturnValue, new Object[][]{});
     }
 
     /**
      * Instantiate a new MockDriver
      */
-    public MockDriver(List<String> mockReturnValueColumnLabels, Object[][] mockReturnValue, Object[][] mockColumnsMetasReturnValue, Object[][] mockIndexMetasReturnValue) {
+    public MockDriver(List<String> mockReturnValueColumnLabels, Object[][] mockReturnValue, Object[][] mockColumnsMetasReturnValue, Object[][] mockIndexMetasReturnValue, Object[][] mockPkMetasReturnValue) {
         this.mockReturnValueColumnLabels = mockReturnValueColumnLabels;
         this.mockReturnValue = mockReturnValue;
         this.mockColumnsMetasReturnValue = mockColumnsMetasReturnValue;
         this.mockIndexMetasReturnValue = mockIndexMetasReturnValue;
+        this.mockPkMetasReturnValue = mockPkMetasReturnValue;
         this.setMockExecuteHandler(new MockExecuteHandlerImpl(mockReturnValueColumnLabels, mockReturnValue, mockColumnsMetasReturnValue));
     }
 
@@ -142,6 +156,14 @@ public class MockDriver extends com.alibaba.druid.mock.MockDriver {
      */
     public Object[][] getMockIndexMetasReturnValue() {
         return mockIndexMetasReturnValue;
+    }
+
+    /**
+     * get the return value of pk meta
+     * @return
+     */
+    public Object[][] getMockPkMetasReturnValue() {
+        return mockPkMetasReturnValue;
     }
 
     /**

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCacheTest.java
@@ -13,13 +13,19 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.seata.rm.datasource.sql.struct;
+package io.seata.rm.datasource.sql.struct.cache;
 
 import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.util.JdbcConstants;
 import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.rm.datasource.DataSourceProxy;
 import io.seata.rm.datasource.mock.MockDriver;
+import io.seata.rm.datasource.sql.struct.ColumnMeta;
+import io.seata.rm.datasource.sql.struct.IndexMeta;
+import io.seata.rm.datasource.sql.struct.IndexType;
+import io.seata.rm.datasource.sql.struct.TableMeta;
+import io.seata.rm.datasource.sql.struct.TableMetaCache;
+import io.seata.rm.datasource.sql.struct.TableMetaCacheFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +38,7 @@ import java.util.Collections;
  *
  * @author hanwen created at 2019-02-01
  */
-public class TableMetaCacheTest {
+public class MysqlTableMetaCacheTest {
 
     private static Object[][] columnMetas =
         new Object[][] {

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/OracleTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/OracleTableMetaCacheTest.java
@@ -71,5 +71,13 @@ public class OracleTableMetaCacheTest {
         TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t1", proxy.getResourceId());
 
         Assertions.assertNotNull(tableMeta);
+
+        tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.t1", proxy.getResourceId());
+
+        Assertions.assertNotNull(tableMeta);
+
+        tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.\"t1\"", proxy.getResourceId());
+
+        Assertions.assertNotNull(tableMeta);
     }
 }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/OracleTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/OracleTableMetaCacheTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.sql.struct.cache;
+
+import java.sql.SQLException;
+import java.sql.Types;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.util.JdbcConstants;
+
+import io.seata.rm.datasource.DataSourceProxy;
+import io.seata.rm.datasource.mock.MockDriver;
+import io.seata.rm.datasource.sql.struct.TableMeta;
+import io.seata.rm.datasource.sql.struct.TableMetaCache;
+import io.seata.rm.datasource.sql.struct.TableMetaCacheFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+  * @author will.zjw
+  */
+public class OracleTableMetaCacheTest {
+
+    private static Object[][] columnMetas =
+        new Object[][] {
+            new Object[] {"", "", "t1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
+            new Object[] {"", "", "t1", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
+                "NO"},
+            new Object[] {"", "", "t1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
+                "NO"},
+            new Object[] {"", "", "t1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
+                "NO"}
+        };
+
+    private static Object[][] indexMetas =
+        new Object[][] {
+            new Object[] {"id", "id", false, "", 3, 0, "A", 34},
+            new Object[] {"name1", "name1", false, "", 3, 1, "A", 34},
+            new Object[] {"name2", "name2", true, "", 3, 2, "A", 34},
+        };
+
+    private static Object[][] pkMetas =
+        new Object[][] {
+            new Object[] {"id"}
+        };
+
+    @Test
+    public void getTableMetaTest() throws SQLException {
+        MockDriver mockDriver = new MockDriver(columnMetas, indexMetas, pkMetas);
+        DruidDataSource dataSource = new DruidDataSource();
+        dataSource.setUrl("jdbc:mock:xxx");
+        dataSource.setDriver(mockDriver);
+
+        DataSourceProxy proxy = new DataSourceProxy(dataSource);
+
+        TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.ORACLE);
+
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t1", proxy.getResourceId());
+
+        Assertions.assertNotNull(tableMeta);
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
1.change the name of TableMetaCacheTest to MysqlTableMetaCacheTest
2.increate the oracle table meta cache code coverage
3.support mock primary key meta.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

