### PR TITLE
bugfix: fix executeBatch can not get targetSql in Statement mode

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/AbstractStatementProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/AbstractStatementProxy.java
@@ -222,7 +222,7 @@ public abstract class AbstractStatementProxy<T extends Statement> implements Sta
     @Override
     public void clearBatch() throws SQLException {
         targetStatement.clearBatch();
-
+        targetSQL = null;
     }
 
     @Override

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/StatementProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/StatementProxy.java
@@ -19,6 +19,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import io.seata.common.util.StringUtils;
 import io.seata.rm.datasource.exec.ExecuteTemplate;
 
 /**
@@ -111,6 +112,16 @@ public class StatementProxy<T extends Statement> extends AbstractStatementProxy<
     public boolean execute(String sql, String[] columnNames) throws SQLException {
         this.targetSQL = sql;
         return ExecuteTemplate.execute(this, (statement, args) -> statement.execute((String) args[0],(String[])args[1]), sql,columnNames);
+    }
+
+    @Override
+    public void addBatch(String sql) throws SQLException {
+        if (StringUtils.isNotBlank(targetSQL)) {
+            targetSQL += "; " + sql;
+        } else {
+            targetSQL = sql;
+        }
+        targetStatement.addBatch(sql);
     }
 
     @Override

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/StatementProxyTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/StatementProxyTest.java
@@ -101,8 +101,41 @@ public class StatementProxyTest {
     }
 
     @Test
-    public void testGetTargetSQL() {
+    public void testGetTargetSQL() throws SQLException{
+        String qrySql = "select * from table_statment_proxy";
+        Assertions.assertNotNull(statementProxy.executeQuery(qrySql));
         Assertions.assertNotNull(statementProxy.getTargetSQL());
+        Assertions.assertDoesNotThrow(() -> statementProxy.clearBatch());
+        Assertions.assertNull(statementProxy.getTargetSQL());
+
+        String insertSql = "insert into t(id) values (?)";
+        Assertions.assertDoesNotThrow(() -> statementProxy.executeUpdate(insertSql, new int[]{1}));
+        Assertions.assertNotNull(statementProxy.getTargetSQL());
+        Assertions.assertDoesNotThrow(() -> statementProxy.clearBatch());
+        Assertions.assertNull(statementProxy.getTargetSQL());
+
+        String updateSql = "update t set t.x=? where t.id=?";
+        Assertions.assertDoesNotThrow(() -> statementProxy.executeUpdate(updateSql, new int[]{1}));
+        Assertions.assertNotNull(statementProxy.getTargetSQL());
+        Assertions.assertDoesNotThrow(() -> statementProxy.clearBatch());
+        Assertions.assertNull(statementProxy.getTargetSQL());
+
+        statementProxy.addBatch("insert into t(id) values (1)");
+        statementProxy.addBatch("insert into t(id) values (2)");
+        Assertions.assertNotNull(statementProxy.getTargetSQL());
+        Assertions.assertDoesNotThrow(() -> statementProxy.clearBatch());
+        Assertions.assertNull(statementProxy.getTargetSQL());
+
+        statementProxy.addBatch("update t set t.x = x+1 where t.id = 1");
+        statementProxy.addBatch("update t set t.x = x+1 where t.id = 2");
+        Assertions.assertNotNull(statementProxy.getTargetSQL());
+        Assertions.assertDoesNotThrow(() -> statementProxy.clearBatch());
+        Assertions.assertNull(statementProxy.getTargetSQL());
+
+        statementProxy.addBatch("delete from t where t.id = 1");
+        statementProxy.addBatch("delete from t where t.id = 2");
+        Assertions.assertNotNull(statementProxy.getTargetSQL());
+        Assertions.assertDoesNotThrow(() -> statementProxy.clearBatch());
     }
 
     @Test


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
fix bug #2537 
### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
in seata 1.1.0 addBatch could invoke only once。
if use jdbcTemplate.batchUpdate(String...sql), Only supports one SQL
