### PR TITLE
CollectionUtils.decodeMap method variable ConcurrentHashMap refactor to HashMap

### DIFF
--- a/common/src/main/java/io/seata/common/util/CollectionUtils.java
+++ b/common/src/main/java/io/seata/common/util/CollectionUtils.java
@@ -17,9 +17,9 @@ package io.seata.common.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The type Collection utils.
@@ -82,8 +82,7 @@ public class CollectionUtils {
         if (isEmpty(col)) {
             return "";
         }
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
+        StringBuilder sb = new StringBuilder("]");
         for (Object obj : col) {
             sb.append(StringUtils.toString(obj));
             sb.append(",");
@@ -146,7 +145,7 @@ public class CollectionUtils {
         if (data == null) {
             return null;
         }
-        Map<String, String> map = new ConcurrentHashMap<>();
+        Map<String, String> map = new HashMap<>(8);
         if (StringUtils.isBlank(data)) {
             return map;
         }


### PR DESCRIPTION
CollectionUtils.decodeMap method variable  ConcurrentHashMap refactor to HashMap

### 1.  CollectionUtils.decodeMap method variable  ConcurrentHashMap refactor to HashMap

### 2. Local variables are stored in each thread's own stack. That means that local variables are never shared between threads. That also means that all local primitive variables are thread safe.

Local references to objects are a bit different. The reference itself is not shared. The object referenced however, is not stored in each threads's local stack. All objects are stored in the shared heap. If an object created locally never escapes the method it was created in, it is thread safe. In fact you can also pass it on to other methods and objects as long as none of these methods or objects make the passed object available to other threads.
https://stackoverflow.com/questions/11535237/local-variables-in-static-method-and-thread-safety

### 3. run CollectionUtilsTest


