### PR TITLE
feature:  redis to support reentry locks

### DIFF
--- a/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
+++ b/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
@@ -91,8 +91,7 @@ public class RedisLocker extends AbstractLocker {
                 } else {
                     LockDO existed = JSON.parseObject(existedKey, LockDO.class);
                     if (!StringUtils.equals(existed.getXid(), locks.get(i).getXid())) {
-                        pipeline.setnx(key, JSON.toJSONString(locks.get(i)));
-                        readyKeys.add(key);
+                        return false;
                     }
                 }
             }

--- a/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
+++ b/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
@@ -79,6 +79,7 @@ public class RedisLocker extends AbstractLocker {
             List<String> readyKeys = new ArrayList<>();
             for (LockDO lock : locks) {
                 String key = getLockKey(lock.getRowKey());
+                // check the lock if it is existed
                 LockDO existed = JSON.parseObject(jedis.get(key), LockDO.class);
                 if (existed != null && StringUtils.equals(existed.getXid(), lock.getXid())) {
                     continue;

--- a/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
+++ b/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
@@ -82,10 +82,10 @@ public class RedisLocker extends AbstractLocker {
             List<String> lockList = jedis.mget(existedKeyList.toArray(new String[0]));
             Pipeline pipeline = jedis.pipelined();
             List<String> readyKeys = new ArrayList<>();
-            for (int i = 0; i < locks.size(); i++) {
-                String key = getLockKey(locks.get(i).getRowKey());
+            for (int i = 0; i < existedKeyList.size(); i++) {
                 String existedKey = lockList.get(i);
                 if (existedKey == null) {
+                    String key = existedKeyList.get(i);
                     pipeline.setnx(key, JSON.toJSONString(locks.get(i)));
                     readyKeys.add(key);
                 } else {

--- a/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
+++ b/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
@@ -76,6 +76,7 @@ public class RedisLocker extends AbstractLocker {
                     locks.stream().filter(LambdaUtils.distinctByKey(LockDO::getRowKey)).collect(Collectors.toList());
             }
             List<String> existedKeyList = new ArrayList<>();
+
             locks.forEach(lockDO -> {
                 existedKeyList.add(getLockKey(lockDO.getRowKey()));
             });


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
redis模块支持可重入锁；即对同一条数据，在同一事务下，可以获取到锁，并对数据进行修改

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
自己发现的
### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
在同一个接口中，先插入一条数据，然后再对同一条数据进行更新操作，可以正常更新；
未修复之前，对同一数据进行更新会报获取锁失败异常
### Ⅴ. Special notes for reviews
redis不支持可重入锁
