### PR TITLE
bugfix: fix global lock not released when rollback retry timeout

### DIFF
--- a/common/src/main/java/io/seata/common/util/ReflectionUtil.java
+++ b/common/src/main/java/io/seata/common/util/ReflectionUtil.java
@@ -18,6 +18,7 @@ package io.seata.common.util;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -198,4 +199,13 @@ public class ReflectionUtil {
         return interfaces;
     }
 
+    public static void modifyStaticFinalField(Class cla, String modifyFieldName, Object newValue)
+        throws NoSuchFieldException, IllegalAccessException {
+        Field field = cla.getDeclaredField(modifyFieldName);
+        field.setAccessible(true);
+        Field modifiers = field.getClass().getDeclaredField("modifiers");
+        modifiers.setAccessible(true);
+        modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(cla, newValue);
+    }
 }

--- a/common/src/test/java/io/seata/common/util/ReflectionUtilTest.java
+++ b/common/src/test/java/io/seata/common/util/ReflectionUtilTest.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.Test;
 
 public class ReflectionUtilTest {
 
+    //Prevent jvm from optimizing final
+    public static final String testValue = (null != null ? "hello" : "hello");
+
     @Test
     public void testGetClassByName() throws ClassNotFoundException {
         Assertions.assertEquals(String.class,
@@ -97,5 +100,12 @@ public class ReflectionUtilTest {
         Assertions.assertArrayEquals(new Object[]{
                         Serializable.class, Comparable.class, CharSequence.class},
                 ReflectionUtil.getInterfaces(String.class).toArray());
+    }
+
+    @Test
+    public void testModifyStaticFinalField() throws NoSuchFieldException, IllegalAccessException {
+        Assertions.assertEquals("hello", testValue);
+        ReflectionUtil.modifyStaticFinalField(ReflectionUtilTest.class, "testValue", "hello world");
+        Assertions.assertEquals("hello world", testValue);
     }
 }

--- a/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
+++ b/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
@@ -328,7 +328,6 @@ public class ConfigurationKeys {
      */
     public static final String ROLLBACK_RETRY_TIMEOUT_UNLOCK_ENABLE = SERVER_PREFIX + "rollback.retry.timeout.unlock.enable";
 
-
     /**
      * The constant TRANSPORT_TYPE
      */

--- a/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
+++ b/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
@@ -324,6 +324,12 @@ public class ConfigurationKeys {
     public static final String MAX_ROLLBACK_RETRY_TIMEOUT = SERVER_PREFIX + "max.rollback.retry.timeout";
 
     /**
+     * The constant ROLLBACK_RETRY_TIMEOUT_UNLOCK_ENABLE.
+     */
+    public static final String ROLLBACK_RETRY_TIMEOUT_UNLOCK_ENABLE = SERVER_PREFIX + "rollback.retry.timeout.unlock.enable";
+
+
+    /**
      * The constant TRANSPORT_TYPE
      */
     public static final String TRANSPORT_TYPE = TRANSPORT_PREFIX + "type";

--- a/script/config-center/config.txt
+++ b/script/config-center/config.txt
@@ -50,6 +50,7 @@ server.recovery.rollbacking-retry-period=1000
 server.recovery.timeout-retry-period=1000
 server.max.commit.retry.timeout=-1
 server.max.rollback.retry.timeout=-1
+server.rollback.retry.timeout.unlock.enable=false
 client.undo.data.validation=true
 client.undo.log.serialization=jackson
 server.undo.log.save.days=7

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
@@ -131,6 +131,9 @@ public class DefaultCoordinator extends AbstractTCInboundHandler
     private static final Duration MAX_ROLLBACK_RETRY_TIMEOUT = ConfigurationFactory.getInstance().getDuration(
         ConfigurationKeys.MAX_ROLLBACK_RETRY_TIMEOUT, DurationUtil.DEFAULT_DURATION, 100);
 
+    private static final boolean ROLLBACK_RETRY_TIMEOUT_UNLOCK_ENABLE = ConfigurationFactory.getInstance().getBoolean(
+        ConfigurationKeys.ROLLBACK_RETRY_TIMEOUT_UNLOCK_ENABLE, false);
+
     private ScheduledThreadPoolExecutor retryRollbacking = new ScheduledThreadPoolExecutor(1,
         new NamedThreadFactory("RetryRollbacking", 1));
 
@@ -389,6 +392,9 @@ public class DefaultCoordinator extends AbstractTCInboundHandler
                     continue;
                 }
                 if (isRetryTimeout(now, MAX_ROLLBACK_RETRY_TIMEOUT.toMillis(), rollbackingSession.getBeginTime())) {
+                    if (ROLLBACK_RETRY_TIMEOUT_UNLOCK_ENABLE) {
+                        rollbackingSession.clean();
+                    }
                     /**
                      * Prevent thread safety issues
                      */

--- a/server/src/main/resources/file.conf.example
+++ b/server/src/main/resources/file.conf.example
@@ -124,6 +124,7 @@ server {
   #unit ms,s,m,h,d represents milliseconds, seconds, minutes, hours, days, default permanent
   max.commit.retry.timeout = "-1"
   max.rollback.retry.timeout = "-1"
+  rollback.retry.timeout.unlock.enable = false
 }
 
 ## metrics settings


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #2166 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
DefaultCoordinatorTest.test_handleRetryRollbackingTimeOut
DefaultCoordinatorTest.test_handleRetryRollbackingTimeOut_unlock

### Ⅴ. Special notes for reviews

