### PR TITLE
bugfix: The color characters are messy when running by 'seata-server.bat'

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -205,8 +205,8 @@
                                     <extraArgument>-verbose:gc</extraArgument>
                                     <!--netty-->
                                     <extraArgument>-Dio.netty.leakDetectionLevel=advanced</extraArgument>
-                                    <!--run by *.bat or *.sh-->
-                                    <extraArgument>-Drun.by-startup=true</extraArgument>
+                                    <!--log-->
+                                    <extraArgument>-Dlogback.color.disable-for-bat=true</extraArgument>
                                 </extraArguments>
                             </jvmSettings>
                             <platforms>
@@ -265,8 +265,8 @@
                             <jvmFlag>-verbose:gc</jvmFlag>
                             <!--netty-->
                             <jvmFlag>-Dio.netty.leakDetectionLevel=advanced</jvmFlag>
-                            <!--run by *.bat or *.sh-->
-                            <jvmFlag>-Drun.by-startup=true</jvmFlag>
+                            <!--log-->
+                            <jvmFlag>-Dlogback.color.disable-for-bat=true</jvmFlag>
                         </jvmFlags>
                         <labels>
                             <name>seata-server</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -205,6 +205,8 @@
                                     <extraArgument>-verbose:gc</extraArgument>
                                     <!--netty-->
                                     <extraArgument>-Dio.netty.leakDetectionLevel=advanced</extraArgument>
+                                    <!--run by *.bat or *.sh-->
+                                    <extraArgument>-Drun.by-startup=true</extraArgument>
                                 </extraArguments>
                             </jvmSettings>
                             <platforms>
@@ -263,6 +265,8 @@
                             <jvmFlag>-verbose:gc</jvmFlag>
                             <!--netty-->
                             <jvmFlag>-Dio.netty.leakDetectionLevel=advanced</jvmFlag>
+                            <!--run by *.bat or *.sh-->
+                            <jvmFlag>-Drun.by-startup=true</jvmFlag>
                         </jvmFlags>
                         <labels>
                             <name>seata-server</name>

--- a/server/src/main/java/io/seata/server/env/ContainerHelper.java
+++ b/server/src/main/java/io/seata/server/env/ContainerHelper.java
@@ -15,7 +15,6 @@
  */
 package io.seata.server.env;
 
-import io.netty.util.internal.PlatformDependent;
 import io.seata.common.util.NumberUtils;
 import io.seata.common.util.StringUtils;
 
@@ -59,20 +58,6 @@ public class ContainerHelper {
             }
         }
         return false;
-    }
-
-    /**
-     * Judge if application is run in windows with seata-server.bat.
-     *
-     * @return If application is run in windows with seata-server.bat.
-     */
-    public static boolean isRunningInWindowsWithBat() {
-        if (!PlatformDependent.isWindows()) {
-            return false;
-        }
-
-        String runByStartup = System.getProperty("run.by-startup");
-        return runByStartup != null && runByStartup.equalsIgnoreCase("true");
     }
 
     /**

--- a/server/src/main/java/io/seata/server/env/ContainerHelper.java
+++ b/server/src/main/java/io/seata/server/env/ContainerHelper.java
@@ -15,6 +15,7 @@
  */
 package io.seata.server.env;
 
+import io.netty.util.internal.PlatformDependent;
 import io.seata.common.util.NumberUtils;
 import io.seata.common.util.StringUtils;
 
@@ -27,6 +28,7 @@ import java.util.stream.Stream;
 import static io.seata.common.DefaultValues.SERVER_DEFAULT_PORT;
 
 /**
+ * @author xingfudeshi@gmail.com
  * @author wang.liang
  */
 public class ContainerHelper {
@@ -57,6 +59,20 @@ public class ContainerHelper {
             }
         }
         return false;
+    }
+
+    /**
+     * Judge if application is run in windows with seata-server.bat.
+     *
+     * @return If application is run in windows with seata-server.bat.
+     */
+    public static boolean isRunningInWindowsWithBat() {
+        if (!PlatformDependent.isWindows()) {
+            return false;
+        }
+
+        String runByStartup = System.getProperty("run.by-startup");
+        return runByStartup != null && runByStartup.equalsIgnoreCase("true");
     }
 
     /**

--- a/server/src/main/java/io/seata/server/logging/logback/ColorConverter.java
+++ b/server/src/main/java/io/seata/server/logging/logback/ColorConverter.java
@@ -18,7 +18,7 @@ package io.seata.server.logging.logback;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.CompositeConverter;
-import io.seata.server.env.ContainerHelper;
+import io.netty.util.internal.PlatformDependent;
 import io.seata.server.logging.logback.ansi.AnsiColor;
 import io.seata.server.logging.logback.ansi.AnsiElement;
 import io.seata.server.logging.logback.ansi.AnsiOutput;
@@ -39,6 +39,8 @@ import java.util.Map;
 public class ColorConverter extends CompositeConverter<ILoggingEvent> {
 
     private static final Map<String, AnsiElement> ELEMENTS;
+
+    private static final String DISABLE_PROPERTY_NAME = "logback.color.disable-for-bat";
 
     static {
         Map<String, AnsiElement> ansiElements = new HashMap<String, AnsiElement>();
@@ -61,15 +63,17 @@ public class ColorConverter extends CompositeConverter<ILoggingEvent> {
         LEVELS = Collections.unmodifiableMap(ansiLevels);
     }
 
-    private final boolean isRunInWindowsWithBat;
+    private final boolean disable;
 
     public ColorConverter() {
-        isRunInWindowsWithBat = ContainerHelper.isRunningInWindowsWithBat();
+        //If is windows and run by seata-server.bat, then disable the color log.
+        disable = PlatformDependent.isWindows() && Boolean.parseBoolean(System.getProperty(DISABLE_PROPERTY_NAME));
     }
 
     @Override
     protected String transform(ILoggingEvent event, String in) {
-        if (isRunInWindowsWithBat) {
+        if (disable) {
+            //return the original log
             return in;
         }
 

--- a/server/src/main/java/io/seata/server/logging/logback/ColorConverter.java
+++ b/server/src/main/java/io/seata/server/logging/logback/ColorConverter.java
@@ -18,6 +18,7 @@ package io.seata.server.logging.logback;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.CompositeConverter;
+import io.seata.server.env.ContainerHelper;
 import io.seata.server.logging.logback.ansi.AnsiColor;
 import io.seata.server.logging.logback.ansi.AnsiElement;
 import io.seata.server.logging.logback.ansi.AnsiOutput;
@@ -60,8 +61,18 @@ public class ColorConverter extends CompositeConverter<ILoggingEvent> {
         LEVELS = Collections.unmodifiableMap(ansiLevels);
     }
 
+    private final boolean isRunInWindowsWithBat;
+
+    public ColorConverter() {
+        isRunInWindowsWithBat = ContainerHelper.isRunningInWindowsWithBat();
+    }
+
     @Override
     protected String transform(ILoggingEvent event, String in) {
+        if (isRunInWindowsWithBat) {
+            return in;
+        }
+
         AnsiElement element = ELEMENTS.get(getFirstOption());
         if (element == null) {
             // Assume highlighting

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -23,8 +23,8 @@
     <conversionRule conversionWord="clr" converterClass="io.seata.server.logging.logback.ColorConverter" />
     <conversionRule conversionWord="wex" converterClass="io.seata.server.logging.logback.WhitespaceThrowableProxyConverter" />
     <conversionRule conversionWord="wEx" converterClass="io.seata.server.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
-    <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"/>
-    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%t] %-40.40logger{39} : %m%n%wEx"/>
+    <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%30.30t] %-40.40logger{39} : %m%n%wEx"/>
 
     <property name="LOG_HOME" value="${user.home}/logs/seata"/>
 
@@ -38,10 +38,10 @@
 
     <!--ALL-->
     <appender name="ALL" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_HOME}/txc.${PORT}.all.log</file>
+        <file>${LOG_HOME}/seata-server.${PORT}.all.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/history/txc.${PORT}.all.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.all.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <maxFileSize>2GB</maxFileSize>
             <MaxHistory>7</MaxHistory>
             <totalSizeCap>7GB</totalSizeCap>
@@ -60,10 +60,10 @@
             <onMatch>ACCEPT</onMatch>
             <onMismatch>DENY</onMismatch>
         </filter>
-        <file>${LOG_HOME}/txc.${PORT}.warn.log</file>
+        <file>${LOG_HOME}/seata-server.${PORT}.warn.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/history/txc.${PORT}.warn.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.warn.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <maxFileSize>2GB</maxFileSize>
             <MaxHistory>7</MaxHistory>
             <totalSizeCap>7GB</totalSizeCap>
@@ -82,10 +82,10 @@
             <onMatch>ACCEPT</onMatch>
             <onMismatch>DENY</onMismatch>
         </filter>
-        <file>${LOG_HOME}/txc.${PORT}.error.log</file>
+        <file>${LOG_HOME}/seata-server.${PORT}.error.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/history/txc.${PORT}.error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
             <maxFileSize>2GB</maxFileSize>
             <MaxHistory>7</MaxHistory>
             <totalSizeCap>7GB</totalSizeCap>


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
bugfix: The color characters are messy when running by `seata-server.bat`.
BUG修复：当使用`seata-server.bat`运行时，颜色符号变成乱码的问题修复。


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #2954

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

