### PR TITLE
bugfix: fix the bug that the node data will be covered when switching nodes in the edit state in the detail form on the right (seata#2882)

### DIFF
--- a/saga/seata-saga-statemachine-designer/ggeditor/components/DetailPanel/Panel.js
+++ b/saga/seata-saga-statemachine-designer/ggeditor/components/DetailPanel/Panel.js
@@ -26,7 +26,9 @@ class Panel extends React.Component {
 
     return (
       <div {...pick(this.props, ['style', 'className'])}>
-        {children}
+        {
+          React.Children.toArray(children).map(child => React.cloneElement(child))
+        }
       </div>
     );
   }

--- a/saga/seata-saga-statemachine-designer/src/components/EditorDetailPanel/DetailForm.js
+++ b/saga/seata-saga-statemachine-designer/src/components/EditorDetailPanel/DetailForm.js
@@ -16,13 +16,11 @@ const inlineFormItemLayout = {
   },
 };
 
-let lastSelectedItem;
-
 class DetailForm extends React.Component {
   get item() {
     const { propsAPI } = this.props;
 
-    return propsAPI.getSelected()[0] ? propsAPI.getSelected()[0] : lastSelectedItem;
+    return propsAPI.getSelected()[0];
   }
 
   handleSubmit = (e) => {
@@ -48,8 +46,6 @@ class DetailForm extends React.Component {
         if (values.stateProps) {
           values.stateProps = JSON.parse(values.stateProps);
         }
-
-        lastSelectedItem = item;
 
         executeCommand(() => {
           update(item, {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

fix the bug that the node data will be covered when switching nodes in the edit state in the detail form on the right.
修复右侧详情表单在编辑状态下切换节点会导致节点数据被覆盖的BUG。

### Ⅱ. Does this pull request fix one issue?

<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #2882

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

no test files were found in the front-end project.
未在前端项目中发现测试文件。

### Ⅳ. Describe how to verify it

Switch nodes when you edit the details form on the right, check whether the detail form data is updated.
在右侧详情表单的编辑状态下切换节点，看右侧详情表单数据是否更新成新节点的数据。

On the basis of the previous step, edit the new node's details form but does not modify any data, check whether the details form data is covered after exit edit.
在上一步的基础上，编辑新节点的右侧详情表单但不修改任何数据，退出编辑状态，查看新节点数据是否被节点数据所覆盖。

**before fix（修改前）**：

![修改前](https://user-images.githubusercontent.com/49681036/87401776-2fe9e480-c5ed-11ea-9502-477f91c1c349.gif)

**after fix（修改后）**：

![修改后](https://user-images.githubusercontent.com/49681036/87401790-35dfc580-c5ed-11ea-907d-c645a04ed56a.gif)

### Ⅴ. Special notes for reviews

nothing
