### PR TITLE
optimize: optimized the generation rules of thread name factory

### DIFF
--- a/common/src/main/java/io/seata/common/thread/NamedThreadFactory.java
+++ b/common/src/main/java/io/seata/common/thread/NamedThreadFactory.java
@@ -30,6 +30,7 @@ import io.netty.util.concurrent.FastThreadLocalThread;
  */
 public class NamedThreadFactory implements ThreadFactory {
     private final static Map<String, AtomicInteger> PREFIX_COUNTER = new ConcurrentHashMap<>();
+    private AtomicInteger counter = new AtomicInteger(0);
     private final String prefix;
     private final int totalSize;
     private final boolean makeDaemons;
@@ -71,7 +72,7 @@ public class NamedThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(Runnable r) {
-        String name = prefix;
+        String name = prefix + "_" + counter.incrementAndGet();
         if (totalSize > 1) {
             name += "_" + totalSize;
         }

--- a/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
+++ b/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
@@ -57,10 +57,12 @@ public class NamedThreadFactoryTest {
     public void testThreadNameHasCounterWithPrefixCounter() {
         NamedThreadFactory factory = new NamedThreadFactory("prefix", THREAD_TOTAL_SIZE,true);
         for (int i = 0; i < THREAD_TOTAL_SIZE; i ++) {
-            Thread t1 = factory.newThread(() -> {});
+            Thread thread = factory.newThread(() -> {});
+
 
             // the first _DEFAULT_THREAD_PREFIX_COUNTER is meaning thread counter
-            assertThat(t1.getName()).startsWith("prefix_" + DEFAULT_THREAD_PREFIX_COUNTER + "_" + (i + 1));
+            assertThat("prefix_" + DEFAULT_THREAD_PREFIX_COUNTER + "_" + (i + 1) + "_" + THREAD_TOTAL_SIZE)
+                    .isEqualTo(thread.getName());
         }
     }
 }

--- a/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
+++ b/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
@@ -62,7 +62,7 @@ public class NamedThreadFactoryTest {
 
             // the first _DEFAULT_THREAD_PREFIX_COUNTER is meaning thread counter
             assertThat("prefix_" + DEFAULT_THREAD_PREFIX_COUNTER + "_" + (i + 1) + "_" + THREAD_TOTAL_SIZE)
-                    .isEqualTo(thread.getName());
+                .isEqualTo(thread.getName());
         }
     }
 }

--- a/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
+++ b/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
@@ -55,7 +55,7 @@ public class NamedThreadFactoryTest {
 
     @Test
     public void testThreadNameHasCounterWithPrefixCounter() {
-        NamedThreadFactory factory = new NamedThreadFactory("prefix", THREAD_TOTAL_SIZE,true);
+        NamedThreadFactory factory = new NamedThreadFactory("prefix", THREAD_TOTAL_SIZE, true);
         for (int i = 0; i < THREAD_TOTAL_SIZE; i ++) {
             Thread thread = factory.newThread(() -> {});
 

--- a/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
+++ b/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
  * @author Otis.z
  */
 public class NamedThreadFactoryTest {
+    private static final int THREAD_TOTAL_SIZE = 3;
+    private static final int DEFAULT_THREAD_PREFIX_COUNTER = 1;
 
     @Test
     public void testNewThread() {
@@ -48,5 +50,17 @@ public class NamedThreadFactoryTest {
 
         assertThat(thread.getName()).startsWith("prefix");
         assertThat(thread.isDaemon()).isTrue();
+    }
+
+
+    @Test
+    public void testThreadNameHasCounterWithPrefixCounter() {
+        NamedThreadFactory factory = new NamedThreadFactory("prefix", THREAD_TOTAL_SIZE,true);
+        for (int i = 0; i < THREAD_TOTAL_SIZE; i ++) {
+            Thread t1 = factory.newThread(() -> {});
+
+            // the first _DEFAULT_THREAD_PREFIX_COUNTER is meaning thread counter
+            assertThat(t1.getName()).startsWith("prefix_" + DEFAULT_THREAD_PREFIX_COUNTER + "_" + (i + 1));
+        }
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
optimized the generation rules of thread name factory

### Ⅱ. Does this pull request fix one issue?
fixes #2741

### Ⅲ. Why don't you add test cases (unit test/integration test)?
has already add `NamedThreadFactoryTest#testThreadNameHasCounterWithPrefixCounter`

### Ⅳ. Describe how to verify it
test cases pass
can view the thread name using jstack or jconsole

### Ⅴ. Special notes for reviews
