### PR TITLE
bugfix: fix some problems in the automatic data source proxy

### DIFF
--- a/core/src/main/java/io/seata/core/context/RootContext.java
+++ b/core/src/main/java/io/seata/core/context/RootContext.java
@@ -16,17 +16,19 @@
 package io.seata.core.context;
 
 import java.util.Map;
+import javax.annotation.Nonnull;
 
+import io.seata.common.DefaultValues;
 import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.common.util.StringUtils;
 import io.seata.config.ConfigurationFactory;
 import io.seata.core.constants.ConfigurationKeys;
-import io.seata.common.DefaultValues;
 import io.seata.core.model.BranchType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
+import static io.seata.core.model.BranchType.AT;
+import static io.seata.core.model.BranchType.XA;
 
 /**
  * The type Root context.
@@ -58,8 +60,16 @@ public class RootContext {
 
     private static ContextCore CONTEXT_HOLDER = ContextCoreLoader.load();
 
-    private static final BranchType DEFAULT_BRANCH_TYPE = BranchType.get(ConfigurationFactory.getInstance()
+    private static BranchType DEFAULT_BRANCH_TYPE = BranchType.get(ConfigurationFactory.getInstance()
             .getConfig(ConfigurationKeys.DATA_SOURCE_PROXY_MODE, DefaultValues.DEFAULT_DATA_SOURCE_PROXY_MODE));
+
+    public static void setDefaultBranchType(BranchType defaultBranchType) {
+        if (defaultBranchType != AT && defaultBranchType != XA) {
+            throw new IllegalArgumentException("The default branch type must be AT or XA." +
+                    " the value of the argument is: " + defaultBranchType);
+        }
+        DEFAULT_BRANCH_TYPE = defaultBranchType;
+    }
 
     /**
      * Gets xid.

--- a/core/src/main/java/io/seata/core/context/RootContext.java
+++ b/core/src/main/java/io/seata/core/context/RootContext.java
@@ -58,8 +58,8 @@ public class RootContext {
 
     private static ContextCore CONTEXT_HOLDER = ContextCoreLoader.load();
 
-    private static final String DATA_SOURCE_PROXY_MODE = ConfigurationFactory.getInstance()
-            .getConfig(ConfigurationKeys.DATA_SOURCE_PROXY_MODE, DefaultValues.DEFAULT_DATA_SOURCE_PROXY_MODE);
+    private static final BranchType DEFAULT_BRANCH_TYPE = BranchType.get(ConfigurationFactory.getInstance()
+            .getConfig(ConfigurationKeys.DATA_SOURCE_PROXY_MODE, DefaultValues.DEFAULT_DATA_SOURCE_PROXY_MODE));
 
     /**
      * Gets xid.
@@ -156,8 +156,8 @@ public class RootContext {
             if (branchType != null) {
                 return branchType;
             }
-            //default branchType is the dataSourceProxyMode
-            return BranchType.XA.name().equalsIgnoreCase(DATA_SOURCE_PROXY_MODE) ? BranchType.XA : BranchType.AT;
+            //Returns the default branch type.
+            return DEFAULT_BRANCH_TYPE;
         }
         return null;
     }

--- a/core/src/main/java/io/seata/core/model/BranchType.java
+++ b/core/src/main/java/io/seata/core/model/BranchType.java
@@ -60,11 +60,26 @@ public enum BranchType {
      * @return the branch type
      */
     public static BranchType get(int ordinal) {
-        for (BranchType branchType : BranchType.values()) {
+        for (BranchType branchType : values()) {
             if (branchType.ordinal() == ordinal) {
                 return branchType;
             }
         }
         throw new IllegalArgumentException("Unknown BranchType[" + ordinal + "]");
+    }
+
+    /**
+     * Get branch type.
+     *
+     * @param name the name
+     * @return the branch type
+     */
+    public static BranchType get(String name) {
+        for (BranchType branchType : values()) {
+            if (branchType.name().equalsIgnoreCase(name)) {
+                return branchType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown BranchType[" + name + "]");
     }
 }

--- a/core/src/test/java/io/seata/core/model/BranchTypeTest.java
+++ b/core/src/test/java/io/seata/core/model/BranchTypeTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 public class BranchTypeTest {
 
     private static final int AT_ORDINAL = 0;
+    private static final String AT_NAME = "AT";
     private static final int NONE = 99;
 
     @Test
@@ -42,14 +43,20 @@ public class BranchTypeTest {
 
     @Test
     public void testGetWithByte() {
-        BranchType branchStatus = BranchType.get((byte) AT_ORDINAL);
-        Assertions.assertEquals(branchStatus, BranchType.AT);
+        BranchType type = BranchType.get((byte) AT_ORDINAL);
+        Assertions.assertEquals(type, BranchType.AT);
     }
 
     @Test
     public void testGetWithInt() {
-        BranchType branchStatus = BranchType.get(AT_ORDINAL);
-        Assertions.assertEquals(branchStatus, BranchType.AT);
+        BranchType type = BranchType.get(AT_ORDINAL);
+        Assertions.assertEquals(type, BranchType.AT);
+    }
+
+    @Test
+    public void testGetWithName() {
+        BranchType type = BranchType.get(AT_NAME);
+        Assertions.assertEquals(type, BranchType.AT);
     }
 
     @Test

--- a/rm-datasource/src/main/java/io/seata/rm/BaseDataSourceResource.java
+++ b/rm-datasource/src/main/java/io/seata/rm/BaseDataSourceResource.java
@@ -18,6 +18,7 @@ package io.seata.rm;
 import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.core.model.BranchType;
 import io.seata.core.model.Resource;
+import io.seata.rm.datasource.SeataDataSourceProxy;
 import io.seata.rm.datasource.xa.Holdable;
 import io.seata.rm.datasource.xa.Holder;
 
@@ -34,7 +35,7 @@ import java.util.logging.Logger;
  *
  * @author sharajava
  */
-public abstract class BaseDataSourceResource<T extends Holdable> implements DataSource, Resource, Holder<T> {
+public abstract class BaseDataSourceResource<T extends Holdable> implements SeataDataSourceProxy, Resource, Holder<T> {
 
     protected DataSource dataSource;
 
@@ -49,6 +50,16 @@ public abstract class BaseDataSourceResource<T extends Holdable> implements Data
     protected Driver driver;
 
     private ConcurrentHashMap<String, T> keeper = new ConcurrentHashMap<>();
+
+    /**
+     * Gets target data source.
+     *
+     * @return the target data source
+     */
+    @Override
+    public DataSource getTargetDataSource() {
+        return dataSource;
+    }
 
     @Override
     public String getResourceId() {

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/AbstractDataSourceProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/AbstractDataSourceProxy.java
@@ -26,12 +26,17 @@ import java.util.logging.Logger;
  *
  * @author sharajava
  */
-public abstract class AbstractDataSourceProxy implements DataSource {
+public abstract class AbstractDataSourceProxy implements SeataDataSourceProxy {
 
     /**
      * The Target data source.
      */
     protected DataSource targetDataSource;
+
+    /**
+     * Instantiates a new Abstract data source proxy.
+     */
+    public AbstractDataSourceProxy(){}
 
     /**
      * Instantiates a new Abstract data source proxy.
@@ -47,6 +52,7 @@ public abstract class AbstractDataSourceProxy implements DataSource {
      *
      * @return the target data source
      */
+    @Override
     public DataSource getTargetDataSource() {
         return targetDataSource;
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/DataSourceProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/DataSourceProxy.java
@@ -81,7 +81,10 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
      * @param resourceGroupId  the resource group id
      */
     public DataSourceProxy(DataSource targetDataSource, String resourceGroupId) {
-        super(targetDataSource);
+        if (targetDataSource instanceof SeataDataSourceProxy) {
+            targetDataSource = ((SeataDataSourceProxy) targetDataSource).getTargetDataSource();
+        }
+        this.targetDataSource = targetDataSource;
         init(targetDataSource, resourceGroupId);
     }
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/DataSourceProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/DataSourceProxy.java
@@ -86,7 +86,7 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
      */
     public DataSourceProxy(DataSource targetDataSource, String resourceGroupId) {
         if (targetDataSource instanceof SeataDataSourceProxy) {
-            LOGGER.info("Unwrap the target data source, because the type of the target data source is: {}", targetDataSource.getClass().getName());
+            LOGGER.info("Unwrap the target data source, because the type is: {}", targetDataSource.getClass().getName());
             targetDataSource = ((SeataDataSourceProxy) targetDataSource).getTargetDataSource();
         }
         this.targetDataSource = targetDataSource;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/DataSourceProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/DataSourceProxy.java
@@ -31,6 +31,8 @@ import io.seata.rm.DefaultResourceManager;
 import io.seata.rm.datasource.sql.struct.TableMetaCacheFactory;
 import io.seata.rm.datasource.util.JdbcUtils;
 import io.seata.sqlparser.util.JdbcConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static io.seata.common.DefaultValues.DEFAULT_CLIENT_TABLE_META_CHECK_ENABLE;
 
@@ -41,9 +43,11 @@ import static io.seata.common.DefaultValues.DEFAULT_CLIENT_TABLE_META_CHECK_ENAB
  */
 public class DataSourceProxy extends AbstractDataSourceProxy implements Resource {
 
-    private String resourceGroupId;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceProxy.class);
 
     private static final String DEFAULT_RESOURCE_GROUP_ID = "DEFAULT";
+
+    private String resourceGroupId;
 
     private String jdbcUrl;
 
@@ -82,6 +86,7 @@ public class DataSourceProxy extends AbstractDataSourceProxy implements Resource
      */
     public DataSourceProxy(DataSource targetDataSource, String resourceGroupId) {
         if (targetDataSource instanceof SeataDataSourceProxy) {
+            LOGGER.info("Unwrap the target data source, because the type of the target data source is: {}", targetDataSource.getClass().getName());
             targetDataSource = ((SeataDataSourceProxy) targetDataSource).getTargetDataSource();
         }
         this.targetDataSource = targetDataSource;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/SeataDataSourceProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/SeataDataSourceProxy.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource;
+
+import javax.sql.DataSource;
+
+/**
+ * The interface Seata data source.
+ *
+ * @author wang.liang
+ */
+public interface SeataDataSourceProxy extends DataSource {
+
+    /**
+     * Gets target data source.
+     *
+     * @return the target data source
+     */
+    DataSource getTargetDataSource();
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/SeataDataSourceProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/SeataDataSourceProxy.java
@@ -17,6 +17,8 @@ package io.seata.rm.datasource;
 
 import javax.sql.DataSource;
 
+import io.seata.core.model.BranchType;
+
 /**
  * The interface Seata data source.
  *
@@ -30,4 +32,11 @@ public interface SeataDataSourceProxy extends DataSource {
      * @return the target data source
      */
     DataSource getTargetDataSource();
+
+    /**
+     * Gets branch type.
+     *
+     * @return the branch type
+     */
+    BranchType getBranchType();
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
@@ -43,7 +43,7 @@ public class DataSourceProxyXA extends AbstractDataSourceProxyXA {
 
     public DataSourceProxyXA(DataSource dataSource, String resourceGroupId) {
         if (dataSource instanceof SeataDataSourceProxy) {
-            LOGGER.info("Unwrap the data source, because the type of the data source is: {}", dataSource.getClass().getName());
+            LOGGER.info("Unwrap the data source, because the type is: {}", dataSource.getClass().getName());
             dataSource = ((SeataDataSourceProxy) dataSource).getTargetDataSource();
         }
         this.dataSource = dataSource;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
@@ -17,6 +17,7 @@ package io.seata.rm.datasource.xa;
 
 import io.seata.core.context.RootContext;
 import io.seata.core.model.BranchType;
+import io.seata.rm.datasource.SeataDataSourceProxy;
 import io.seata.rm.datasource.util.JdbcUtils;
 import io.seata.rm.datasource.util.XAUtils;
 
@@ -37,6 +38,9 @@ public class DataSourceProxyXA extends AbstractDataSourceProxyXA {
     }
 
     public DataSourceProxyXA(DataSource dataSource, String resourceGroupId) {
+        if (dataSource instanceof SeataDataSourceProxy) {
+            dataSource = ((SeataDataSourceProxy) dataSource).getTargetDataSource();
+        }
         this.dataSource = dataSource;
         this.branchType = BranchType.XA;
         JdbcUtils.initDataSourceResource(this, dataSource, resourceGroupId);

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
@@ -20,6 +20,8 @@ import io.seata.core.model.BranchType;
 import io.seata.rm.datasource.SeataDataSourceProxy;
 import io.seata.rm.datasource.util.JdbcUtils;
 import io.seata.rm.datasource.util.XAUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import javax.sql.XAConnection;
@@ -33,12 +35,15 @@ import java.sql.SQLException;
  */
 public class DataSourceProxyXA extends AbstractDataSourceProxyXA {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceProxyXA.class);
+
     public DataSourceProxyXA(DataSource dataSource) {
         this(dataSource, DEFAULT_RESOURCE_GROUP_ID);
     }
 
     public DataSourceProxyXA(DataSource dataSource, String resourceGroupId) {
         if (dataSource instanceof SeataDataSourceProxy) {
+            LOGGER.info("Unwrap the data source, because the type of the data source is: {}", dataSource.getClass().getName());
             dataSource = ((SeataDataSourceProxy) dataSource).getTargetDataSource();
         }
         this.dataSource = dataSource;

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/DataSourceProxyTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/DataSourceProxyTest.java
@@ -15,10 +15,12 @@
  */
 package io.seata.rm.datasource;
 
+import javax.sql.DataSource;
 import java.lang.reflect.Field;
 import java.sql.SQLException;
 
 import com.alibaba.druid.pool.DruidDataSource;
+import io.seata.rm.datasource.mock.MockDataSource;
 import io.seata.rm.datasource.mock.MockDriver;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -27,6 +29,17 @@ import org.junit.jupiter.api.Test;
  * @author ph3636
  */
 public class DataSourceProxyTest {
+
+    @Test
+    public void test_constructor() {
+        DataSource dataSource = new MockDataSource();
+
+        DataSourceProxy dataSourceProxy = new DataSourceProxy(dataSource);
+        Assertions.assertEquals(dataSourceProxy.getTargetDataSource(), dataSource);
+
+        DataSourceProxy dataSourceProxy2 = new DataSourceProxy(dataSourceProxy);
+        Assertions.assertEquals(dataSourceProxy2.getTargetDataSource(), dataSource);
+    }
 
     @Test
     public void getResourceIdTest() throws SQLException, NoSuchFieldException, IllegalAccessException {

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/mock/MockDataSource.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/mock/MockDataSource.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.mock;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+/**
+ * @author wang.liang
+ */
+public class MockDataSource implements DataSource {
+    @Override
+    public Connection getConnection() throws SQLException {
+        return new MockConnection(new MockDriver(), "jdbc:mysql://127.0.0.1:3306/seata", null);
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return false;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+}

--- a/rm-datasource/src/test/java/io/seata/rm/xa/DataSourceProxyXATest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/xa/DataSourceProxyXATest.java
@@ -19,12 +19,14 @@ import com.alibaba.druid.pool.DruidDataSource;
 import com.mysql.jdbc.JDBC4MySQLConnection;
 import com.mysql.jdbc.jdbc2.optional.JDBC4ConnectionWrapper;
 import io.seata.core.context.RootContext;
+import io.seata.rm.datasource.mock.MockDataSource;
 import io.seata.rm.datasource.xa.ConnectionProxyXA;
 import io.seata.rm.datasource.xa.DataSourceProxyXA;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import javax.sql.DataSource;
 import javax.sql.PooledConnection;
 import javax.sql.XAConnection;
 import java.sql.Connection;
@@ -40,6 +42,17 @@ import static org.mockito.ArgumentMatchers.any;
  * @author sharajava
  */
 public class DataSourceProxyXATest {
+
+    @Test
+    public void test_constructor() {
+        DataSource dataSource = new MockDataSource();
+
+        DataSourceProxyXA dataSourceProxy = new DataSourceProxyXA(dataSource);
+        Assertions.assertEquals(dataSourceProxy.getTargetDataSource(), dataSource);
+
+        DataSourceProxyXA dataSourceProxy2 = new DataSourceProxyXA(dataSourceProxy);
+        Assertions.assertEquals(dataSourceProxy2.getTargetDataSource(), dataSource);
+    }
 
     @Test
     public void testGetConnection() throws SQLException {

--- a/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/SeataAutoConfiguration.java
+++ b/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/SeataAutoConfiguration.java
@@ -17,6 +17,7 @@ package io.seata.spring.boot.autoconfigure;
 
 import io.seata.spring.annotation.GlobalTransactionScanner;
 import io.seata.spring.annotation.datasource.SeataAutoDataSourceProxyCreator;
+import io.seata.spring.annotation.datasource.SeataDataSourceBeanPostProcessor;
 import io.seata.spring.boot.autoconfigure.properties.SeataProperties;
 import io.seata.spring.boot.autoconfigure.provider.SpringApplicationContextProvider;
 import io.seata.tm.api.DefaultFailureHandlerImpl;
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.DependsOn;
 import static io.seata.common.Constants.BEAN_NAME_FAILURE_HANDLER;
 import static io.seata.common.Constants.BEAN_NAME_SPRING_APPLICATION_CONTEXT_PROVIDER;
 import static io.seata.spring.annotation.datasource.AutoDataSourceProxyRegistrar.BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR;
+import static io.seata.spring.annotation.datasource.AutoDataSourceProxyRegistrar.BEAN_NAME_SEATA_DATA_SOURCE_BEAN_POST_PROCESSOR;
 
 /**
  * @author xingfudeshi@gmail.com
@@ -67,11 +69,30 @@ public class SeataAutoConfiguration {
         return new GlobalTransactionScanner(seataProperties.getApplicationId(), seataProperties.getTxServiceGroup(), failureHandler);
     }
 
-    @Bean(BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR)
+    /**
+     * The data source configuration.
+     */
+    @Configuration
     @ConditionalOnProperty(prefix = StarterConstants.SEATA_PREFIX, name = {"enableAutoDataSourceProxy", "enable-auto-data-source-proxy"}, havingValue = "true", matchIfMissing = true)
-    @ConditionalOnMissingBean(SeataAutoDataSourceProxyCreator.class)
-    public SeataAutoDataSourceProxyCreator seataAutoDataSourceProxyCreator(SeataProperties seataProperties) {
-        return new SeataAutoDataSourceProxyCreator(seataProperties.isUseJdkProxy(),
-            seataProperties.getExcludesForAutoProxying(), seataProperties.getDataSourceProxyMode());
+    static class SeataDataSourceConfiguration {
+
+        /**
+         * The bean seataDataSourceBeanPostProcessor.
+         */
+        @Bean(BEAN_NAME_SEATA_DATA_SOURCE_BEAN_POST_PROCESSOR)
+        @ConditionalOnMissingBean(SeataDataSourceBeanPostProcessor.class)
+        public SeataDataSourceBeanPostProcessor seataDataSourceBeanPostProcessor(SeataProperties seataProperties) {
+            return new SeataDataSourceBeanPostProcessor(seataProperties.getExcludesForAutoProxying(), seataProperties.getDataSourceProxyMode());
+        }
+
+        /**
+         * The bean seataAutoDataSourceProxyCreator.
+         */
+        @Bean(BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR)
+        @ConditionalOnMissingBean(SeataAutoDataSourceProxyCreator.class)
+        public SeataAutoDataSourceProxyCreator seataAutoDataSourceProxyCreator(SeataProperties seataProperties) {
+            return new SeataAutoDataSourceProxyCreator(seataProperties.isUseJdkProxy(),
+                    seataProperties.getExcludesForAutoProxying(), seataProperties.getDataSourceProxyMode());
+        }
     }
 }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/AutoDataSourceProxyRegistrar.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/AutoDataSourceProxyRegistrar.java
@@ -15,6 +15,8 @@
  */
 package io.seata.spring.annotation.datasource;
 
+import io.seata.core.context.RootContext;
+import io.seata.core.model.BranchType;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -42,6 +44,9 @@ public class AutoDataSourceProxyRegistrar implements ImportBeanDefinitionRegistr
         boolean useJdkProxy = Boolean.parseBoolean(annotationAttributes.get(ATTRIBUTE_KEY_USE_JDK_PROXY).toString());
         String[] excludes = (String[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDES);
         String dataSourceProxyMode = (String) annotationAttributes.get(ATTRIBUTE_KEY_DATA_SOURCE_PROXY_MODE);
+
+        //Set the default branch type to RootContext.
+        RootContext.setDefaultBranchType(BranchType.get(dataSourceProxyMode));
 
         //register seataDataSourceBeanPostProcessor bean def
         if (!registry.containsBeanDefinition(BEAN_NAME_SEATA_DATA_SOURCE_BEAN_POST_PROCESSOR)) {

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/AutoDataSourceProxyRegistrar.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/AutoDataSourceProxyRegistrar.java
@@ -31,17 +31,29 @@ public class AutoDataSourceProxyRegistrar implements ImportBeanDefinitionRegistr
     private static final String ATTRIBUTE_KEY_USE_JDK_PROXY = "useJdkProxy";
     private static final String ATTRIBUTE_KEY_EXCLUDES = "excludes";
     private static final String ATTRIBUTE_KEY_DATA_SOURCE_PROXY_MODE = "dataSourceProxyMode";
+
+    public static final String BEAN_NAME_SEATA_DATA_SOURCE_BEAN_POST_PROCESSOR = "seataDataSourceBeanPostProcessor";
     public static final String BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR = "seataAutoDataSourceProxyCreator";
 
     @Override
     public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+        Map<String, Object> annotationAttributes = importingClassMetadata.getAnnotationAttributes(EnableAutoDataSourceProxy.class.getName());
+
+        boolean useJdkProxy = Boolean.parseBoolean(annotationAttributes.get(ATTRIBUTE_KEY_USE_JDK_PROXY).toString());
+        String[] excludes = (String[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDES);
+        String dataSourceProxyMode = (String) annotationAttributes.get(ATTRIBUTE_KEY_DATA_SOURCE_PROXY_MODE);
+
+        //register seataDataSourceBeanPostProcessor bean def
+        if (!registry.containsBeanDefinition(BEAN_NAME_SEATA_DATA_SOURCE_BEAN_POST_PROCESSOR)) {
+            AbstractBeanDefinition beanDefinition = BeanDefinitionBuilder
+                .genericBeanDefinition(SeataDataSourceBeanPostProcessor.class)
+                .addConstructorArgValue(dataSourceProxyMode)
+                .getBeanDefinition();
+            registry.registerBeanDefinition(BEAN_NAME_SEATA_DATA_SOURCE_BEAN_POST_PROCESSOR, beanDefinition);
+        }
+
+        //register seataAutoDataSourceProxyCreator bean def
         if (!registry.containsBeanDefinition(BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR)) {
-            Map<String, Object> annotationAttributes = importingClassMetadata.getAnnotationAttributes(EnableAutoDataSourceProxy.class.getName());
-
-            boolean useJdkProxy = Boolean.parseBoolean(annotationAttributes.get(ATTRIBUTE_KEY_USE_JDK_PROXY).toString());
-            String[] excludes = (String[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDES);
-            String dataSourceProxyMode = (String) annotationAttributes.get(ATTRIBUTE_KEY_DATA_SOURCE_PROXY_MODE);
-
             AbstractBeanDefinition beanDefinition = BeanDefinitionBuilder
                 .genericBeanDefinition(SeataAutoDataSourceProxyCreator.class)
                 .addConstructorArgValue(useJdkProxy)
@@ -51,5 +63,4 @@ public class AutoDataSourceProxyRegistrar implements ImportBeanDefinitionRegistr
             registry.registerBeanDefinition(BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR, beanDefinition);
         }
     }
-
 }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/DataSourceProxyHolder.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/DataSourceProxyHolder.java
@@ -66,8 +66,9 @@ public class DataSourceProxyHolder {
     public SeataDataSourceProxy putDataSource(DataSource dataSource, BranchType dataSourceProxyMode) {
         DataSource originalDataSource;
         if (dataSource instanceof SeataDataSourceProxy) {
+            SeataDataSourceProxy dataSourceProxy = (SeataDataSourceProxy) dataSource;
+
             //If it's an right proxy, return it directly.
-            SeataDataSourceProxy dataSourceProxy = (SeataDataSourceProxy)dataSource;
             if (dataSourceProxyMode == dataSourceProxy.getBranchType()) {
                 return (SeataDataSourceProxy)dataSource;
             }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/DataSourceProxyHolder.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/DataSourceProxyHolder.java
@@ -63,17 +63,17 @@ public class DataSourceProxyHolder {
      * @param dataSourceProxyMode the data source proxy mode
      * @return dataSourceProxy
      */
-    public DataSource putDataSource(DataSource dataSource, BranchType dataSourceProxyMode) {
+    public SeataDataSourceProxy putDataSource(DataSource dataSource, BranchType dataSourceProxyMode) {
         DataSource originalDataSource;
         if (dataSource instanceof SeataDataSourceProxy) {
-            if ((BranchType.AT == dataSourceProxyMode && dataSource instanceof DataSourceProxy)
-                    || (BranchType.XA == dataSourceProxyMode && dataSource instanceof DataSourceProxyXA)) {
-                //It's already a proxy, return it directly.
-                return dataSource;
-            } else {
-                //Get the original data source.
-                originalDataSource = ((SeataDataSourceProxy) dataSource).getTargetDataSource();
+            //If it's an right proxy, return it directly.
+            SeataDataSourceProxy dataSourceProxy = (SeataDataSourceProxy)dataSource;
+            if (dataSourceProxyMode == dataSourceProxy.getBranchType()) {
+                return (SeataDataSourceProxy)dataSource;
             }
+
+            //Get the original data source.
+            originalDataSource = dataSourceProxy.getTargetDataSource();
         } else {
             originalDataSource = dataSource;
         }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
@@ -15,6 +15,9 @@
  */
 package io.seata.spring.annotation.datasource;
 
+import javax.sql.DataSource;
+import java.lang.reflect.Method;
+
 import io.seata.core.context.RootContext;
 import io.seata.core.model.BranchType;
 import io.seata.rm.datasource.DataSourceProxy;
@@ -23,9 +26,6 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.aop.IntroductionInfo;
 import org.springframework.beans.BeanUtils;
-
-import javax.sql.DataSource;
-import java.lang.reflect.Method;
 
 /**
  * @author xingfudeshi@gmail.com

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
@@ -37,12 +37,14 @@ public class SeataAutoDataSourceProxyAdvice implements MethodInterceptor, Introd
     private final Class<? extends SeataDataSourceProxy> dataSourceProxyClazz;
 
     public SeataAutoDataSourceProxyAdvice(String dataSourceProxyMode) {
-        if (BranchType.XA.name().equalsIgnoreCase(dataSourceProxyMode)) {
+        if (BranchType.AT.name().equalsIgnoreCase(dataSourceProxyMode)) {
+            this.dataSourceProxyMode = BranchType.AT;
+            this.dataSourceProxyClazz = DataSourceProxy.class;
+        } else if (BranchType.XA.name().equalsIgnoreCase(dataSourceProxyMode)) {
             this.dataSourceProxyMode = BranchType.XA;
             this.dataSourceProxyClazz = DataSourceProxyXA.class;
         } else {
-            this.dataSourceProxyMode = BranchType.AT;
-            this.dataSourceProxyClazz = DataSourceProxy.class;
+            throw new IllegalArgumentException("Unknown dataSourceProxyMode: " + dataSourceProxyMode);
         }
     }
 

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
@@ -15,9 +15,7 @@
  */
 package io.seata.spring.annotation.datasource;
 
-import javax.sql.DataSource;
-import java.lang.reflect.Method;
-
+import io.seata.core.context.RootContext;
 import io.seata.core.model.BranchType;
 import io.seata.rm.datasource.DataSourceProxy;
 import io.seata.rm.datasource.xa.DataSourceProxyXA;
@@ -26,27 +24,40 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.aop.IntroductionInfo;
 import org.springframework.beans.BeanUtils;
 
+import javax.sql.DataSource;
+import java.lang.reflect.Method;
+
 /**
  * @author xingfudeshi@gmail.com
  */
 public class SeataAutoDataSourceProxyAdvice implements MethodInterceptor, IntroductionInfo {
 
-    private final String dataSourceProxyMode;
+    private final BranchType dataSourceProxyMode;
     private final Class<? extends DataSource> dataSourceProxyClazz;
 
     public SeataAutoDataSourceProxyAdvice(String dataSourceProxyMode) {
-        this.dataSourceProxyMode = dataSourceProxyMode;
-        this.dataSourceProxyClazz = BranchType.XA.name().equalsIgnoreCase(dataSourceProxyMode) ?
-                DataSourceProxyXA.class : DataSourceProxy.class;
+        if (BranchType.XA.name().equalsIgnoreCase(dataSourceProxyMode)) {
+            this.dataSourceProxyMode = BranchType.XA;
+            this.dataSourceProxyClazz = DataSourceProxyXA.class;
+        } else {
+            this.dataSourceProxyMode = BranchType.AT;
+            this.dataSourceProxyClazz = DataSourceProxy.class;
+        }
     }
 
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
-        DataSource dataSourceProxy = DataSourceProxyHolder.get().putDataSource((DataSource) invocation.getThis(), dataSourceProxyMode);
+        if (!RootContext.requireGlobalLock()
+                && BranchType.AT != RootContext.getBranchType()
+                && BranchType.XA != RootContext.getBranchType()) {
+            return invocation.proceed();
+        }
+
         Method method = invocation.getMethod();
         Object[] args = invocation.getArguments();
         Method m = BeanUtils.findDeclaredMethod(dataSourceProxyClazz, method.getName(), method.getParameterTypes());
         if (m != null) {
+            DataSource dataSourceProxy = DataSourceProxyHolder.get().putDataSource((DataSource) invocation.getThis(), dataSourceProxyMode);
             return m.invoke(dataSourceProxy, args);
         } else {
             return invocation.proceed();
@@ -57,5 +68,4 @@ public class SeataAutoDataSourceProxyAdvice implements MethodInterceptor, Introd
     public Class<?>[] getInterfaces() {
         return new Class[]{SeataProxy.class};
     }
-
 }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
@@ -49,8 +49,7 @@ public class SeataAutoDataSourceProxyAdvice implements MethodInterceptor, Introd
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
         if (!RootContext.requireGlobalLock()
-                && BranchType.AT != RootContext.getBranchType()
-                && BranchType.XA != RootContext.getBranchType()) {
+                && dataSourceProxyMode != RootContext.getBranchType()) {
             return invocation.proceed();
         }
 

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyAdvice.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import io.seata.core.context.RootContext;
 import io.seata.core.model.BranchType;
 import io.seata.rm.datasource.DataSourceProxy;
+import io.seata.rm.datasource.SeataDataSourceProxy;
 import io.seata.rm.datasource.xa.DataSourceProxyXA;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -33,7 +34,7 @@ import org.springframework.beans.BeanUtils;
 public class SeataAutoDataSourceProxyAdvice implements MethodInterceptor, IntroductionInfo {
 
     private final BranchType dataSourceProxyMode;
-    private final Class<? extends DataSource> dataSourceProxyClazz;
+    private final Class<? extends SeataDataSourceProxy> dataSourceProxyClazz;
 
     public SeataAutoDataSourceProxyAdvice(String dataSourceProxyMode) {
         if (BranchType.XA.name().equalsIgnoreCase(dataSourceProxyMode)) {
@@ -57,7 +58,7 @@ public class SeataAutoDataSourceProxyAdvice implements MethodInterceptor, Introd
         Object[] args = invocation.getArguments();
         Method m = BeanUtils.findDeclaredMethod(dataSourceProxyClazz, method.getName(), method.getParameterTypes());
         if (m != null) {
-            DataSource dataSourceProxy = DataSourceProxyHolder.get().putDataSource((DataSource) invocation.getThis(), dataSourceProxyMode);
+            SeataDataSourceProxy dataSourceProxy = DataSourceProxyHolder.get().putDataSource((DataSource) invocation.getThis(), dataSourceProxyMode);
             return m.invoke(dataSourceProxy, args);
         } else {
             return invocation.proceed();

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyCreator.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyCreator.java
@@ -17,6 +17,7 @@ package io.seata.spring.annotation.datasource;
 
 import javax.sql.DataSource;
 import java.util.Arrays;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,11 +32,11 @@ import org.springframework.beans.BeansException;
  */
 public class SeataAutoDataSourceProxyCreator extends AbstractAutoProxyCreator {
     private static final Logger LOGGER = LoggerFactory.getLogger(SeataAutoDataSourceProxyCreator.class);
-    private final String[] excludes;
+    private final List<String> excludes;
     private final Advisor advisor;
 
     public SeataAutoDataSourceProxyCreator(boolean useJdkProxy, String[] excludes, String dataSourceProxyMode) {
-        this.excludes = excludes;
+        this.excludes = Arrays.asList(excludes);
         this.advisor = new DefaultIntroductionAdvisor(new SeataAutoDataSourceProxyAdvice(dataSourceProxyMode));
         setProxyTargetClass(!useJdkProxy);
     }
@@ -52,6 +53,6 @@ public class SeataAutoDataSourceProxyCreator extends AbstractAutoProxyCreator {
     protected boolean shouldSkip(Class<?> beanClass, String beanName) {
         return SeataProxy.class.isAssignableFrom(beanClass) ||
             !DataSource.class.isAssignableFrom(beanClass) ||
-            Arrays.asList(excludes).contains(beanClass.getName());
+            excludes.contains(beanClass.getName());
     }
 }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyCreator.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyCreator.java
@@ -51,8 +51,8 @@ public class SeataAutoDataSourceProxyCreator extends AbstractAutoProxyCreator {
 
     @Override
     protected boolean shouldSkip(Class<?> beanClass, String beanName) {
-        return SeataProxy.class.isAssignableFrom(beanClass) ||
-            !DataSource.class.isAssignableFrom(beanClass) ||
+        return !DataSource.class.isAssignableFrom(beanClass) ||
+            SeataProxy.class.isAssignableFrom(beanClass) ||
             excludes.contains(beanClass.getName());
     }
 }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
@@ -17,6 +17,8 @@ package io.seata.spring.annotation.datasource;
 
 import io.seata.core.model.BranchType;
 import io.seata.rm.datasource.SeataDataSourceProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 
@@ -31,6 +33,8 @@ import java.util.List;
  * @author wang.liang
  */
 public class SeataDataSourceBeanPostProcessor implements BeanPostProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SeataDataSourceBeanPostProcessor.class);
 
     private final List<String> excludes;
     private final BranchType dataSourceProxyMode;
@@ -56,6 +60,7 @@ public class SeataDataSourceBeanPostProcessor implements BeanPostProcessor {
 
             //If is SeataDataSourceProxy, return the original data source.
             if (bean instanceof SeataDataSourceProxy) {
+                LOGGER.info("unwrap the bean of the data source, and return the original data source as a bean.");
                 return ((SeataDataSourceProxy) bean).getTargetDataSource();
             }
         }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
@@ -15,16 +15,16 @@
  */
 package io.seata.spring.annotation.datasource;
 
+import java.util.Arrays;
+import java.util.List;
+import javax.sql.DataSource;
+
 import io.seata.core.model.BranchType;
 import io.seata.rm.datasource.SeataDataSourceProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
-
-import javax.sql.DataSource;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * The type seata data source bean post processor
@@ -60,7 +60,8 @@ public class SeataDataSourceBeanPostProcessor implements BeanPostProcessor {
 
             //If is SeataDataSourceProxy, return the original data source.
             if (bean instanceof SeataDataSourceProxy) {
-                LOGGER.info("Unwrap the bean of the data source, and return the original data source as a bean.");
+                LOGGER.info("Unwrap the bean of the data source," +
+                    " and return the original data source to replace the data source proxy.");
                 return ((SeataDataSourceProxy) bean).getTargetDataSource();
             }
         }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
@@ -60,7 +60,7 @@ public class SeataDataSourceBeanPostProcessor implements BeanPostProcessor {
 
             //If is SeataDataSourceProxy, return the original data source.
             if (bean instanceof SeataDataSourceProxy) {
-                LOGGER.info("unwrap the bean of the data source, and return the original data source as a bean.");
+                LOGGER.info("Unwrap the bean of the data source, and return the original data source as a bean.");
                 return ((SeataDataSourceProxy) bean).getTargetDataSource();
             }
         }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
@@ -47,9 +47,12 @@ public class SeataDataSourceBeanPostProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        if (bean instanceof DataSource && !excludes.contains(bean.getClass().getName())) {
-            //Only put and init proxy, not return proxy.
-            DataSourceProxyHolder.get().putDataSource((DataSource) bean, dataSourceProxyMode);
+        if (bean instanceof DataSource) {
+            //When not in the excludes, put and init proxy.
+            if (!excludes.contains(bean.getClass().getName())) {
+                //Only put and init proxy, not return proxy.
+                DataSourceProxyHolder.get().putDataSource((DataSource) bean, dataSourceProxyMode);
+            }
 
             //If is SeataDataSourceProxy, return the original data source.
             if (bean instanceof SeataDataSourceProxy) {

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataDataSourceBeanPostProcessor.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.annotation.datasource;
+
+import io.seata.core.model.BranchType;
+import io.seata.rm.datasource.SeataDataSourceProxy;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import javax.sql.DataSource;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The type seata data source bean post processor
+ *
+ * @author xingfudeshi@gmail.com
+ * @author wang.liang
+ */
+public class SeataDataSourceBeanPostProcessor implements BeanPostProcessor {
+
+    private final List<String> excludes;
+    private final BranchType dataSourceProxyMode;
+
+    public SeataDataSourceBeanPostProcessor(String[] excludes, String dataSourceProxyMode) {
+        this.excludes = Arrays.asList(excludes);
+        this.dataSourceProxyMode = BranchType.XA.name().equalsIgnoreCase(dataSourceProxyMode) ? BranchType.XA : BranchType.AT;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof DataSource && !excludes.contains(bean.getClass().getName())) {
+            //Only put and init proxy, not return proxy.
+            DataSourceProxyHolder.get().putDataSource((DataSource) bean, dataSourceProxyMode);
+
+            //If is SeataDataSourceProxy, return the original data source.
+            if (bean instanceof SeataDataSourceProxy) {
+                return ((SeataDataSourceProxy) bean).getTargetDataSource();
+            }
+        }
+        return bean;
+    }
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
bugfix: fixed some problems in the automatic data source proxy.
修复自动数据源代理的一些问题，用户使用体验会更好，与第三方组件的兼容性也会更好。

注：从此PR是从 #2879 中拆分出来的。

### 此PR调整的内容：
1. `AT`/`XA`代理类构造函数中解除代理，避免用户手动创建代理导致双重代理所致的各种未知问题；(借用了大佬 @slievrly 的PR #2921 的代码，主要我这边新增了一个接口`SeataDataSourceProxy`)
2. 在不需要执行`AT`/`XA`代理时，不进入代理类的方法，而是直接执行原来的`DataSource`的功能，避免一些不可预测的问题，增强`seata`与其他第三方组件的兼容性。
3. 将1.1.0版本中所使用的生命周期时创建数据源代理的Bean恢复过来，并进行了改造。原本代理类会直接代替原来的数据源而成为bean，这次仅创建和初始化数据源代理，数据源bean还是原生的，不会改变。这样就不会产生1.1.0时的兼容性问题，同时解决了`AT`/`XA`在项目启动时未注册资源的问题了。
4. 修复了 _非springboot用户_ 使用`@EnableDataSourceProxy`启用XA模式时，`RootContext.DEFAULT_BRANCH_TYPE`的值却为`AT`的BUG。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

