### PR TITLE
bugfix: fix business exception is lost when compensation succeed in saga mode

### DIFF
--- a/saga/seata-saga-engine-store/src/main/java/io/seata/saga/engine/store/db/DbAndReportTcStateLogStore.java
+++ b/saga/seata-saga-engine-store/src/main/java/io/seata/saga/engine/store/db/DbAndReportTcStateLogStore.java
@@ -155,6 +155,11 @@ public class DbAndReportTcStateLogStore extends AbstractStore implements StateLo
                 endParams.remove(DomainConstants.VAR_NAME_GLOBAL_TX);
             }
 
+            // if success, clear exception
+            if (ExecutionStatus.SU.equals(machineInstance.getStatus()) && machineInstance.getException() != null) {
+                machineInstance.setException(null);
+            }
+
             machineInstance.setSerializedEndParams(paramsSerializer.serialize(machineInstance.getEndParams()));
             machineInstance.setSerializedException(exceptionSerializer.serialize(machineInstance.getException()));
             int effect = executeUpdate(stateLogStoreSqls.getRecordStateMachineFinishedSql(dbType),

--- a/saga/seata-saga-engine/src/main/java/io/seata/saga/engine/pcext/handlers/CompensationTriggerStateHandler.java
+++ b/saga/seata-saga-engine/src/main/java/io/seata/saga/engine/pcext/handlers/CompensationTriggerStateHandler.java
@@ -60,7 +60,10 @@ public class CompensationTriggerStateHandler implements StateHandler {
         if (stateListToBeCompensated != null && stateListToBeCompensated.size() > 0) {
 
             //Clear exceptions that occur during forward execution
-            context.removeVariable(DomainConstants.VAR_NAME_CURRENT_EXCEPTION);
+            Exception e = (Exception)context.removeVariable(DomainConstants.VAR_NAME_CURRENT_EXCEPTION);
+            if (e != null) {
+                stateMachineInstance.setException(e);
+            }
 
             Stack<StateInstance> stateStackToBeCompensated = CompensationHolder.getCurrent(context, true)
                 .getStateStackNeedCompensation();

--- a/saga/seata-saga-processctrl/src/main/java/io/seata/saga/proctrl/HierarchicalProcessContext.java
+++ b/saga/seata-saga-processctrl/src/main/java/io/seata/saga/proctrl/HierarchicalProcessContext.java
@@ -66,8 +66,9 @@ public interface HierarchicalProcessContext extends ProcessContext {
      * Remove variable locally.
      *
      * @param name the name
+     * @return the removed variable or null
      */
-    void removeVariableLocally(String name);
+    Object removeVariableLocally(String name);
 
     /**
      * Clear locally.

--- a/saga/seata-saga-processctrl/src/main/java/io/seata/saga/proctrl/ProcessContext.java
+++ b/saga/seata-saga-processctrl/src/main/java/io/seata/saga/proctrl/ProcessContext.java
@@ -61,8 +61,9 @@ public interface ProcessContext {
      * Remove variable.
      *
      * @param name the name
+     * @return the removed variable or null
      */
-    void removeVariable(String name);
+    Object removeVariable(String name);
 
     /**
      * Has variable boolean.

--- a/saga/seata-saga-processctrl/src/main/java/io/seata/saga/proctrl/impl/ProcessContextImpl.java
+++ b/saga/seata-saga-processctrl/src/main/java/io/seata/saga/proctrl/impl/ProcessContextImpl.java
@@ -137,21 +137,21 @@ public class ProcessContextImpl implements HierarchicalProcessContext, ProcessCo
     }
 
     @Override
-    public void removeVariable(String name) {
+    public Object removeVariable(String name) {
         if (variables.containsKey(name)) {
-            variables.remove(name);
-            return;
+            return variables.remove(name);
         }
 
         if (parent != null) {
-            parent.removeVariable(name);
-            return;
+            return parent.removeVariable(name);
         }
+
+        return null;
     }
 
     @Override
-    public void removeVariableLocally(String name) {
-        variables.remove(name);
+    public Object removeVariableLocally(String name) {
+        return variables.remove(name);
     }
 
     @Override


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
bug修复：在SAGA事务，以同步方式执行时，正向服务出现异常后，可以通过stateMachineInstance.getException()方法获取到该异常。

此PR从 #2551 中拆分出来的。



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
以同步方式执行SAGA事务，并故意在业务方法中抛出异常，并使冲正补偿执行成功。然后在事务结束后，通过stateMachineInst.getException()，看看是否可以获取到业务方法中抛出的异常信息。


### Ⅴ. Special notes for reviews

