### PR TITLE
bugfix: ColumnUtils delEscape with scheme error.

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ColumnUtils.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ColumnUtils.java
@@ -30,6 +30,8 @@ import java.util.List;
  */
 public final class ColumnUtils {
 
+    private static final String DOT = ".";
+
     /**
      * The escape
      */
@@ -107,6 +109,11 @@ public final class ColumnUtils {
             return colName;
         }
         if (colName.charAt(0) == escape.value && colName.charAt(colName.length() - 1) == escape.value) {
+            final String withScheme = escape.value + DOT + escape.value;
+            int index = colName.indexOf(withScheme);
+            if (index > -1) {
+                return colName.substring(1, index) + DOT + colName.substring(index + withScheme.length(), colName.length() - 1);
+            }
             return colName.substring(1, colName.length() - 1);
         }
         return colName;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/DeleteExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/DeleteExecutor.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
+import io.seata.rm.datasource.ColumnUtils;
 import io.seata.rm.datasource.StatementProxy;
 import io.seata.rm.datasource.sql.struct.TableMeta;
 import io.seata.rm.datasource.sql.struct.TableRecords;
@@ -62,7 +63,6 @@ public class DeleteExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
     }
 
     private String buildBeforeImageSQL(SQLDeleteRecognizer visitor, TableMeta tableMeta, ArrayList<List<Object>> paramAppenderList) {
-        KeywordChecker keywordChecker = KeywordCheckerFactory.getKeywordChecker(getDbType());
         String whereCondition = buildWhereCondition(visitor, paramAppenderList);
         StringBuilder suffix = new StringBuilder(" FROM ").append(getFromTableInSQL());
         if (StringUtils.isNotBlank(whereCondition)) {
@@ -71,7 +71,7 @@ public class DeleteExecutor<T, S extends Statement> extends AbstractDMLBaseExecu
         suffix.append(" FOR UPDATE");
         StringJoiner selectSQLAppender = new StringJoiner(", ", "SELECT ", suffix.toString());
         for (String column : tableMeta.getAllColumns().keySet()) {
-            selectSQLAppender.add(getColumnNameInSQL(keywordChecker.checkAndReplace(column)));
+            selectSQLAppender.add(getColumnNameInSQL(ColumnUtils.addEscape(column, getDbType())));
         }
         return selectSQLAppender.toString();
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/DeleteExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/DeleteExecutor.java
@@ -25,8 +25,6 @@ import io.seata.rm.datasource.ColumnUtils;
 import io.seata.rm.datasource.StatementProxy;
 import io.seata.rm.datasource.sql.struct.TableMeta;
 import io.seata.rm.datasource.sql.struct.TableRecords;
-import io.seata.rm.datasource.undo.KeywordChecker;
-import io.seata.rm.datasource.undo.KeywordCheckerFactory;
 import io.seata.sqlparser.SQLDeleteRecognizer;
 import io.seata.sqlparser.SQLRecognizer;
 import org.apache.commons.lang.StringUtils;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/MultiDeleteExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/MultiDeleteExecutor.java
@@ -18,6 +18,7 @@ package io.seata.rm.datasource.exec;
 import io.seata.common.util.StringUtils;
 
 
+import io.seata.rm.datasource.ColumnUtils;
 import io.seata.rm.datasource.StatementProxy;
 import io.seata.rm.datasource.sql.struct.TableMeta;
 import io.seata.rm.datasource.sql.struct.TableRecords;
@@ -50,7 +51,6 @@ public class MultiDeleteExecutor<T, S extends Statement> extends AbstractDMLBase
             DeleteExecutor executor = new DeleteExecutor(statementProxy, statementCallback, sqlRecognizers.get(0));
             return executor.beforeImage();
         }
-        final KeywordChecker keywordChecker = KeywordCheckerFactory.getKeywordChecker(getDbType());
         final TableMeta tmeta = getTableMeta(sqlRecognizers.get(0).getTableName());
         final ArrayList<List<Object>> paramAppenderList = new ArrayList<>();
         StringBuilder whereCondition = new StringBuilder();
@@ -75,7 +75,7 @@ public class MultiDeleteExecutor<T, S extends Statement> extends AbstractDMLBase
         suffix.append(" FOR UPDATE");
         final StringJoiner selectSQLAppender = new StringJoiner(", ", "SELECT ", suffix.toString());
         for (String column : tmeta.getAllColumns().keySet()) {
-            selectSQLAppender.add(getColumnNameInSQL(keywordChecker.checkAndReplace(column)));
+            selectSQLAppender.add(getColumnNameInSQL(ColumnUtils.addEscape(column, getDbType())));
         }
         return buildTableRecords(tmeta, selectSQLAppender.toString(), paramAppenderList);
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/MultiDeleteExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/MultiDeleteExecutor.java
@@ -22,8 +22,6 @@ import io.seata.rm.datasource.ColumnUtils;
 import io.seata.rm.datasource.StatementProxy;
 import io.seata.rm.datasource.sql.struct.TableMeta;
 import io.seata.rm.datasource.sql.struct.TableRecords;
-import io.seata.rm.datasource.undo.KeywordChecker;
-import io.seata.rm.datasource.undo.KeywordCheckerFactory;
 import io.seata.sqlparser.SQLDeleteRecognizer;
 import io.seata.sqlparser.SQLRecognizer;
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCache.java
@@ -29,8 +29,6 @@ import io.seata.rm.datasource.sql.struct.ColumnMeta;
 import io.seata.rm.datasource.sql.struct.IndexMeta;
 import io.seata.rm.datasource.sql.struct.IndexType;
 import io.seata.rm.datasource.sql.struct.TableMeta;
-import io.seata.rm.datasource.undo.KeywordChecker;
-import io.seata.rm.datasource.undo.KeywordCheckerFactory;
 import io.seata.sqlparser.util.JdbcConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +42,6 @@ import org.slf4j.LoggerFactory;
 public class MysqlTableMetaCache extends AbstractTableMetaCache {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MysqlTableMetaCache.class);
-
-    private KeywordChecker keywordChecker = KeywordCheckerFactory.getKeywordChecker(JdbcConstants.MYSQL);
 
     @Override
     protected String getCacheKey(Connection connection, String tableName, String resourceId) {

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCache.java
@@ -24,6 +24,7 @@ import java.sql.Statement;
 
 import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.common.loader.LoadLevel;
+import io.seata.rm.datasource.ColumnUtils;
 import io.seata.rm.datasource.sql.struct.ColumnMeta;
 import io.seata.rm.datasource.sql.struct.IndexMeta;
 import io.seata.rm.datasource.sql.struct.IndexType;
@@ -79,7 +80,7 @@ public class MysqlTableMetaCache extends AbstractTableMetaCache {
 
     @Override
     protected TableMeta fetchSchema(Connection connection, String tableName) throws SQLException {
-        String sql = "SELECT * FROM " + keywordChecker.checkAndReplace(tableName) + " LIMIT 1";
+        String sql = "SELECT * FROM " + ColumnUtils.addEscape(tableName, JdbcConstants.MYSQL) + " LIMIT 1";
         try (Statement stmt = connection.createStatement();
             ResultSet rs = stmt.executeQuery(sql)) {
             return resultSetMetaToSchema(rs.getMetaData(), connection.getMetaData());

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.common.loader.LoadLevel;
 import io.seata.common.util.StringUtils;
+import io.seata.rm.datasource.ColumnUtils;
 import io.seata.rm.datasource.sql.struct.ColumnMeta;
 import io.seata.rm.datasource.sql.struct.IndexMeta;
 import io.seata.rm.datasource.sql.struct.IndexType;
@@ -37,8 +38,6 @@ import io.seata.sqlparser.util.JdbcConstants;
  */
 @LoadLevel(name = JdbcConstants.POSTGRESQL)
 public class PostgresqlTableMetaCache extends AbstractTableMetaCache {
-
-    private KeywordChecker keywordChecker = KeywordCheckerFactory.getKeywordChecker(JdbcConstants.POSTGRESQL);
 
     @Override
     protected String getCacheKey(Connection connection, String tableName, String resourceId) {
@@ -64,7 +63,7 @@ public class PostgresqlTableMetaCache extends AbstractTableMetaCache {
     protected TableMeta fetchSchema(Connection connection, String tableName) throws SQLException {
         try {
             DatabaseMetaData dbmd = connection.getMetaData();
-            tableName = keywordChecker.checkAndReplace(tableName);
+            tableName = ColumnUtils.addEscape(tableName, JdbcConstants.POSTGRESQL);
             return resultSetMetaToSchema(dbmd, tableName);
         } catch (SQLException sqlEx) {
             throw sqlEx;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
@@ -27,8 +27,6 @@ import io.seata.rm.datasource.sql.struct.ColumnMeta;
 import io.seata.rm.datasource.sql.struct.IndexMeta;
 import io.seata.rm.datasource.sql.struct.IndexType;
 import io.seata.rm.datasource.sql.struct.TableMeta;
-import io.seata.rm.datasource.undo.KeywordChecker;
-import io.seata.rm.datasource.undo.KeywordCheckerFactory;
 import io.seata.sqlparser.util.JdbcConstants;
 
 /**

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/KeywordChecker.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/KeywordChecker.java
@@ -37,11 +37,4 @@ public interface KeywordChecker {
      */
     boolean checkEscape(String fieldOrTableName);
 
-    /**
-     * check whether given field name and table name use keywords and,if so,will add "`" to the name.
-     *
-     * @param fieldOrTableName the field or table name
-     * @return string
-     */
-    String checkAndReplace(String fieldOrTableName);
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/mysql/keyword/MySQLKeywordChecker.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/mysql/keyword/MySQLKeywordChecker.java
@@ -1117,9 +1117,4 @@ public class MySQLKeywordChecker implements KeywordChecker {
         return check(fieldOrTableName);
     }
 
-    @Override
-    public String checkAndReplace(String fieldOrTableName) {
-        return check(fieldOrTableName) ? "`" + fieldOrTableName + "`" : fieldOrTableName;
-    }
-
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/oracle/keyword/OracleKeywordChecker.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/oracle/keyword/OracleKeywordChecker.java
@@ -511,12 +511,6 @@ public class OracleKeywordChecker implements KeywordChecker {
         return true;
     }
 
-    @Override
-    public String checkAndReplace(String fieldOrTableName) {
-        return check(fieldOrTableName) ? fieldOrTableName : fieldOrTableName;
-        //        return check(fieldOrTableName)?"`" + fieldOrTableName + "`":fieldOrTableName;
-    }
-
     private static boolean isUppercase(String fieldOrTableName) {
         if (fieldOrTableName == null) {
             return false;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/postgresql/keyword/PostgresqlKeywordChecker.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/postgresql/keyword/PostgresqlKeywordChecker.java
@@ -380,18 +380,6 @@ public class PostgresqlKeywordChecker implements KeywordChecker {
         return true;
     }
 
-    @Override
-    public String checkAndReplace(String fieldOrTableName) {
-        return check(fieldOrTableName) ? replace(fieldOrTableName) : fieldOrTableName;
-    }
-
-    private String replace(String fieldOrTableName) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("\"").append(fieldOrTableName).append("\"");
-        String name = builder.toString();
-        return name;
-    }
-
     private static boolean containsUppercase(String colName) {
         if (colName == null) {
             return false;

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/ColumnUtilsTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/ColumnUtilsTest.java
@@ -36,10 +36,20 @@ public class ColumnUtilsTest {
         Assertions.assertEquals("id", cols.get(0));
         Assertions.assertEquals("name", cols.get(1));
 
+        List<String> cols4 = new ArrayList<>();
+        cols4.add("`scheme`.`id`");
+        cols4 = ColumnUtils.delEscape(cols4, ColumnUtils.Escape.MYSQL);
+        Assertions.assertEquals("scheme.id", cols4.get(0));
+
         List<String> cols2 = new ArrayList<>();
         cols2.add("\"id\"");
         cols2 = ColumnUtils.delEscape(cols2, ColumnUtils.Escape.STANDARD);
         Assertions.assertEquals("id", cols2.get(0));
+
+        List<String> cols3 = new ArrayList<>();
+        cols3.add("\"scheme\".\"id\"");
+        cols3 = ColumnUtils.delEscape(cols3, ColumnUtils.Escape.STANDARD);
+        Assertions.assertEquals("scheme.id", cols3.get(0));
 
         Assertions.assertNull(ColumnUtils.delEscape((String) null, ColumnUtils.Escape.MYSQL));
     }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCacheTest.java
@@ -42,12 +42,12 @@ public class MysqlTableMetaCacheTest {
 
     private static Object[][] columnMetas =
         new Object[][] {
-            new Object[] {"", "", "t1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
-            new Object[] {"", "", "t1", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
+            new Object[] {"", "", "mt1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
+            new Object[] {"", "", "mt1", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
                 "NO"},
-            new Object[] {"", "", "t1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
+            new Object[] {"", "", "mt1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
                 "NO"},
-            new Object[] {"", "", "t1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
+            new Object[] {"", "", "mt1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
                 "NO"}
         };
 
@@ -84,9 +84,9 @@ public class MysqlTableMetaCacheTest {
 
         DataSourceProxy proxy = new DataSourceProxy(dataSource);
 
-        TableMeta tableMeta = getTableMetaCache().getTableMeta(proxy.getPlainConnection(), "t1", proxy.getResourceId());
+        TableMeta tableMeta = getTableMetaCache().getTableMeta(proxy.getPlainConnection(), "mt1", proxy.getResourceId());
 
-        Assertions.assertEquals("t1", tableMeta.getTableName());
+        Assertions.assertEquals("mt1", tableMeta.getTableName());
         Assertions.assertEquals("id", tableMeta.getPrimaryKeyOnlyName().get(0));
 
         Assertions.assertEquals("id", tableMeta.getColumnMeta("id").getColumnName());
@@ -113,12 +113,12 @@ public class MysqlTableMetaCacheTest {
             };
         mockDriver.setMockIndexMetasReturnValue(indexMetas);
         Assertions.assertThrows(ShouldNeverHappenException.class, () -> {
-            getTableMetaCache().getTableMeta(proxy.getPlainConnection(), "t2", proxy.getResourceId());
+            getTableMetaCache().getTableMeta(proxy.getPlainConnection(), "mt2", proxy.getResourceId());
         });
 
         mockDriver.setMockColumnsMetasReturnValue(null);
         Assertions.assertThrows(ShouldNeverHappenException.class, () -> {
-            getTableMetaCache().getTableMeta(proxy.getPlainConnection(), "t2", proxy.getResourceId());
+            getTableMetaCache().getTableMeta(proxy.getPlainConnection(), "mt2", proxy.getResourceId());
         });
 
     }
@@ -138,12 +138,12 @@ public class MysqlTableMetaCacheTest {
         //change the columns meta
         columnMetas =
             new Object[][] {
-                new Object[] {"", "", "t1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
-                new Object[] {"", "", "t1", "name1", Types.VARCHAR, "VARCHAR", 65, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
+                new Object[] {"", "", "mt1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
+                new Object[] {"", "", "mt1", "name1", Types.VARCHAR, "VARCHAR", 65, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
                     "NO"},
-                new Object[] {"", "", "t1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
+                new Object[] {"", "", "mt1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
                     "NO"},
-                new Object[] {"", "", "t1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
+                new Object[] {"", "", "mt1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
                     "NO"}
             };
         mockDriver.setMockColumnsMetasReturnValue(columnMetas);

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/OracleTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/OracleTableMetaCacheTest.java
@@ -36,12 +36,12 @@ public class OracleTableMetaCacheTest {
 
     private static Object[][] columnMetas =
         new Object[][] {
-            new Object[] {"", "", "t1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
-            new Object[] {"", "", "t1", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
+            new Object[] {"", "", "ot1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
+            new Object[] {"", "", "ot1", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
                 "NO"},
-            new Object[] {"", "", "t1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
+            new Object[] {"", "", "ot1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
                 "NO"},
-            new Object[] {"", "", "t1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
+            new Object[] {"", "", "ot1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
                 "NO"}
         };
 
@@ -68,11 +68,11 @@ public class OracleTableMetaCacheTest {
 
         TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.ORACLE);
 
-        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.t1", proxy.getResourceId());
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.ot1", proxy.getResourceId());
 
         Assertions.assertNotNull(tableMeta);
 
-        tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.\"t1\"", proxy.getResourceId());
+        tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.\"ot1\"", proxy.getResourceId());
 
         Assertions.assertNotNull(tableMeta);
     }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCacheTest.java
@@ -36,12 +36,12 @@ public class PostgresqlTableMetaCacheTest {
 
     private static Object[][] columnMetas =
         new Object[][] {
-            new Object[] {"", "", "t1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
-            new Object[] {"", "", "t1", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
+            new Object[] {"", "", "pt1", "id", Types.INTEGER, "INTEGER", 64, 0, 10, 1, "", "", 0, 0, 64, 1, "NO", "YES"},
+            new Object[] {"", "", "pt1", "name1", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 2, "YES",
                 "NO"},
-            new Object[] {"", "", "t1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
+            new Object[] {"", "", "pt1", "name2", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 3, "YES",
                 "NO"},
-            new Object[] {"", "", "t1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
+            new Object[] {"", "", "pt1", "name3", Types.VARCHAR, "VARCHAR", 64, 0, 10, 0, "", "", 0, 0, 64, 4, "YES",
                 "NO"}
         };
 
@@ -68,15 +68,15 @@ public class PostgresqlTableMetaCacheTest {
 
         TableMetaCache tableMetaCache = TableMetaCacheFactory.getTableMetaCache(JdbcConstants.POSTGRESQL);
 
-        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t1", proxy.getResourceId());
+        TableMeta tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "pt1", proxy.getResourceId());
 
         Assertions.assertNotNull(tableMeta);
 
-        tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.t1", proxy.getResourceId());
+        tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.pt1", proxy.getResourceId());
 
         Assertions.assertNotNull(tableMeta);
 
-        tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.\"t1\"", proxy.getResourceId());
+        tableMeta = tableMetaCache.getTableMeta(proxy.getPlainConnection(), "t.\"pt1\"", proxy.getResourceId());
 
         Assertions.assertNotNull(tableMeta);
     }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/mysql/keyword/MySQLKeywordCheckerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/mysql/keyword/MySQLKeywordCheckerTest.java
@@ -52,16 +52,6 @@ public class MySQLKeywordCheckerTest {
     }
 
     /**
-     * Test check and replace
-     */
-    @Test
-    public void testCheckAndReplace() {
-        KeywordChecker keywordChecker = KeywordCheckerFactory.getKeywordChecker(JdbcConstants.MYSQL);
-        Assertions.assertEquals("`desc`", keywordChecker.checkAndReplace("desc"));
-
-    }
-
-    /**
      * Test keyword check with UPDATE case
      */
     @Test

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/oracle/keyword/OracleKeywordCheckerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/oracle/keyword/OracleKeywordCheckerTest.java
@@ -33,11 +33,4 @@ public class OracleKeywordCheckerTest {
         Assertions.assertNotNull(keywordChecker);
     }
 
-    @Test
-    public void testCheckAndReplate() {
-        KeywordChecker keywordChecker = KeywordCheckerFactory.getKeywordChecker(JdbcConstants.ORACLE);
-        Assertions.assertNull(keywordChecker.checkAndReplace(null));
-        Assertions.assertEquals("undo_log", keywordChecker.checkAndReplace("undo_log"));
-        Assertions.assertEquals("TABLE", keywordChecker.checkAndReplace("TABLE"));
-    }
 }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/undo/postgresql/keyword/PostgresqlKeywordCheckerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/undo/postgresql/keyword/PostgresqlKeywordCheckerTest.java
@@ -33,11 +33,4 @@ public class PostgresqlKeywordCheckerTest {
         Assertions.assertNotNull(keywordChecker);
     }
 
-    @Test
-    public void testCheckAndReplate() {
-        KeywordChecker keywordChecker = KeywordCheckerFactory.getKeywordChecker(JdbcConstants.POSTGRESQL);
-        Assertions.assertEquals(null, keywordChecker.checkAndReplace(null));
-        Assertions.assertEquals("undo_log", keywordChecker.checkAndReplace("undo_log"));
-        Assertions.assertEquals("\"TABLE\"", keywordChecker.checkAndReplace("TABLE"));
-    }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
fix ColumnUtils#delEscape like \`scheme\`.\`table\` error, optimize KeywordChecker checkAndReplace method.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

