### PR TITLE
bugfix: the redis lock key and the session key has conflict

### DIFF
--- a/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
@@ -51,7 +51,7 @@ import redis.clients.jedis.ScanResult;
 public class RedisTransactionStoreManager extends AbstractTransactionStoreManager implements TransactionStoreManager {
 
     // global transaction prefix
-    private static final String DEFAULT_REDIS_SEATA_GLOBAL_PREFIX = "SEATA_GLOBAL_";
+    private static final String DEFAULT_REDIS_SEATA_GLOBAL_SESSION_PREFIX = "SEATA_GLOBAL_SESSION_";
 
     // the prefix of the branchs transaction
     private static final String DEFAULT_REDIS_SEATA_XID_BRANCHS_PREFIX = "SEATA_XID_BRANCHS_";

--- a/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
@@ -394,7 +394,7 @@ public class RedisTransactionStoreManager extends AbstractTransactionStoreManage
     }
 
     private String getGlobalKeyByXid(String xid) {
-        return DEFAULT_REDIS_SEATA_GLOBAL_PREFIX + xid;
+        return DEFAULT_REDIS_SEATA_GLOBAL_SESSION_PREFIX + xid;
     }
 
     private String getBranchListKeyByXid(String xid) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
the lock has this key,it is a name of hash:
`private static final String DEFAULT_REDIS_SEATA_GLOBAL_LOCK_PREFIX = "SEATA_GLOBAL_LOCK";`
the session has this key,it is a name of string:
` private static final String DEFAULT_REDIS_SEATA_GLOBAL_PREFIX = "SEATA_GLOBAL_";`

They have the same prefix :SEATA_GLOBAL_ ，the `RedisTransactionStoreManager# public List<GlobalSession> readSession(GlobalStatus[] statuses)`  ,use the` redis scan` of key SEATA_GLOBAL_* to get(key).
It will cause:
`redis.clients.jedis.exceptions.JedisDataException: WRONGTYPE Operation against a key holding the wrong kind of value
	at redis.clients.jedis.Protocol.processError(Protocol.java:132)
	at redis.clients.jedis.Protocol.process(Protocol.java:166)
	at redis.clients.jedis.Protocol.read(Protocol.java:220)
	at redis.clients.jedis.Connection.readProtocolWithCheckingBroken(Connection.java:318)
	at redis.clients.jedis.Connection.getBinaryBulkReply(Connection.java:255)
	at redis.clients.jedis.Connection.getBulkReply(Connection.java:245)
	at redis.clients.jedis.Jedis.get(Jedis.java:181)
	at io.seata.server.storage.redis.store.RedisTransactionStoreManager.readSession(RedisTransactionStoreManager.java:230)
	at io.seata.server.storage.redis.store.RedisTransactionStoreManager.readSession(RedisTransactionStoreManager.java:290)
	at io.seata.server.storage.redis.session.RedisSessionManager.findGlobalSessions(RedisSessionManager.java:188)
	at io.seata.server.storage.redis.session.RedisSessionManager.allSessions(RedisSessionManager.java:178)
	at io.seata.server.coordinator.DefaultCoordinator.timeoutCheck(DefaultCoordinator.java:216)
	at io.seata.server.coordinator.DefaultCoordinator.lambda$init$20(DefaultCoordinator.java:404)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset$$$capture(FutureTask.java:308)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java)
	at `


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

