### PR TITLE
bugfix: In AT mode, when PostgreSQL and ShardingSphere are used, Cannot get charOctetLength of column

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/ColumnMeta.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/ColumnMeta.java
@@ -37,7 +37,7 @@ public class ColumnMeta {
     private String columnDef;
     private int sqlDataType;
     private int sqlDatetimeSub;
-    private int charOctetLength;
+    private Object charOctetLength;
     private int ordinalPosition;
     private String isNullAble;
     private String isAutoincrement;
@@ -337,7 +337,7 @@ public class ColumnMeta {
      *
      * @return the char octet length
      */
-    public int getCharOctetLength() {
+    public Object getCharOctetLength() {
         return charOctetLength;
     }
 
@@ -346,7 +346,7 @@ public class ColumnMeta {
      *
      * @param charOctetLength the char octet length
      */
-    public void setCharOctetLength(int charOctetLength) {
+    public void setCharOctetLength(Object charOctetLength) {
         this.charOctetLength = charOctetLength;
     }
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
@@ -128,7 +128,7 @@ public class PostgresqlTableMetaCache extends AbstractTableMetaCache {
                 col.setColumnDef(rsColumns.getString("COLUMN_DEF"));
                 col.setSqlDataType(rsColumns.getInt("SQL_DATA_TYPE"));
                 col.setSqlDatetimeSub(rsColumns.getInt("SQL_DATETIME_SUB"));
-                col.setCharOctetLength(rsColumns.getInt("CHAR_OCTET_LENGTH"));
+                col.setCharOctetLength(rsColumns.getObject("CHAR_OCTET_LENGTH"));
                 col.setOrdinalPosition(rsColumns.getInt("ORDINAL_POSITION"));
                 col.setIsNullAble(rsColumns.getString("IS_NULLABLE"));
                 col.setIsAutoincrement(rsColumns.getString("IS_AUTOINCREMENT"));


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
bugfix: In AT mode, when PostgreSQL and ShardingSphere are used, Cannot get charOctetLength of column

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #2807

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

