### PR TITLE
optimize: saga statemachine designer add default properties for 'catch' node

### DIFF
--- a/saga/seata-saga-statemachine-designer/src/Flow/WorkSpace.js
+++ b/saga/seata-saga-statemachine-designer/src/Flow/WorkSpace.js
@@ -61,7 +61,7 @@ class WorkSpaceBase extends React.Component {
         }
         else if (param.item.source.model.stateType == 'Catch') {
           const catchLinePropsTemplate = {
-            "Exceptions": [""]
+            "Exceptions": ["java.lang.Throwable"]
           };
           executeCommand(() => {
             update(param.item, {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
Optimize: saga statemachine designer add default properties for 'catch' node.

Many user feedback added the catch node, but did not catch the exception, 
the reason is because they don't configure the type of exception to catch. So the designer fills in "java.lang.Throwable" by default


