### PR TITLE
bugfix: fix rm client receive response logic.

### DIFF
--- a/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
+++ b/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
@@ -152,7 +152,7 @@ public abstract class AbstractRMHandler extends AbstractExceptionHandler
 
     @Override
     public void onResponse(AbstractResultMessage response, RpcContext context) {
-        LOGGER.info("the rm client received response msg from tc server, bug without any processing logic.");
+        LOGGER.info("the rm client received response msg [{}] from tc server.", response.toString());
     }
 
     public abstract BranchType getBranchType();

--- a/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
+++ b/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
@@ -153,7 +153,6 @@ public abstract class AbstractRMHandler extends AbstractExceptionHandler
 
     @Override
     public void onResponse(AbstractResultMessage response, RpcContext context) {
-        throw new ShouldNeverHappenException();
     }
 
     public abstract BranchType getBranchType();

--- a/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
+++ b/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
@@ -152,6 +152,7 @@ public abstract class AbstractRMHandler extends AbstractExceptionHandler
 
     @Override
     public void onResponse(AbstractResultMessage response, RpcContext context) {
+        LOGGER.warn("client received response msg [{}] from tc server, bug without any processing logic.", response.getMsg());
     }
 
     public abstract BranchType getBranchType();

--- a/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
+++ b/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
@@ -15,7 +15,6 @@
  */
 package io.seata.rm;
 
-import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.core.exception.AbstractExceptionHandler;
 import io.seata.core.exception.TransactionException;
 import io.seata.core.model.BranchStatus;

--- a/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
+++ b/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
@@ -152,7 +152,7 @@ public abstract class AbstractRMHandler extends AbstractExceptionHandler
 
     @Override
     public void onResponse(AbstractResultMessage response, RpcContext context) {
-        LOGGER.warn("client received response msg [{}] from tc server, bug without any processing logic.", response.getMsg());
+        LOGGER.info("client received response msg [{}] from tc server, bug without any processing logic.", response.getMsg());
     }
 
     public abstract BranchType getBranchType();

--- a/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
+++ b/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
@@ -152,7 +152,7 @@ public abstract class AbstractRMHandler extends AbstractExceptionHandler
 
     @Override
     public void onResponse(AbstractResultMessage response, RpcContext context) {
-        LOGGER.info("client received response msg [{}] from tc server, bug without any processing logic.", response.getMsg());
+        LOGGER.info("the rm client received response msg [{}] from tc server, bug without any processing logic.", response.getMsg());
     }
 
     public abstract BranchType getBranchType();

--- a/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
+++ b/rm/src/main/java/io/seata/rm/AbstractRMHandler.java
@@ -152,7 +152,7 @@ public abstract class AbstractRMHandler extends AbstractExceptionHandler
 
     @Override
     public void onResponse(AbstractResultMessage response, RpcContext context) {
-        LOGGER.info("the rm client received response msg [{}] from tc server, bug without any processing logic.", response.getMsg());
+        LOGGER.info("the rm client received response msg from tc server, bug without any processing logic.");
     }
 
     public abstract BranchType getBranchType();


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
The previous logic client side did not have onResponse logic. The TransactionMessageHandler interface has an implementation class AbstractRMHandler. The onRequest method is specifically used to handle rm’s commit, rollback, and deleteUndoLog. After putting these logics in the processor, commit, rollback, and deleteUndoLog are all independent. The respective processor, the logic of onResponse is placed in ClientOnResponseProcessor, so the relevant logic of the client response is placed here, unified and centralized processing

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

