### PR TITLE
bugfix: fix could not create folder in zookeeper

### DIFF
--- a/discovery/seata-discovery-zk/src/main/java/io/seata/discovery/registry/zk/ZookeeperRegisterServiceImpl.java
+++ b/discovery/seata-discovery-zk/src/main/java/io/seata/discovery/registry/zk/ZookeeperRegisterServiceImpl.java
@@ -223,14 +223,14 @@ public class ZookeeperRegisterServiceImpl implements RegistryService<IZkChildLis
     // visible for test.
     ZkClient buildZkClient(String address, int sessionTimeout, int connectTimeout,String... authInfo) {
         ZkClient zkClient = new ZkClient(address, sessionTimeout, connectTimeout);
-        if (!zkClient.exists(ROOT_PATH_WITHOUT_SUFFIX)) {
-            zkClient.createPersistent(ROOT_PATH_WITHOUT_SUFFIX, true);
-        }
         if (null != authInfo && authInfo.length == 2) {
             if (!StringUtils.isBlank(authInfo[0]) && !StringUtils.isBlank(authInfo[1])) {
                 StringBuilder auth = new StringBuilder(authInfo[0]).append(":").append(authInfo[1]);
                 zkClient.addAuthInfo("digest", auth.toString().getBytes());
             }
+        }
+        if (!zkClient.exists(ROOT_PATH_WITHOUT_SUFFIX)) {
+            zkClient.createPersistent(ROOT_PATH_WITHOUT_SUFFIX, true);
         }
         zkClient.subscribeStateChanges(new IZkStateListener() {
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
seata-server使用zookeeper作为注册中心时，zookeeper要求设置密码才可以建立目录和写数据。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
原有实现是先建目录，再设置密码进行写数据；但是当zookeeper根目录都要求有密码访问时，原实现会出错。需要改为先设置密码，再创建目录和写数据。

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

