### PR TITLE
bugfix: fix get table meta failed when table name like 'schame'.'table'.

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/AbstractConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/AbstractConnectionProxy.java
@@ -114,9 +114,8 @@ public abstract class AbstractConnectionProxy implements Connection {
             if (sqlRecognizers != null && sqlRecognizers.size() == 1) {
                 SQLRecognizer sqlRecognizer = sqlRecognizers.get(0);
                 if (sqlRecognizer != null && sqlRecognizer.getSQLType() == SQLType.INSERT) {
-                    String tableName = ColumnUtils.delEscape(sqlRecognizer.getTableName(), dbType);
                     TableMeta tableMeta = TableMetaCacheFactory.getTableMetaCache(dbType).getTableMeta(getTargetConnection(),
-                            tableName, getDataSourceProxy().getResourceId());
+                            sqlRecognizer.getTableName(), getDataSourceProxy().getResourceId());
                     String[] pkNameArray = new String[tableMeta.getPrimaryKeyOnlyName().size()];
                     tableMeta.getPrimaryKeyOnlyName().toArray(pkNameArray);
                     targetPreparedStatement = getTargetConnection().prepareStatement(sql,pkNameArray);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
When get table meta, table meta cache already handle the different kind of table name. so we do not need to transfer it.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

