### PR TITLE
optimize: override eureka getHostName() return ipAddress

### DIFF
--- a/discovery/seata-discovery-eureka/src/main/java/io/seata/discovery/registry/eureka/CustomEurekaInstanceConfig.java
+++ b/discovery/seata-discovery-eureka/src/main/java/io/seata/discovery/registry/eureka/CustomEurekaInstanceConfig.java
@@ -62,6 +62,11 @@ public class CustomEurekaInstanceConfig extends MyDataCenterInstanceConfig imple
         return applicationName;
     }
 
+    @Override
+    public String getHostName(boolean refresh) {
+        return this.getIpAddress();
+    }
+
     public void setInstanceId(String instanceId) {
         this.instanceId = instanceId;
     }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
在 通过eureka作为注册中心过程中发现注册到 eureka 中，健康检查和状态等地址中获取的均为服务器的hostname而非对应ip。通过 CustomEurekaInstanceConfig 中重写getHostName()方法修改为获取ip来解决该问题。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

