### PR TITLE
optimize: ensure that the register message is sent after RM client initialization

### DIFF
--- a/core/src/main/java/io/seata/core/rpc/netty/RmNettyRemotingClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmNettyRemotingClient.java
@@ -74,9 +74,9 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
             super.init();
 
             // Found one or more resources that were registered before initialization
-            if (resourceManager!=null
+            if (resourceManager != null
                     && !resourceManager.getManagedResources().isEmpty()
-                    && StringUtils.isNotBlank(transactionServiceGroup) ){
+                    && StringUtils.isNotBlank(transactionServiceGroup)) {
                 getClientChannelManager().reconnect(transactionServiceGroup);
             }
         }
@@ -187,7 +187,7 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
     public void registerResource(String resourceGroupId, String resourceId) {
 
         // Resource registration cannot be performed until the RM client is initialized
-        if (StringUtils.isBlank(transactionServiceGroup)){
+        if (StringUtils.isBlank(transactionServiceGroup)) {
             return;
         }
 

--- a/core/src/main/java/io/seata/core/rpc/netty/RmNettyRemotingClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmNettyRemotingClient.java
@@ -75,8 +75,8 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
 
             // Found one or more resources that were registered before initialization
             if (resourceManager!=null
-                    && resourceManager.getManagedResources().size() >0
-                    && StringUtils.isNotEmpty(transactionServiceGroup) ){
+                    && !resourceManager.getManagedResources().isEmpty()
+                    && StringUtils.isNotBlank(transactionServiceGroup) ){
                 getClientChannelManager().reconnect(transactionServiceGroup);
             }
         }

--- a/core/src/main/java/io/seata/core/rpc/netty/RmNettyRemotingClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/RmNettyRemotingClient.java
@@ -21,6 +21,7 @@ import io.netty.util.concurrent.EventExecutorGroup;
 import io.seata.common.exception.FrameworkErrorCode;
 import io.seata.common.exception.FrameworkException;
 import io.seata.common.thread.NamedThreadFactory;
+import io.seata.common.util.StringUtils;
 import io.seata.core.model.Resource;
 import io.seata.core.model.ResourceManager;
 import io.seata.core.protocol.AbstractMessage;
@@ -71,6 +72,13 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
         registerProcessor();
         if (initialized.compareAndSet(false, true)) {
             super.init();
+
+            // Found one or more resources that were registered before initialization
+            if (resourceManager!=null
+                    && resourceManager.getManagedResources().size() >0
+                    && StringUtils.isNotEmpty(transactionServiceGroup) ){
+                getClientChannelManager().reconnect(transactionServiceGroup);
+            }
         }
     }
 
@@ -177,6 +185,12 @@ public final class RmNettyRemotingClient extends AbstractNettyRemotingClient {
      * @param resourceId      the db key
      */
     public void registerResource(String resourceGroupId, String resourceId) {
+
+        // Resource registration cannot be performed until the RM client is initialized
+        if (StringUtils.isBlank(transactionServiceGroup)){
+            return;
+        }
+
         if (getClientChannelManager().getChannels().isEmpty()) {
             getClientChannelManager().reconnect(transactionServiceGroup);
             return;


### PR DESCRIPTION

### Ⅰ. Describe what this PR did

【情况说明】
当资源注册（ResourceManager.registerResource）先于RM初始化（RMClient.init）时会打印错误日志，不过由于RMClient初始化后会有定时连接检测，所以对业务的影响只是在连接检测被触发之前资源不会被注册到TC，连接检测启动延迟目前为1分钟。（AbstractNettyRemotingClient.SCHEDULE_DELAY_MILLS = 60 * 1000L）。

错误日志:
Failed to get available servers: endpoint format should like ip:port
![image](https://user-images.githubusercontent.com/1582168/89255229-cab96a00-d653-11ea-91e4-730e5ddb93df.png)

【原因分析】: 

由于资源注册时RM还没有初始化，所以此时transactionServiceGroup为空！

【解决方案】：
RmNettyRemotingClient.registerResource 加上transactionServiceGroup是否为空的检查
延迟注册，注册资源时如果RM尚未初始化则先不连接，待RM初始化时检查有已注册的RM则连接后将资源一并注册到TC

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

【复现方法】：
1、[样例代码](https://github.com/seata/seata-samples/tree/master/api) 直接将POM中seata版本切换为1.3运行
日志中会找到错误:Failed to get available servers: endpoint format should like ip:port
2、简化代码后发现，只要当资源注册先于RM初始化就会**复现问题**。可以将[样例代码](https://github.com/seata/seata-samples/blob/master/api/src/main/java/io/seata/samples/api/Bussiness.java)中的RM初始化部分简化为如下形式，可复现问题。同时可见，一分钟后连接检测时会自动修复问题。
```java
DataSourceUtil.getDataSource("account"); // DataSourceProxy初始化的时候会触发registerResource
RMClient.init(applicationId, txServiceGroup);
```
![image](https://user-images.githubusercontent.com/1582168/89256547-f722b580-d656-11ea-95a5-ed40dd2acf13.png)

3、进一步分析发现，如果初始化先于资源注册，则无此问题。
```java
RMClient.init(applicationId, txServiceGroup);
DataSourceUtil.getDataSource("account"); 
```
![image](https://user-images.githubusercontent.com/1582168/89256670-3c46e780-d657-11ea-8849-51a04f972d36.png)

【验证方式】：
修正后，无论先注册资源还是先初始化RM，都不会报错，且当资源注册先于RM初始化时，会在RM初始化后立即将资源注册到TC


### Ⅴ. Special notes for reviews

