### PR TITLE
Add the default configuration when store.mode is 'db'

### DIFF
--- a/core/src/main/java/io/seata/core/constants/DefaultValues.java
+++ b/core/src/main/java/io/seata/core/constants/DefaultValues.java
@@ -73,6 +73,13 @@ public class DefaultValues {
      */
     public static final String DEFAULT_LOCK_DB_TABLE = "lock_table";
 
+    public static final String DEFAULT_STORE_DB_DATA_SOURCE = "dbcp";
+    public static final String DEFAULT_STORE_DB_TYPE = "mysql";
+    public static final String DEFAULT_STORE_DB_DRIVER_CLASS_NAME = "com.mysql.jdbc.Driver";
+    public static final String DEFAULT_STORE_DB_URL = "jdbc:mysql://127.0.0.1:3306/seata";
+    public static final String DEFAULT_STORE_DB_USER = "mysql";
+    public static final String DEFAULT_STORE_DB_PASSWORD = "mysql";
+
     public static final int DEFAULT_TM_COMMIT_RETRY_COUNT = 5;
     public static final int DEFAULT_TM_ROLLBACK_RETRY_COUNT = 5;
 

--- a/core/src/main/java/io/seata/core/store/db/AbstractDataSourceProvider.java
+++ b/core/src/main/java/io/seata/core/store/db/AbstractDataSourceProvider.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import static io.seata.core.constants.DefaultValues.*;
+
 /**
  * The abstract datasource provider
  * 
@@ -88,7 +90,7 @@ public abstract class AbstractDataSourceProvider implements DataSourceProvider, 
      * @return the db type
      */
     protected DBType getDBType() {
-        return DBType.valueof(CONFIG.getConfig(ConfigurationKeys.STORE_DB_TYPE));
+        return DBType.valueof(CONFIG.getConfig(ConfigurationKeys.STORE_DB_TYPE, DEFAULT_STORE_DB_TYPE));
     }
 
     /**
@@ -97,7 +99,8 @@ public abstract class AbstractDataSourceProvider implements DataSourceProvider, 
      * @return the db driver class name
      */
     protected String getDriverClassName() {
-        String driverClassName = CONFIG.getConfig(ConfigurationKeys.STORE_DB_DRIVER_CLASS_NAME);
+        String driverClassName = CONFIG.getConfig(ConfigurationKeys.STORE_DB_DRIVER_CLASS_NAME,
+                DEFAULT_STORE_DB_DRIVER_CLASS_NAME);
         if (StringUtils.isBlank(driverClassName)) {
             throw new StoreException(
                 String.format("the {%s} can't be empty", ConfigurationKeys.STORE_DB_DRIVER_CLASS_NAME));
@@ -168,7 +171,7 @@ public abstract class AbstractDataSourceProvider implements DataSourceProvider, 
      * @return the string
      */
     protected String getUrl() {
-        String url = CONFIG.getConfig(ConfigurationKeys.STORE_DB_URL);
+        String url = CONFIG.getConfig(ConfigurationKeys.STORE_DB_URL, DEFAULT_STORE_DB_URL);
         if (StringUtils.isBlank(url)) {
             throw new StoreException(String.format("the {%s} can't be empty", ConfigurationKeys.STORE_DB_URL));
         }
@@ -181,7 +184,7 @@ public abstract class AbstractDataSourceProvider implements DataSourceProvider, 
      * @return the string
      */
     protected String getUser() {
-        String user = CONFIG.getConfig(ConfigurationKeys.STORE_DB_USER);
+        String user = CONFIG.getConfig(ConfigurationKeys.STORE_DB_USER, DEFAULT_STORE_DB_USER);
         if (StringUtils.isBlank(user)) {
             throw new StoreException(String.format("the {%s} can't be empty", ConfigurationKeys.STORE_DB_USER));
         }
@@ -194,7 +197,7 @@ public abstract class AbstractDataSourceProvider implements DataSourceProvider, 
      * @return the string
      */
     protected String getPassword() {
-        String password = CONFIG.getConfig(ConfigurationKeys.STORE_DB_PASSWORD);
+        String password = CONFIG.getConfig(ConfigurationKeys.STORE_DB_PASSWORD, DEFAULT_STORE_DB_PASSWORD);
         return password;
     }
 

--- a/server/src/main/java/io/seata/server/storage/db/lock/DataBaseLockManager.java
+++ b/server/src/main/java/io/seata/server/storage/db/lock/DataBaseLockManager.java
@@ -32,6 +32,8 @@ import io.seata.server.lock.AbstractLockManager;
 import io.seata.server.session.BranchSession;
 import io.seata.server.session.GlobalSession;
 
+import static io.seata.core.constants.DefaultValues.DEFAULT_STORE_DB_DATA_SOURCE;
+
 /**
  * The type db lock manager.
  *
@@ -48,7 +50,8 @@ public class DataBaseLockManager extends AbstractLockManager implements Initiali
     @Override
     public void init() {
         // init dataSource
-        String datasourceType = ConfigurationFactory.getInstance().getConfig(ConfigurationKeys.STORE_DB_DATASOURCE_TYPE);
+        String datasourceType = ConfigurationFactory.getInstance().getConfig(
+                ConfigurationKeys.STORE_DB_DATASOURCE_TYPE, DEFAULT_STORE_DB_DATA_SOURCE);
         DataSource lockStoreDataSource = EnhancedServiceLoader.load(DataSourceProvider.class, datasourceType).provide();
         locker = new DataBaseLocker(lockStoreDataSource);
     }

--- a/server/src/main/java/io/seata/server/storage/db/store/DataBaseTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/db/store/DataBaseTransactionStoreManager.java
@@ -43,6 +43,8 @@ import io.seata.server.store.AbstractTransactionStoreManager;
 import io.seata.server.store.SessionStorable;
 import io.seata.server.store.TransactionStoreManager;
 
+import static io.seata.core.constants.DefaultValues.DEFAULT_STORE_DB_DATA_SOURCE;
+
 /**
  * The type Database transaction store manager.
  *
@@ -92,7 +94,7 @@ public class DataBaseTransactionStoreManager extends AbstractTransactionStoreMan
      */
     private DataBaseTransactionStoreManager() {
         logQueryLimit = CONFIG.getInt(ConfigurationKeys.STORE_DB_LOG_QUERY_LIMIT, DEFAULT_LOG_QUERY_LIMIT);
-        String datasourceType = CONFIG.getConfig(ConfigurationKeys.STORE_DB_DATASOURCE_TYPE);
+        String datasourceType = CONFIG.getConfig(ConfigurationKeys.STORE_DB_DATASOURCE_TYPE, DEFAULT_STORE_DB_DATA_SOURCE);
         //init dataSource
         DataSource logStoreDataSource = EnhancedServiceLoader.load(DataSourceProvider.class, datasourceType).provide();
         logStore = new LogStoreDataBaseDAO(logStoreDataSource);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Add the default configuration when store.mode is 'db'.
The default configurations are added according to the description in the official document.

![image](https://user-images.githubusercontent.com/1582168/87847391-6a63c200-c90a-11ea-8c5c-f2fb8ff88487.png)


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #2903

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

