### PR TITLE
optimize: Only global transaction with the status of begin is read for the timeout check task.

### DIFF
--- a/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
@@ -217,7 +217,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
         if (CollectionUtils.isEmpty(allSessions)) {
             return;
         }
-        if (allSessions.size() > 0 && LOGGER.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Global transaction timeout check begin, size: {}", allSessions.size());
         }
         for (GlobalSession globalSession : allSessions) {
@@ -256,10 +256,9 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
             SessionHolder.getRetryRollbackingSessionManager().addGlobalSession(globalSession);
 
         }
-        if (allSessions.size() > 0 && LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Global transaction timeout check end. ");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Global transaction timeout check end.");
         }
-
     }
 
     /**

--- a/server/src/main/java/io/seata/server/session/SessionCondition.java
+++ b/server/src/main/java/io/seata/server/session/SessionCondition.java
@@ -25,7 +25,6 @@ import io.seata.core.model.GlobalStatus;
 public class SessionCondition {
     private Long transactionId;
     private String xid;
-    private GlobalStatus status;
     private GlobalStatus[] statuses;
     private long overTimeAliveMills;
 
@@ -50,7 +49,6 @@ public class SessionCondition {
      * @param status the status
      */
     public SessionCondition(GlobalStatus status) {
-        this.status = status;
         statuses = new GlobalStatus[] {status};
     }
 
@@ -70,24 +68,6 @@ public class SessionCondition {
      */
     public SessionCondition(long overTimeAliveMills) {
         this.overTimeAliveMills = overTimeAliveMills;
-    }
-
-    /**
-     * Gets status.
-     *
-     * @return the status
-     */
-    public GlobalStatus getStatus() {
-        return status;
-    }
-
-    /**
-     * Sets status.
-     *
-     * @param status the status
-     */
-    public void setStatus(GlobalStatus status) {
-        this.status = status;
     }
 
     /**

--- a/server/src/main/java/io/seata/server/storage/db/session/DataBaseSessionManager.java
+++ b/server/src/main/java/io/seata/server/storage/db/session/DataBaseSessionManager.java
@@ -171,17 +171,20 @@ public class DataBaseSessionManager extends AbstractSessionManager
         if (SessionHolder.ASYNC_COMMITTING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
             return findGlobalSessions(new SessionCondition(GlobalStatus.AsyncCommitting));
         } else if (SessionHolder.RETRY_COMMITTING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
-            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.CommitRetrying}));
+            return findGlobalSessions(new SessionCondition(GlobalStatus.CommitRetrying));
         } else if (SessionHolder.RETRY_ROLLBACKING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
-            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.RollbackRetrying,
-                GlobalStatus.Rollbacking, GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying}));
+            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {
+                GlobalStatus.RollbackRetrying, GlobalStatus.Rollbacking,
+                GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying}));
+        } else if (SessionHolder.TIMEOUT_CHECK_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
+            return findGlobalSessions(new SessionCondition(GlobalStatus.Begin));
         } else {
             // all data
             return findGlobalSessions(new SessionCondition(new GlobalStatus[] {
                 GlobalStatus.UnKnown, GlobalStatus.Begin,
-                GlobalStatus.Committing, GlobalStatus.CommitRetrying, GlobalStatus.Rollbacking,
-                GlobalStatus.RollbackRetrying,
-                GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying, GlobalStatus.AsyncCommitting}));
+                GlobalStatus.Committing, GlobalStatus.CommitRetrying, GlobalStatus.AsyncCommitting,
+                GlobalStatus.Rollbacking, GlobalStatus.RollbackRetrying,
+                GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying}));
         }
     }
 

--- a/server/src/main/java/io/seata/server/storage/redis/session/RedisSessionManager.java
+++ b/server/src/main/java/io/seata/server/storage/redis/session/RedisSessionManager.java
@@ -169,16 +169,20 @@ public class RedisSessionManager extends AbstractSessionManager
         if (SessionHolder.ASYNC_COMMITTING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
             return findGlobalSessions(new SessionCondition(GlobalStatus.AsyncCommitting));
         } else if (SessionHolder.RETRY_COMMITTING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
-            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.CommitRetrying}));
+            return findGlobalSessions(new SessionCondition(GlobalStatus.CommitRetrying));
         } else if (SessionHolder.RETRY_ROLLBACKING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
-            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.RollbackRetrying,
-                GlobalStatus.Rollbacking, GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying}));
+            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {
+                GlobalStatus.RollbackRetrying, GlobalStatus.Rollbacking,
+                GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying}));
+        } else if (SessionHolder.TIMEOUT_CHECK_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
+            return findGlobalSessions(new SessionCondition(GlobalStatus.Begin));
         } else {
             // all data
-            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.UnKnown, GlobalStatus.Begin,
-                GlobalStatus.Committing, GlobalStatus.CommitRetrying, GlobalStatus.Rollbacking,
-                GlobalStatus.RollbackRetrying, GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying,
-                GlobalStatus.AsyncCommitting}));
+            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {
+                GlobalStatus.UnKnown, GlobalStatus.Begin,
+                GlobalStatus.Committing, GlobalStatus.CommitRetrying, GlobalStatus.AsyncCommitting,
+                GlobalStatus.Rollbacking, GlobalStatus.RollbackRetrying,
+                GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying}));
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
优化全局事务超时处理功能。只读取状态为Begin的全局事务数据。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

