### PR TITLE
bugfix: fix connection context can't be remove when global lock retry

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
@@ -207,6 +207,15 @@ public class ConnectionContext {
         return sqlUndoItemsBuffer;
     }
 
+    /**
+     * Gets lock keys buffer.
+     *
+     * @return the lock keys buffer
+     */
+    public Set<String> getLockKeysBuffer() {
+        return lockKeysBuffer;
+    }
+
     @Override
     public String toString() {
         return "ConnectionContext [xid=" + xid + ", branchId=" + branchId + ", lockKeysBuffer=" + lockKeysBuffer

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutor.java
@@ -15,18 +15,18 @@
  */
 package io.seata.rm.datasource.exec;
 
-import io.seata.rm.datasource.AbstractConnectionProxy;
-import io.seata.rm.datasource.ConnectionProxy;
-import io.seata.rm.datasource.StatementProxy;
-import io.seata.sqlparser.SQLRecognizer;
-import io.seata.rm.datasource.sql.struct.TableRecords;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.Callable;
+
+import io.seata.rm.datasource.AbstractConnectionProxy;
+import io.seata.rm.datasource.ConnectionContext;
+import io.seata.rm.datasource.ConnectionProxy;
+import io.seata.rm.datasource.StatementProxy;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import io.seata.sqlparser.SQLRecognizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The type Abstract dml base executor.
@@ -87,7 +87,7 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
         ConnectionProxy connectionProxy = statementProxy.getConnectionProxy();
         try {
             connectionProxy.setAutoCommit(false);
-            return new LockRetryPolicy(connectionProxy.getTargetConnection()).execute(() -> {
+            return new LockRetryPolicy(connectionProxy).execute(() -> {
                 T result = executeAutoCommitFalse(args);
                 connectionProxy.commit();
                 return result;
@@ -123,9 +123,9 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
     protected abstract TableRecords afterImage(TableRecords beforeImage) throws SQLException;
 
     private static class LockRetryPolicy extends ConnectionProxy.LockRetryPolicy {
-        private final Connection connection;
+        private final ConnectionProxy connection;
 
-        LockRetryPolicy(final Connection connection) {
+        LockRetryPolicy(final ConnectionProxy connection) {
             this.connection = connection;
         }
 
@@ -140,7 +140,11 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
 
         @Override
         protected void onException(Exception e) throws Exception {
-            connection.rollback();
+            ConnectionContext context = connection.getContext();
+            //UndoItems can't use the Set collection class to prevent ABA
+            context.getUndoItems().clear();
+            context.getLockKeysBuffer().clear();
+            connection.getTargetConnection().rollback();
         }
 
         public static boolean isLockRetryPolicyBranchRollbackOnConflict() {


### PR DESCRIPTION
Signed-off-by: slievrly <slievrly@163.com>

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

bugfix: fix connection context can't be remove when global lock conflict

### Ⅱ. Does this pull request fix one issue?
fix #2286 


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

