### PR TITLE
bugfix:  fix the NPE and reduce the request when lockkey is null

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -15,8 +15,10 @@
  */
 package io.seata.rm.datasource;
 
+import io.seata.common.util.CollectionUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import io.seata.common.util.StringUtils;
@@ -198,8 +200,10 @@ public class ConnectionProxy extends AbstractConnectionProxy {
     }
 
     private void processLocalCommitWithGlobalLocks() throws SQLException {
-
-        checkLock(context.buildLockKeys());
+        Set<String> lockKeys = context.getLockKeysBuffer();
+        if (CollectionUtils.isNotEmpty(lockKeys)) {
+            checkLock(context.buildLockKeys());
+        }
         try {
             targetConnection.commit();
         } catch (Throwable ex) {

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -15,10 +15,8 @@
  */
 package io.seata.rm.datasource;
 
-import io.seata.common.util.CollectionUtils;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 import io.seata.common.util.StringUtils;
@@ -110,6 +108,9 @@ public class ConnectionProxy extends AbstractConnectionProxy {
      * @throws SQLException the sql exception
      */
     public void checkLock(String lockKeys) throws SQLException {
+        if (StringUtils.isBlank(lockKeys)) {
+            return;
+        }
         // Just check lock without requiring lock by now.
         try {
             boolean lockable = DefaultResourceManager.get().lockQuery(BranchType.AT,
@@ -200,10 +201,7 @@ public class ConnectionProxy extends AbstractConnectionProxy {
     }
 
     private void processLocalCommitWithGlobalLocks() throws SQLException {
-        Set<String> lockKeys = context.getLockKeysBuffer();
-        if (CollectionUtils.isNotEmpty(lockKeys)) {
-            checkLock(context.buildLockKeys());
-        }
+        checkLock(context.buildLockKeys());
         try {
             targetConnection.commit();
         } catch (Throwable ex) {

--- a/server/src/main/java/io/seata/server/lock/AbstractLockManager.java
+++ b/server/src/main/java/io/seata/server/lock/AbstractLockManager.java
@@ -75,6 +75,10 @@ public abstract class AbstractLockManager implements LockManager {
 
     @Override
     public boolean isLockable(String xid, String resourceId, String lockKey) throws TransactionException {
+        if (StringUtils.isBlank(lockKey)) {
+            // no lock
+            return true;
+        }
         List<RowLock> locks = collectRowLocks(lockKey, resourceId, xid);
         try {
             return getLocker().isLockable(locks);

--- a/server/src/main/java/io/seata/server/lock/AbstractLockManager.java
+++ b/server/src/main/java/io/seata/server/lock/AbstractLockManager.java
@@ -153,6 +153,9 @@ public abstract class AbstractLockManager implements LockManager {
                                             Long branchID) {
         List<RowLock> locks = new ArrayList<RowLock>();
 
+        if (StringUtils.isEmpty(lockKey)) {
+            return null;
+        }
         String[] tableGroupedLockKeys = lockKey.split(";");
         for (String tableGroupedLockKey : tableGroupedLockKeys) {
             int idx = tableGroupedLockKey.indexOf(":");

--- a/server/src/main/java/io/seata/server/lock/AbstractLockManager.java
+++ b/server/src/main/java/io/seata/server/lock/AbstractLockManager.java
@@ -157,9 +157,6 @@ public abstract class AbstractLockManager implements LockManager {
                                             Long branchID) {
         List<RowLock> locks = new ArrayList<RowLock>();
 
-        if (StringUtils.isBlank(lockKey)) {
-            return locks;
-        }
         String[] tableGroupedLockKeys = lockKey.split(";");
         for (String tableGroupedLockKey : tableGroupedLockKeys) {
             int idx = tableGroupedLockKey.indexOf(":");

--- a/server/src/main/java/io/seata/server/lock/AbstractLockManager.java
+++ b/server/src/main/java/io/seata/server/lock/AbstractLockManager.java
@@ -153,8 +153,8 @@ public abstract class AbstractLockManager implements LockManager {
                                             Long branchID) {
         List<RowLock> locks = new ArrayList<RowLock>();
 
-        if (StringUtils.isEmpty(lockKey)) {
-            return null;
+        if (StringUtils.isBlank(lockKey)) {
+            return locks;
         }
         String[] tableGroupedLockKeys = lockKey.split(";");
         for (String tableGroupedLockKey : tableGroupedLockKeys) {

--- a/server/src/main/java/io/seata/server/storage/db/lock/DataBaseLocker.java
+++ b/server/src/main/java/io/seata/server/storage/db/lock/DataBaseLocker.java
@@ -111,6 +111,10 @@ public class DataBaseLocker extends AbstractLocker {
 
     @Override
     public boolean isLockable(List<RowLock> locks) {
+        if (CollectionUtils.isEmpty(locks)) {
+            // no lock
+            return true;
+        }
         try {
             return lockStore.isLockable(convertToLockDO(locks));
         } catch (DataAccessException e) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
1.fix: Fix the NPE when lockkey is null;
2.optimize:  Reduce once db request when lockkey is null;

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
yes.
[issue](https://github.com/seata/seata/issues/2496)
### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

