### PR TITLE
optimize: spring find @GlobalTransactional and @GlobalLock in GlobalTransactionScanner and GlobalTransactionalInterceptor

### DIFF
--- a/spring/src/main/java/io/seata/spring/annotation/AbstractFallbackGlobalTransactionSource.java
+++ b/spring/src/main/java/io/seata/spring/annotation/AbstractFallbackGlobalTransactionSource.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.annotation;
+
+import io.seata.spring.util.SpringProxyUtils;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * @author chusen
+ * @email chusen12@163.com
+ */
+public abstract class AbstractFallbackGlobalTransactionSource implements GlobalTransactionalSource {
+
+
+    private final Object NO_TRANSACTION_ATTRIBUTE = new Object();
+
+    /**
+     * the cache
+     */
+    private final Map<Object, Object> attributeCache = new ConcurrentHashMap<>(1024);
+
+
+    @Override
+    public boolean existGlobalTransactionalAnnotation(Object bean) throws Exception {
+        Set<Class<?>> classes = new LinkedHashSet<>();
+        Class<?> serviceInterface = SpringProxyUtils.findTargetClass(bean);
+        Class<?>[] interfacesIfJdk = SpringProxyUtils.findInterfaces(bean);
+
+        classes.add(serviceInterface);
+        classes.addAll(Arrays.stream(interfacesIfJdk).collect(Collectors.toSet()));
+
+        Annotation annotation;
+        for (Class<?> clazz : classes) {
+            Method[] methods = ReflectionUtils.getAllDeclaredMethods(clazz);
+            for (Method method : methods) {
+                annotation = getGlobalTransactionalAnnotation(method, clazz);
+                if (annotation != null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    @Override
+    public Annotation getGlobalTransactionalAnnotation(Method method, Class<?> targetClass) {
+        // skip object' method
+        if (method.getDeclaringClass() == Object.class) {
+            return null;
+        }
+
+        Object cacheKey = getCacheKey(method, targetClass);
+        Object cached = this.attributeCache.get(cacheKey);
+
+        if (cached != null) {
+            return cached != NO_TRANSACTION_ATTRIBUTE ? (Annotation) cached : null;
+        } else {
+            Annotation transactionAnnotation = computeGlobalTransactionAnnotation(method, targetClass);
+            if (transactionAnnotation != null) {
+                this.attributeCache.put(cacheKey, transactionAnnotation);
+            } else {
+                this.attributeCache.put(cacheKey, NO_TRANSACTION_ATTRIBUTE);
+            }
+            return transactionAnnotation;
+        }
+    }
+
+
+    /**
+     * find the GlobalTransaction and GlobalLock annotation
+     * @param method
+     * @param targetClass
+     * @return
+     */
+    private Annotation computeGlobalTransactionAnnotation(Method method, Class<?> targetClass) {
+        if (allowPublicMethodsOnly() && !Modifier.isPublic(method.getModifiers())) {
+            return null;
+        }
+
+        Method specificMethod = AopUtils.getMostSpecificMethod(method, targetClass);
+
+        Annotation annotation = findTransactionAnnotation(specificMethod);
+        if (annotation != null) {
+            return annotation;
+        }
+
+
+        annotation = findTransactionAnnotation(specificMethod.getDeclaringClass());
+        if (annotation != null && ClassUtils.isUserLevelMethod(specificMethod)) {
+            return annotation;
+        }
+
+        if (specificMethod != method) {
+            annotation = findTransactionAnnotation(method);
+            if (annotation != null) {
+                return annotation;
+            }
+
+            annotation = findTransactionAnnotation(method.getDeclaringClass());
+            if (annotation != null && ClassUtils.isUserLevelMethod(method)) {
+                return annotation;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * find global transaction annotation on the method
+     *
+     * @param method
+     * @return
+     */
+    protected abstract Annotation findTransactionAnnotation(Method method);
+
+
+    /**
+     * find global transaction annotation on the target class
+     *
+     * @param targetClass
+     * @return
+     */
+    protected abstract Annotation findTransactionAnnotation(Class<?> targetClass);
+
+
+    private Object getCacheKey(Method method, Class<?> targetClass) {
+        return new MethodClassKey(method, targetClass);
+    }
+
+
+    private boolean allowPublicMethodsOnly() {
+        return true;
+    }
+}

--- a/spring/src/main/java/io/seata/spring/annotation/AnnotationGlobalTransactionSource.java
+++ b/spring/src/main/java/io/seata/spring/annotation/AnnotationGlobalTransactionSource.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.annotation;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+/**
+ * @author chusen
+ * @emal chusen12@163.com
+ */
+public class AnnotationGlobalTransactionSource extends AbstractFallbackGlobalTransactionSource implements Serializable {
+
+
+    private final SpringGlobalTransactionAnnotationParser transactionAnnotationParser;
+
+    public AnnotationGlobalTransactionSource() {
+        this.transactionAnnotationParser = new SpringGlobalTransactionAnnotationParser();
+    }
+
+
+    /**
+     * find global transactional annotation on the method
+     * @param method
+     * @return
+     */
+    @Override
+    protected Annotation findTransactionAnnotation(Method method) {
+        Collection<? extends Annotation> annotations = transactionAnnotationParser.parseGlobalTransactionAnnotation(method);
+        return annotations == null ? null : annotations.stream().findFirst().orElse(null);
+    }
+
+
+    /**
+     * find global transactional annotation on the targetClass
+     * @param targetClass
+     * @return
+     */
+    @Override
+    protected Annotation findTransactionAnnotation(Class<?> targetClass) {
+        Collection<? extends Annotation> annotations = transactionAnnotationParser.parseGlobalTransactionAnnotation(targetClass);
+        return annotations == null ? null : annotations.stream().findFirst().orElse(null);
+    }
+}

--- a/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionScanner.java
+++ b/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionScanner.java
@@ -255,6 +255,10 @@ public class GlobalTransactionScanner extends AbstractAutoProxyCreator
                 }
                 Method[] methods = clazz.getMethods();
                 for (Method method : methods) {
+                    if (method.getDeclaringClass().isAssignableFrom(Object.class)) {
+                        continue;
+                    }
+
                     trxAnno = method.getAnnotation(GlobalTransactional.class);
                     if (trxAnno != null) {
                         return true;

--- a/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionScanner.java
+++ b/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionScanner.java
@@ -43,6 +43,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
 
+import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -248,6 +249,10 @@ public class GlobalTransactionScanner extends AbstractAutoProxyCreator
         } catch (Exception exx) {
             throw new RuntimeException(exx);
         }
+    }
+
+    private MethodDesc makeMethodDesc(GlobalTransactional anno, Method method) {
+        return new MethodDesc(anno, method);
     }
 
     @Override

--- a/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionalSource.java
+++ b/spring/src/main/java/io/seata/spring/annotation/GlobalTransactionalSource.java
@@ -1,0 +1,32 @@
+package io.seata.spring.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+/**
+ * @author chusen
+ * @email chusen12@163.com
+ */
+public interface GlobalTransactionalSource {
+
+
+    /**
+     * decide exist the transaction annotation on the bean
+     *
+     * @param bean
+     * @return
+     * @throws Exception
+     */
+    boolean existGlobalTransactionalAnnotation(Object bean) throws Exception;
+
+
+    /**
+     * get global transaction by method and target class
+     *
+     * @param method
+     * @param targetClass
+     * @return
+     */
+    Annotation getGlobalTransactionalAnnotation(Method method, Class<?> targetClass);
+
+}

--- a/spring/src/main/java/io/seata/spring/annotation/MethodClassKey.java
+++ b/spring/src/main/java/io/seata/spring/annotation/MethodClassKey.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.annotation;
+
+import org.springframework.util.ObjectUtils;
+
+import java.lang.reflect.Method;
+
+/**
+ * A common key class for a method against a specific target class,
+ * including {@link #toString()} representation and {@link Comparable}
+ * support (as suggested for custom {@code HashMap} keys as of Java 8).
+ */
+public final class MethodClassKey implements Comparable<MethodClassKey> {
+
+    private final Method method;
+
+    private final Class<?> targetClass;
+
+
+    /**
+     * Create a key object for the given method and target class.
+     *
+     * @param method      the method to wrap (must not be {@code null})
+     * @param targetClass the target class that the method will be invoked
+     *                    on (may be {@code null} if identical to the declaring class)
+     */
+    public MethodClassKey(Method method,  Class<?> targetClass) {
+        this.method = method;
+        this.targetClass = targetClass;
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof MethodClassKey)) {
+            return false;
+        }
+        MethodClassKey otherKey = (MethodClassKey) other;
+        return (this.method.equals(otherKey.method) &&
+                ObjectUtils.nullSafeEquals(this.targetClass, otherKey.targetClass));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.method.hashCode() + (this.targetClass != null ? this.targetClass.hashCode() * 29 : 0);
+    }
+
+    @Override
+    public String toString() {
+        return this.method + (this.targetClass != null ? " on " + this.targetClass : "");
+    }
+
+    @Override
+    public int compareTo(MethodClassKey other) {
+        int result = this.method.getName().compareTo(other.method.getName());
+        if (result == 0) {
+            result = this.method.toString().compareTo(other.method.toString());
+            if (result == 0 && this.targetClass != null && other.targetClass != null) {
+                result = this.targetClass.getName().compareTo(other.targetClass.getName());
+            }
+        }
+        return result;
+    }
+
+}

--- a/spring/src/main/java/io/seata/spring/annotation/SpringGlobalTransactionAnnotationParser.java
+++ b/spring/src/main/java/io/seata/spring/annotation/SpringGlobalTransactionAnnotationParser.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.annotation;
+
+import org.springframework.core.annotation.AnnotatedElementUtils;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.*;
+
+/**
+ * scan GlobalTransactional and GlobalLock
+ *
+ * @author chusen
+ * @email chusen12@163.com
+ */
+public class SpringGlobalTransactionAnnotationParser implements Serializable {
+
+
+    private static final Set<Class<? extends Annotation>> GLOBAL_TRANSACTION_ANNOTATIONS = new LinkedHashSet<>(2);
+
+    static {
+        // When GlobalTransactional and GlobalLock are on methods at the same time, @GlobalTransactional shall prevail
+        GLOBAL_TRANSACTION_ANNOTATIONS.add(GlobalTransactional.class);
+        GLOBAL_TRANSACTION_ANNOTATIONS.add(GlobalLock.class);
+    }
+
+    public Collection<? extends Annotation> parseGlobalTransactionAnnotation(Class<?> type) {
+        return parseGlobalTransactionAnnotations(type);
+    }
+
+
+    public Collection<? extends Annotation> parseGlobalTransactionAnnotation(Method method) {
+        return parseGlobalTransactionAnnotations(method);
+    }
+
+
+    private Collection<? extends Annotation> parseGlobalTransactionAnnotations(AnnotatedElement ae) {
+        Collection<? extends Annotation> annotations = parseGlobalTransactionAnnotations(ae, false);
+        if (annotations != null && annotations.size() > 1) {
+            // More than one annotation found -> local declarations override interface-declared ones...
+            Collection<? extends Annotation> localAnnotation = parseGlobalTransactionAnnotations(ae, true);
+            if (localAnnotation != null) {
+                return localAnnotation;
+            }
+        }
+        return annotations;
+    }
+
+
+    private Collection<? extends Annotation> parseGlobalTransactionAnnotations(AnnotatedElement ae, boolean localOnly) {
+        Collection<Annotation> anns = new LinkedHashSet<>(2);
+        if (localOnly) {
+            GLOBAL_TRANSACTION_ANNOTATIONS.forEach(annotation -> anns.addAll(AnnotatedElementUtils.getAllMergedAnnotations(ae, annotation)));
+        } else {
+            GLOBAL_TRANSACTION_ANNOTATIONS.forEach(annotation -> anns.addAll(AnnotatedElementUtils.findAllMergedAnnotations(ae, annotation)));
+        }
+        return anns.isEmpty() ? null : anns;
+    }
+
+
+}

--- a/spring/src/test/java/io/seata/spring/annotation/MethodDescTest.java
+++ b/spring/src/test/java/io/seata/spring/annotation/MethodDescTest.java
@@ -17,6 +17,7 @@ package io.seata.spring.annotation;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
 import io.seata.common.exception.FrameworkException;
 import io.seata.core.context.RootContext;
 import io.seata.tm.api.transaction.TransactionInfo;
@@ -34,7 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MethodDescTest {
 
     private static final GlobalTransactionScanner GLOBAL_TRANSACTION_SCANNER = new GlobalTransactionScanner(
-        "global-trans-scanner-test");
+            "global-trans-scanner-test");
+
     private static Method method = null;
     private static Class<?> targetClass = null;
     private static GlobalTransactional transactional = null;
@@ -46,7 +48,8 @@ public class MethodDescTest {
 
     @Test
     public void testGetAnnotation() throws NoSuchMethodException {
-        GlobalTransactionalInterceptor globalTransactionalInterceptor = new GlobalTransactionalInterceptor(null);
+        GlobalTransactionalSource globalTransactionalSource = GLOBAL_TRANSACTION_SCANNER.getGlobalTransactionalSource();
+        GlobalTransactionalInterceptor globalTransactionalInterceptor = new GlobalTransactionalInterceptor(null, globalTransactionalSource);
         Method method = MockBusiness.class.getDeclaredMethod("doBiz", String.class);
         targetClass = Mockito.mock(MockBusiness.class).getClass();
         transactional = globalTransactionalInterceptor.getAnnotation(method, targetClass, GlobalTransactional.class);
@@ -71,12 +74,13 @@ public class MethodDescTest {
 
     @Test
     public void testGlobalTransactional() throws NoSuchMethodException {
+        GlobalTransactionalSource globalTransactionalSource = GLOBAL_TRANSACTION_SCANNER.getGlobalTransactionalSource();
         MockClassAnnotation mockClassAnnotation = new MockClassAnnotation();
         ProxyFactory proxyFactory = new ProxyFactory();
         proxyFactory.setTarget(mockClassAnnotation);
-        proxyFactory.addAdvice(new GlobalTransactionalInterceptor(null));
+        proxyFactory.addAdvice(new GlobalTransactionalInterceptor(null, globalTransactionalSource));
         Object proxy = proxyFactory.getProxy();
-        mockClassAnnotation = (MockClassAnnotation)proxy;
+        mockClassAnnotation = (MockClassAnnotation) proxy;
         mockClassAnnotation.toString();
         Assertions.assertNull(RootContext.getXID());
         mockClassAnnotation.hashCode();
@@ -92,7 +96,7 @@ public class MethodDescTest {
 
     @Test
     public void testGetTransactionAnnotation()
-        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         MethodDesc methodDesc = getMethodDesc();
         assertThat(methodDesc.getTransactionAnnotation()).isEqualTo(transactional);
 
@@ -106,7 +110,7 @@ public class MethodDescTest {
 
     @Test
     public void testSetTransactionAnnotation()
-        throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         MethodDesc methodDesc = getMethodDesc();
         assertThat(methodDesc.getTransactionAnnotation()).isNotNull();
         methodDesc.setTransactionAnnotation(null);
@@ -124,9 +128,9 @@ public class MethodDescTest {
     private MethodDesc getMethodDesc() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         //call the private method
         Method m = GlobalTransactionScanner.class.getDeclaredMethod("makeMethodDesc", GlobalTransactional.class,
-            Method.class);
+                Method.class);
         m.setAccessible(true);
-        return (MethodDesc)m.invoke(GLOBAL_TRANSACTION_SCANNER, transactional, method);
+        return (MethodDesc) m.invoke(GLOBAL_TRANSACTION_SCANNER, transactional, method);
 
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
1. optimize:  spring find @globaltransactional and @GlobalLock , so that whether it is based on JDK agent or cglib agent, can be annotated on methods or interfaces and be found.
2.I main reference the spring cache, transactional way to find annotations.



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix: When using the JDK proxy, although the annotation is found by SpringProxyUtils and enhanced, but the annotation cannot be found in the interceptor, so the interceptor didn't do anything.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
run GlobalTransactionScannerTest and MethodDescTest

### Ⅴ. Special notes for reviews
please review thanks.
