### PR TITLE
feature: mysql 5.x and 8.x jdbc drivers coexist in the server

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -74,7 +74,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-pool2.version>2.4.2</commons-pool2.version>
         <commons-pool.version>1.6</commons-pool.version>
-        <commons-dbcp.version>1.3</commons-dbcp.version>
+        <commons-dbcp2.version>2.7.0</commons-dbcp2.version>
         <cglib.version>3.1</cglib.version>
         <aopalliance.version>1.0</aopalliance.version>
         <zkclient.version>0.11</zkclient.version>
@@ -455,9 +455,9 @@
                 <version>${hessian.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-dbcp</groupId>
-                <artifactId>commons-dbcp</artifactId>
-                <version>${commons-dbcp.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-dbcp2</artifactId>
+                <version>${commons-dbcp2.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,8 +48,8 @@
             <artifactId>commons-pool</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/io/seata/core/store/db/AbstractDataSourceGenerator.java
+++ b/core/src/main/java/io/seata/core/store/db/AbstractDataSourceGenerator.java
@@ -22,12 +22,32 @@ import io.seata.config.ConfigurationFactory;
 import io.seata.core.constants.ConfigurationKeys;
 import io.seata.core.constants.DBType;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
 /**
  * The type Abstract data source generator.
  *
  * @author zhangsen
  */
 public abstract class AbstractDataSourceGenerator implements DataSourceGenerator {
+    private final static String MYSQL_DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
+
+    private final static String MYSQL8_DRIVER_CLASS_NAME = "com.mysql.cj.jdbc.Driver";
+
+    private final static String MYSQL_DRIVER_FILE_PREFIX = "mysql-connector-java-";
+
+    private final static Map<String, ClassLoader> MYSQL_DRIVER_LOADERS;
+
+    static {
+        MYSQL_DRIVER_LOADERS = createMysqlDriverClassLoaders();
+    }
 
     /**
      * The constant CONFIG.
@@ -59,6 +79,53 @@ public abstract class AbstractDataSourceGenerator implements DataSourceGenerator
                 String.format("the {%s} can't be empty", ConfigurationKeys.STORE_DB_DRIVER_CLASS_NAME));
         }
         return driverClassName;
+    }
+
+    protected ClassLoader getDriverClassLoader() {
+        return MYSQL_DRIVER_LOADERS.getOrDefault(getDriverClassName(), ClassLoader.getSystemClassLoader());
+    }
+
+    private static Map<String, ClassLoader> createMysqlDriverClassLoaders() {
+        Map<String, ClassLoader> loaders = new HashMap<>();
+        String cp = System.getProperty("java.class.path");
+        if (cp == null || cp.isEmpty()) {
+            return loaders;
+        }
+        Stream.of(cp.split(File.pathSeparator))
+                .map(File::new)
+                .filter(File::exists)
+                .map(file -> file.isFile() ? file.getParentFile() : file)
+                .filter(Objects::nonNull)
+                .filter(File::isDirectory)
+                .map(file -> new File(file, "jdbc"))
+                .filter(File::exists)
+                .filter(File::isDirectory)
+                .distinct()
+                .flatMap(file -> {
+                    File[] files = file.listFiles((f, name) -> name.startsWith(MYSQL_DRIVER_FILE_PREFIX));
+                    if (files != null) {
+                        return Stream.of(files);
+                    } else {
+                        return Stream.of();
+                    }
+                })
+                .forEach(file -> {
+                    if (loaders.containsKey(MYSQL8_DRIVER_CLASS_NAME) && loaders.containsKey(MYSQL_DRIVER_CLASS_NAME)) {
+                        return;
+                    }
+                    try {
+                        URL url = file.toURI().toURL();
+                        ClassLoader loader = new URLClassLoader(new URL[]{url}, ClassLoader.getSystemClassLoader());
+                        try {
+                            loader.loadClass(MYSQL8_DRIVER_CLASS_NAME);
+                            loaders.putIfAbsent(MYSQL8_DRIVER_CLASS_NAME, loader);
+                        } catch (ClassNotFoundException e) {
+                            loaders.putIfAbsent(MYSQL_DRIVER_CLASS_NAME, loader);
+                        }
+                    } catch (MalformedURLException ignore) {
+                    }
+                });
+        return loaders;
     }
 
     /**
@@ -118,36 +185,6 @@ public abstract class AbstractDataSourceGenerator implements DataSourceGenerator
     }
 
     /**
-     * Get driver name string.
-     *
-     * @param dbType the db type
-     * @return the string
-     */
-    protected static String getDriverName(DBType dbType) {
-        if (DBType.H2.equals(dbType)) {
-            return "org.h2.Driver";
-        } else if (DBType.MYSQL.equals(dbType)) {
-            return "com.mysql.jdbc.Driver";
-        } else if (DBType.ORACLE.equals(dbType)) {
-            return "oracle.jdbc.OracleDriver";
-        } else if (DBType.SYBAEE.equals(dbType)) {
-            return "com.sybase.jdbc2.jdbc.SybDriver";
-        } else if (DBType.SQLSERVER.equals(dbType)) {
-            return "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-        } else if (DBType.SQLITE.equals(dbType)) {
-            return "org.sqlite.JDBC";
-        } else if (DBType.POSTGRESQL.equals(dbType)) {
-            return "org.postgresql.Driver";
-        } else if (DBType.ACCESS.equals(dbType)) {
-            return "com.hxtt.sql.access.AccessDriver";
-        } else if (DBType.DB2.equals(dbType)) {
-            return "com.ibm.db2.jcc.DB2Driver";
-        } else {
-            throw new StoreException("Unsupported database type, dbType:" + dbType);
-        }
-    }
-
-    /**
      * Get validation query string.
      *
      * @param dbType the db type
@@ -160,5 +197,4 @@ public abstract class AbstractDataSourceGenerator implements DataSourceGenerator
             return "select 1";
         }
     }
-
 }

--- a/core/src/test/java/io/seata/core/store/db/DataBaseLockStoreDAOTest.java
+++ b/core/src/test/java/io/seata/core/store/db/DataBaseLockStoreDAOTest.java
@@ -17,7 +17,7 @@ package io.seata.core.store.db;
 
 import io.seata.common.util.IOUtil;
 import io.seata.core.store.LockDO;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 import org.h2.store.fs.FileUtils;
 import org.junit.jupiter.api.AfterAll;

--- a/core/src/test/java/io/seata/core/store/db/LogStoreDataBaseDAOTest.java
+++ b/core/src/test/java/io/seata/core/store/db/LogStoreDataBaseDAOTest.java
@@ -19,7 +19,7 @@ import io.seata.common.util.CollectionUtils;
 import io.seata.common.util.IOUtil;
 import io.seata.core.store.BranchTransactionDO;
 import io.seata.core.store.GlobalTransactionDO;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 import org.h2.store.fs.FileUtils;
 import org.junit.jupiter.api.AfterAll;

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -27,6 +27,11 @@
     <packaging>pom</packaging>
     <name>seata-distribution ${project.version}</name>
 
+    <properties>
+        <mysql.jdbc.version>5.1.30</mysql.jdbc.version>
+        <mysql8.jdbc.version>8.0.19</mysql8.jdbc.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.seata</groupId>
@@ -47,6 +52,38 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <executions>
+                            <execution>
+                                <id>copy-mysql</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>mysql</groupId>
+                                            <artifactId>mysql-connector-java</artifactId>
+                                            <version>${mysql.jdbc.version}</version>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>mysql</groupId>
+                                            <artifactId>mysql-connector-java</artifactId>
+                                            <version>${mysql8.jdbc.version}</version>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <outputDirectory>
+                                        ${basedir}/lib/jdbc
+                                    </outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <version>3.0.0</version>
                         <configuration>

--- a/distribution/release-seata.xml
+++ b/distribution/release-seata.xml
@@ -45,8 +45,11 @@
 
         <fileSet>
             <includes>
-                <include>lib/*</include>
+                <include>lib/**</include>
             </includes>
+            <excludes>
+                <exclude>lib/mysql-connector-java-*.jar</exclude>
+            </excludes>
         </fileSet>
     </fileSets>
     <files>

--- a/rm-datasource/pom.xml
+++ b/rm-datasource/pom.xml
@@ -64,8 +64,8 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BaseH2Test.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/BaseH2Test.java
@@ -22,7 +22,7 @@ import io.seata.rm.datasource.sql.struct.KeyType;
 import io.seata.rm.datasource.sql.struct.Row;
 import io.seata.rm.datasource.sql.struct.TableMeta;
 import io.seata.rm.datasource.sql.struct.TableRecords;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.h2.store.fs.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -67,8 +67,8 @@
             <artifactId>druid</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-dbcp</groupId>
-            <artifactId>commons-dbcp</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/server/src/main/java/io/seata/server/store/db/DbcpDataSourceGenerator.java
+++ b/server/src/main/java/io/seata/server/store/db/DbcpDataSourceGenerator.java
@@ -17,7 +17,7 @@ package io.seata.server.store.db;
 
 import io.seata.common.loader.LoadLevel;
 import io.seata.core.store.db.AbstractDataSourceGenerator;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 import javax.sql.DataSource;
 
@@ -25,22 +25,25 @@ import javax.sql.DataSource;
  * The type Dbcp data source generator.
  *
  * @author zhangsen
+ * @author ggndnn
  */
 @LoadLevel(name = "dbcp")
 public class DbcpDataSourceGenerator extends AbstractDataSourceGenerator {
-
     @Override
     public DataSource generateDataSource() {
         BasicDataSource ds = new BasicDataSource();
         ds.setDriverClassName(getDriverClassName());
+        // DriverClassLoader works if upgrade commons-dbcp to at least 1.3.1.
+        // https://issues.apache.org/jira/browse/DBCP-333
+        ds.setDriverClassLoader(getDriverClassLoader());
         ds.setUrl(getUrl());
         ds.setUsername(getUser());
         ds.setPassword(getPassword());
         ds.setInitialSize(getMinConn());
-        ds.setMaxActive(getMaxConn());
+        ds.setMaxTotal(getMaxConn());
         ds.setMinIdle(getMinConn());
         ds.setMaxIdle(getMinConn());
-        ds.setMaxWait(5000);
+        ds.setMaxWaitMillis(5000);
         ds.setTimeBetweenEvictionRunsMillis(120000);
         ds.setNumTestsPerEvictionRun(1);
         ds.setTestWhileIdle(true);
@@ -48,6 +51,4 @@ public class DbcpDataSourceGenerator extends AbstractDataSourceGenerator {
         ds.setConnectionProperties("useUnicode=yes;characterEncoding=utf8;socketTimeout=5000;connectTimeout=500");
         return ds;
     }
-
-
 }

--- a/server/src/main/java/io/seata/server/store/db/DruidDataSourceGenerator.java
+++ b/server/src/main/java/io/seata/server/store/db/DruidDataSourceGenerator.java
@@ -25,14 +25,15 @@ import javax.sql.DataSource;
  * The type Druid data source generator.
  *
  * @author zhangsen
+ * @author ggndnn
  */
 @LoadLevel(name = "druid")
 public class DruidDataSourceGenerator extends AbstractDataSourceGenerator {
-
     @Override
     public DataSource generateDataSource() {
         DruidDataSource ds = new DruidDataSource();
         ds.setDriverClassName(getDriverClassName());
+        ds.setDriverClassLoader(getDriverClassLoader());
         ds.setUrl(getUrl());
         ds.setUsername(getUser());
         ds.setPassword(getPassword());

--- a/server/src/test/java/io/seata/server/lock/db/DataBaseLockManagerImplTest.java
+++ b/server/src/test/java/io/seata/server/lock/db/DataBaseLockManagerImplTest.java
@@ -22,7 +22,7 @@ import io.seata.core.store.db.LockStoreDataBaseDAO;
 import io.seata.server.lock.DefaultLockManager;
 import io.seata.server.lock.LockManager;
 import io.seata.server.session.BranchSession;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;

--- a/server/src/test/java/io/seata/server/session/db/DataBaseSessionManagerTest.java
+++ b/server/src/test/java/io/seata/server/session/db/DataBaseSessionManagerTest.java
@@ -28,7 +28,7 @@ import io.seata.server.session.GlobalSession;
 import io.seata.server.session.SessionCondition;
 import io.seata.server.session.SessionManager;
 import io.seata.server.store.db.DatabaseTransactionStoreManager;
-import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;

--- a/server/src/test/java/io/seata/server/store/db/DataSourceGeneratorTest.java
+++ b/server/src/test/java/io/seata/server/store/db/DataSourceGeneratorTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.server.store.db;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import io.seata.common.loader.EnhancedServiceLoader;
+import io.seata.core.store.db.DataSourceGenerator;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+
+public class DataSourceGeneratorTest {
+    @Test
+    public void testDbcpGenerateDataSource() {
+        DataSourceGenerator dataSourceGenerator = EnhancedServiceLoader.load(DataSourceGenerator.class, "dbcp");
+        BasicDataSource dataSource = (BasicDataSource) dataSourceGenerator.generateDataSource();
+        ClassLoader driverClassLoader = dataSource.getDriverClassLoader();
+        Assertions.assertNotNull(driverClassLoader);
+    }
+
+    @Test
+    public void testDruidGenerateDataSource() {
+        DataSourceGenerator dataSourceGenerator = EnhancedServiceLoader.load(DataSourceGenerator.class, "druid");
+        DruidDataSource dataSource = (DruidDataSource) dataSourceGenerator.generateDataSource();
+        ClassLoader driverClassLoader = dataSource.getDriverClassLoader();
+        Assertions.assertNotNull(driverClassLoader);
+        try (Connection conn = dataSource.getConnection()) {
+            Assertions.assertNotNull(conn);
+        } catch (SQLException ignore) {
+        } finally {
+            Driver driver = dataSource.getDriver();
+            Assertions.assertNotNull(driver);
+            Assertions.assertEquals(driverClassLoader, driver.getClass().getClassLoader());
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

This PR provided a feature that mysql 5.x and 8.x jdbc drivers coexist in the server to fix issues like #2116.

1) Made use of DriverClassLoader to load mysql 5.x and 8.x driver separately.
2) Moved mysql driver jar from classpath to special location that the mysql drivers can coexist.
3) Upgraded dbcp to avoid loading error ([https://issues.apache.org/jira/browse/DBCP-333](https://issues.apache.org/jira/browse/DBCP-333)).
4) Determined different drivers according to driverClassName:
```
store.db.driverClassName=com.mysql.jdbc.Driver -> mysql 5.x
store.db.driverClassName=com.mysql.cj.jdbc.Driver -> mysql 8.x
``` 
5) Tested following combinations:

```
dbcp + mysql-connector-java-5.1.30
dbcp + mysql-connector-java-8.0.19
druid + mysql-connector-java-5.1.30
druid + mysql-connector-java-8.0.19
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

