### PR TITLE
求助处理SqlServer AT 模式下 列阵列无效问题

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/SqlGenerateUtils.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/SqlGenerateUtils.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.seata.rm.datasource.sql.struct.Field;
+import io.seata.sqlparser.util.JdbcConstants;
 
 /**
  * generate sql and set value to sql
@@ -45,6 +46,9 @@ public class SqlGenerateUtils {
      */
     public static String buildWhereConditionByPKs(List<String> pkNameList, int rowSize, String dbType)
         throws SQLException {
+        if (dbType.equals(JdbcConstants.SQLSERVER)) {
+            return buildWhereConditionByPKs(pkNameList, dbType);
+        }
         StringBuilder whereStr = new StringBuilder();
         //we must consider the situation of composite primary key
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutor.java
@@ -85,7 +85,7 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
      * @throws Exception the exception
      */
     protected T executeAutoCommitFalse(Object[] args) throws Exception {
-        if (!JdbcConstants.MYSQL.equalsIgnoreCase(getDbType()) && getTableMeta().getPrimaryKeyOnlyName().size() > 1)
+        if (!JdbcConstants.MYSQL.equalsIgnoreCase(getDbType()) && !JdbcConstants.SQLSERVER.equalsIgnoreCase(getDbType()) && getTableMeta().getPrimaryKeyOnlyName().size() > 1)
         {
             throw new NotSupportYetException("multi pk only support mysql!");
         }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/sqlserver/SQLServerInsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/sqlserver/SQLServerInsertExecutor.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.exec.sqlserver;
+
+import io.seata.common.exception.NotSupportYetException;
+import io.seata.common.exception.ShouldNeverHappenException;
+import io.seata.common.loader.LoadLevel;
+import io.seata.common.loader.Scope;
+import io.seata.common.util.StringUtils;
+import io.seata.rm.datasource.StatementProxy;
+import io.seata.rm.datasource.exec.BaseInsertExecutor;
+import io.seata.rm.datasource.exec.StatementCallback;
+import io.seata.rm.datasource.sql.struct.ColumnMeta;
+import io.seata.sqlparser.SQLRecognizer;
+import io.seata.sqlparser.struct.Defaultable;
+import io.seata.sqlparser.struct.Null;
+import io.seata.sqlparser.struct.SqlMethodExpr;
+import io.seata.sqlparser.util.JdbcConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+/**
+ * @author jsbxyyx
+ */
+@LoadLevel(name = JdbcConstants.SQLSERVER, scope = Scope.PROTOTYPE)
+public class SQLServerInsertExecutor extends BaseInsertExecutor implements Defaultable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SQLServerInsertExecutor.class);
+
+    /**
+     * the modify for test
+     */
+    public static final String ERR_SQL_STATE = "S1009";
+
+    /**
+     * Instantiates a new Abstract dml base executor.
+     *
+     * @param statementProxy    the statement proxy
+     * @param statementCallback the statement callback
+     * @param sqlRecognizer     the sql recognizer
+     */
+    public SQLServerInsertExecutor(StatementProxy statementProxy, StatementCallback statementCallback,
+                                   SQLRecognizer sqlRecognizer) {
+        super(statementProxy, statementCallback, sqlRecognizer);
+    }
+
+    @Override
+    public Map<String,List<Object>> getPkValues() throws SQLException {
+        Map<String,List<Object>> pkValuesMap = null;
+        List<String> pkColumnNameList = getTableMeta().getPrimaryKeyOnlyName();
+        Boolean isContainsPk = containsPK();
+        //when there is only one pk in the table
+        if (getTableMeta().getPrimaryKeyOnlyName().size() == 1) {
+            if (isContainsPk) {
+                pkValuesMap = getPkValuesByColumn();
+            }
+            else if (containsColumns()) {
+                pkValuesMap = getPkValuesByAuto();
+            }
+            else {
+                pkValuesMap = getPkValuesByColumn();
+            }
+        } else {
+            //when there is multiple pk in the table
+            //1,all pk columns are filled value.
+            //2,the auto increment pk column value is null, and other pk value are not null.
+            pkValuesMap = getPkValuesByColumn();
+            for (String columnName:pkColumnNameList) {
+                if (!pkValuesMap.containsKey(columnName)) {
+                    ColumnMeta pkColumnMeta = getTableMeta().getColumnMeta(columnName);
+                    if (Objects.nonNull(pkColumnMeta) && pkColumnMeta.isAutoincrement()) {
+                        //3,the auto increment pk column is not exits in sql, and other pk are exits also the value is not null.
+                        pkValuesMap.putAll(getPkValuesByAuto());
+                    }
+                }
+            }
+        }
+        return pkValuesMap;
+    }
+
+    /**
+     * the modify for test
+     */
+    public Map<String, List<Object>> getPkValuesByAuto() throws SQLException {
+        // PK is just auto generated
+        Map<String, List<Object>> pkValuesMap = new HashMap<>(8);
+        Map<String, ColumnMeta> pkMetaMap = getTableMeta().getPrimaryKeyMap();
+        String autoColumnName = "";
+        for (String pkColumnName : pkMetaMap.keySet()) {
+            if (pkMetaMap.get(pkColumnName).isAutoincrement())
+            {
+                autoColumnName = pkColumnName;
+                break;
+            }
+        }
+        if (StringUtils.isBlank(autoColumnName))
+        {
+            throw new ShouldNeverHappenException();
+        }
+
+        ResultSet genKeys;
+        try {
+            genKeys = statementProxy.getGeneratedKeys();
+        } catch (SQLException e) {
+            // java.sql.SQLException: Generated keys not requested. You need to
+            // specify Statement.RETURN_GENERATED_KEYS to
+            // Statement.executeUpdate() or Connection.prepareStatement().
+            if (ERR_SQL_STATE.equalsIgnoreCase(e.getSQLState())) {
+                LOGGER.warn("Fail to get auto-generated keys, use 'SELECT LAST_INSERT_ID()' instead. Be cautious, statement could be polluted. Recommend you set the statement to return generated keys.");
+                genKeys = statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
+            } else {
+                throw e;
+            }
+        }
+        List<Object> pkValues = new ArrayList<>();
+        while (genKeys.next()) {
+            Object v = genKeys.getObject(1);
+            pkValues.add(v);
+        }
+        try {
+            genKeys.beforeFirst();
+        } catch (SQLException e) {
+            LOGGER.warn("Fail to reset ResultSet cursor. can not get primary key value");
+        }
+        pkValuesMap.put(autoColumnName,pkValues);
+        return pkValuesMap;
+    }
+
+    @Override
+    public Map<String,List<Object>> getPkValuesByColumn() throws SQLException {
+        Map<String,List<Object>> pkValuesMap  = parsePkValuesFromStatement();
+        Set<String> keySet = new HashSet<>(pkValuesMap.keySet());
+        //auto increment
+        for (String pkKey:keySet) {
+            List<Object> pkValues = pkValuesMap.get(pkKey);
+            // pk auto generated while single insert primary key is expression
+            if (pkValues.size() == 1 && (pkValues.get(0) instanceof SqlMethodExpr)) {
+                pkValuesMap.putAll(getPkValuesByAuto());
+            }
+            // pk auto generated while column exists and value is null
+            else if (!pkValues.isEmpty() && pkValues.get(0) instanceof Null) {
+                pkValuesMap.putAll(getPkValuesByAuto());
+            }
+        }
+        return pkValuesMap;
+    }
+
+    @Override
+    public List<Object> getPkValuesByDefault() throws SQLException {
+        // mysql default keyword the logic not support. (sample: insert into test(id, name) values(default, 'xx'))
+        throw new NotSupportYetException();
+    }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/SQLServerTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/SQLServerTableMetaCache.java
@@ -1,0 +1,196 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.sql.struct.cache;
+
+import io.seata.common.exception.ShouldNeverHappenException;
+import io.seata.common.loader.LoadLevel;
+import io.seata.rm.datasource.ColumnUtils;
+import io.seata.rm.datasource.sql.struct.ColumnMeta;
+import io.seata.rm.datasource.sql.struct.IndexMeta;
+import io.seata.rm.datasource.sql.struct.IndexType;
+import io.seata.rm.datasource.sql.struct.TableMeta;
+import io.seata.rm.datasource.undo.KeywordChecker;
+import io.seata.rm.datasource.undo.KeywordCheckerFactory;
+import io.seata.sqlparser.util.JdbcConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.*;
+
+/**
+ * The type Table meta cache.
+ *
+ * @author Paranoia
+ */
+@LoadLevel(name = JdbcConstants.SQLSERVER)
+public class SQLServerTableMetaCache extends AbstractTableMetaCache {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SQLServerTableMetaCache.class);
+
+    private static KeywordChecker keywordChecker = KeywordCheckerFactory.getKeywordChecker(JdbcConstants.SQLSERVER);
+
+    @Override
+    protected String getCacheKey(Connection connection, String tableName, String resourceId) {
+        StringBuilder cacheKey = new StringBuilder(resourceId);
+        cacheKey.append(".");
+        //remove single quote and separate it to catalogName and tableName
+        String[] tableNameWithCatalog = tableName.replace("`", "").split("\\.");
+        String defaultTableName = tableNameWithCatalog.length > 1 ? tableNameWithCatalog[1] : tableNameWithCatalog[0];
+
+        DatabaseMetaData databaseMetaData = null;
+        try {
+            databaseMetaData = connection.getMetaData();
+        } catch (SQLException e) {
+            LOGGER.error("Could not get connection, use default cache key {}", e.getMessage(), e);
+            return cacheKey.append(defaultTableName).toString();
+        }
+
+        try {
+            //prevent duplicated cache key
+            if (databaseMetaData.supportsMixedCaseIdentifiers()) {
+                cacheKey.append(defaultTableName);
+            } else {
+                cacheKey.append(defaultTableName.toLowerCase());
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Could not get supportsMixedCaseIdentifiers in connection metadata, use default cache key {}", e.getMessage(), e);
+            return cacheKey.append(defaultTableName).toString();
+        }
+
+        return cacheKey.toString();
+    }
+
+    @Override
+    protected TableMeta fetchSchema(Connection connection, String tableName) throws SQLException {
+        String sql = "SELECT TOP 1 * FROM " + ColumnUtils.addEscape(tableName, JdbcConstants.SQLSERVER);
+
+        try{
+            String schemaName = getSchemaName(connection);
+            String catalogName = getCatalogName(connection);
+            Statement stmt = connection.createStatement();
+            ResultSet rs = stmt.executeQuery(sql);
+            return resultSetMetaToSchema(schemaName, catalogName, ColumnUtils.addEscape(tableName, JdbcConstants.SQLSERVER), rs.getMetaData(), connection.getMetaData());
+        }
+        catch (SQLException sqlEx) {
+            throw sqlEx;
+        }
+        catch (Exception e) {
+            throw new SQLException(String.format("Failed to fetch schema of %s", tableName), e);
+        }
+    }
+
+    private String getCatalogName(Connection connection) throws SQLException {
+        String sql = "SELECT DB_NAME()";
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(sql);
+        rs.next();
+        return rs.getString(1);
+    }
+
+    private String getSchemaName(Connection connection) throws SQLException {
+        String sql = "select SCHEMA_NAME()";
+        Statement stmt = connection.createStatement();
+        ResultSet rs = stmt.executeQuery(sql);
+        rs.next();
+        return rs.getString(1);
+    }
+
+    private TableMeta resultSetMetaToSchema(String schemaName, String catalogName, String tableName, ResultSetMetaData rsmd, DatabaseMetaData dbmd)
+            throws SQLException {
+        /*
+         * use ResultSetMetaData to get the pure table name
+         * can avoid the problem below
+         *
+         * select * from account_tbl
+         * select * from account_TBL
+         * select * from `account_tbl`
+         * select * from account.account_tbl
+         */
+//        String tableName = rsmd.getTableName(1);
+
+        TableMeta tm = new TableMeta();
+        tm.setTableName(tableName);
+
+        /*
+         * here has two different type to get the data
+         * make sure the table name was right
+         * 1. show full columns from xxx from xxx(normal)
+         * 2. select xxx from xxx where catalog_name like ? and table_name like ?(informationSchema=true)
+         */
+
+        try (ResultSet rsColumns = dbmd.getColumns(catalogName, schemaName, tableName, "%");
+             ResultSet rsIndex = dbmd.getIndexInfo(catalogName, schemaName, tableName, false, true)) {
+            while (rsColumns.next()) {
+                ColumnMeta col = new ColumnMeta();
+                col.setTableCat(rsColumns.getString("TABLE_CAT"));
+                col.setTableSchemaName(rsColumns.getString("TABLE_SCHEM"));
+                col.setTableName(rsColumns.getString("TABLE_NAME"));
+                col.setColumnName(rsColumns.getString("COLUMN_NAME"));
+                col.setDataType(rsColumns.getInt("DATA_TYPE"));
+                col.setDataTypeName(rsColumns.getString("TYPE_NAME"));
+                col.setColumnSize(rsColumns.getInt("COLUMN_SIZE"));
+                col.setDecimalDigits(rsColumns.getInt("DECIMAL_DIGITS"));
+                col.setNumPrecRadix(rsColumns.getInt("NUM_PREC_RADIX"));
+                col.setNullAble(rsColumns.getInt("NULLABLE"));
+                col.setRemarks(rsColumns.getString("REMARKS"));
+                col.setColumnDef(rsColumns.getString("COLUMN_DEF"));
+                col.setSqlDataType(rsColumns.getInt("SQL_DATA_TYPE"));
+                col.setSqlDatetimeSub(rsColumns.getInt("SQL_DATETIME_SUB"));
+                col.setCharOctetLength(rsColumns.getInt("CHAR_OCTET_LENGTH"));
+                col.setOrdinalPosition(rsColumns.getInt("ORDINAL_POSITION"));
+                col.setIsNullAble(rsColumns.getString("IS_NULLABLE"));
+                col.setIsAutoincrement(rsColumns.getString("IS_AUTOINCREMENT"));
+
+                tm.getAllColumns().put(col.getColumnName(), col);
+            }
+
+            while (rsIndex.next()) {
+                String indexName = rsIndex.getString("INDEX_NAME");
+                String colName = rsIndex.getString("COLUMN_NAME");
+                ColumnMeta col = tm.getAllColumns().get(colName);
+
+                if (tm.getAllIndexes().containsKey(indexName)) {
+                    IndexMeta index = tm.getAllIndexes().get(indexName);
+                    index.getValues().add(col);
+                } else {
+                    IndexMeta index = new IndexMeta();
+                    index.setIndexName(indexName);
+                    index.setNonUnique(rsIndex.getBoolean("NON_UNIQUE"));
+                    index.setIndexQualifier(rsIndex.getString("INDEX_QUALIFIER"));
+                    index.setIndexName(rsIndex.getString("INDEX_NAME"));
+                    index.setType(rsIndex.getShort("TYPE"));
+                    index.setOrdinalPosition(rsIndex.getShort("ORDINAL_POSITION"));
+                    index.setAscOrDesc(rsIndex.getString("ASC_OR_DESC"));
+                    index.setCardinality(rsIndex.getInt("CARDINALITY"));
+                    index.getValues().add(col);
+                    if (indexName != null && indexName.startsWith("PK")) {
+                        index.setIndextype(IndexType.PRIMARY);
+                    } else if (!index.isNonUnique()) {
+                        index.setIndextype(IndexType.UNIQUE);
+                    } else {
+                        index.setIndextype(IndexType.NORMAL);
+                    }
+                    tm.getAllIndexes().put(indexName, index);
+
+                }
+            }
+            if (tm.getAllIndexes().isEmpty()) {
+                throw new ShouldNeverHappenException("Could not found any index in the table: " + tableName);
+            }
+        }
+        return tm;
+    }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoDeleteExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoDeleteExecutor.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo.sqlserver;
+
+import io.seata.common.exception.ShouldNeverHappenException;
+import io.seata.common.util.CollectionUtils;
+import io.seata.rm.datasource.ColumnUtils;
+import io.seata.rm.datasource.sql.struct.Field;
+import io.seata.rm.datasource.sql.struct.Row;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import io.seata.rm.datasource.undo.AbstractUndoExecutor;
+import io.seata.rm.datasource.undo.SQLUndoLog;
+import io.seata.sqlparser.util.JdbcConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The type SQLServer undo delete executor.
+ *
+ * @author Paranoia
+ */
+public class SQLServerUndoDeleteExecutor extends AbstractUndoExecutor {
+
+    /**
+     * Instantiates a new My sql undo delete executor.
+     *
+     * @param sqlUndoLog the sql undo log
+     */
+    public SQLServerUndoDeleteExecutor(SQLUndoLog sqlUndoLog) {
+        super(sqlUndoLog);
+    }
+
+    /**
+     * INSERT INTO a (x, y, z, pk) VALUES (?, ?, ?, ?)
+     */
+    private static final String INSERT_SQL_TEMPLATE = "INSERT INTO %s (%s) VALUES (%s)";
+
+    /**
+     * Undo delete.
+     *
+     * Notice: PK is at last one.
+     * @see AbstractUndoExecutor#undoPrepare
+     *
+     * @return sql
+     */
+    @Override
+    protected String buildUndoSQL() {
+        TableRecords beforeImage = sqlUndoLog.getBeforeImage();
+        List<Row> beforeImageRows = beforeImage.getRows();
+        if (CollectionUtils.isEmpty(beforeImageRows)) {
+            throw new ShouldNeverHappenException("Invalid UNDO LOG");
+        }
+        Row row = beforeImageRows.get(0);
+        List<Field> fields = new ArrayList<>(row.nonPrimaryKeys());
+        Field pkField = row.primaryKeys().get(0);
+        // PK is at last one.
+        fields.add(pkField);
+
+        // delete sql undo log before image all field come from table meta, need add escape.
+        // see BaseTransactionalExecutor#buildTableRecords
+        String insertColumns = fields.stream()
+                .map(field -> ColumnUtils.addEscape(field.getName(), JdbcConstants.SQLSERVER))
+                .collect(Collectors.joining(", "));
+        String insertValues = fields.stream().map(field -> "?")
+                .collect(Collectors.joining(", "));
+
+        return String.format(INSERT_SQL_TEMPLATE, sqlUndoLog.getTableName(), insertColumns, insertValues);
+    }
+
+    @Override
+    protected TableRecords getUndoRows() {
+        return sqlUndoLog.getBeforeImage();
+    }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoDeleteExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoDeleteExecutor.java
@@ -67,9 +67,7 @@ public class SQLServerUndoDeleteExecutor extends AbstractUndoExecutor {
         }
         Row row = beforeImageRows.get(0);
         List<Field> fields = new ArrayList<>(row.nonPrimaryKeys());
-        Field pkField = row.primaryKeys().get(0);
-        // PK is at last one.
-        fields.add(pkField);
+        fields.addAll(getOrderedPkList(beforeImage,row, JdbcConstants.SQLSERVER));
 
         // delete sql undo log before image all field come from table meta, need add escape.
         // see BaseTransactionalExecutor#buildTableRecords

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoExecutorHolder.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoExecutorHolder.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo.sqlserver;
+
+import io.seata.common.loader.LoadLevel;
+import io.seata.rm.datasource.undo.AbstractUndoExecutor;
+import io.seata.rm.datasource.undo.SQLUndoLog;
+import io.seata.rm.datasource.undo.UndoExecutorHolder;
+import io.seata.sqlparser.util.JdbcConstants;
+
+/**
+ * The Type MySQLUndoExecutorHolder
+ *
+ * @author: Zhibei Hao
+ */
+@LoadLevel(name = JdbcConstants.SQLSERVER)
+public class SQLServerUndoExecutorHolder implements UndoExecutorHolder {
+
+    @Override
+    public AbstractUndoExecutor getInsertExecutor(SQLUndoLog sqlUndoLog) {
+        return new SQLServerUndoInsertExecutor(sqlUndoLog);
+    }
+
+    @Override
+    public AbstractUndoExecutor getUpdateExecutor(SQLUndoLog sqlUndoLog) {
+        return new SQLServerUndoUpdateExecutor(sqlUndoLog);
+    }
+
+    @Override
+    public AbstractUndoExecutor getDeleteExecutor(SQLUndoLog sqlUndoLog) {
+        return new SQLServerUndoDeleteExecutor(sqlUndoLog);
+    }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoInsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoInsertExecutor.java
@@ -23,6 +23,8 @@ import io.seata.rm.datasource.sql.struct.Field;
 import io.seata.rm.datasource.sql.struct.Row;
 import io.seata.rm.datasource.sql.struct.TableRecords;
 import io.seata.rm.datasource.undo.AbstractUndoExecutor;
+import io.seata.rm.datasource.undo.KeywordChecker;
+import io.seata.rm.datasource.undo.KeywordCheckerFactory;
 import io.seata.rm.datasource.undo.SQLUndoLog;
 import io.seata.sqlparser.util.JdbcConstants;
 
@@ -56,12 +58,7 @@ public class SQLServerUndoInsertExecutor extends AbstractUndoExecutor {
         if (CollectionUtils.isEmpty(afterImageRows)) {
             throw new ShouldNeverHappenException("Invalid UNDO LOG");
         }
-        Row row = afterImageRows.get(0);
-        Field pkField = row.primaryKeys().get(0);
-        // insert sql undo log after image all field come from table meta, need add escape.
-        // see BaseTransactionalExecutor#buildTableRecords
-        return String.format(DELETE_SQL_TEMPLATE, sqlUndoLog.getTableName(),
-                ColumnUtils.addEscape(pkField.getName(), JdbcConstants.SQLSERVER));
+        return generateDeleteSql(afterImageRows,afterImage);
     }
 
     @Override
@@ -72,6 +69,13 @@ public class SQLServerUndoInsertExecutor extends AbstractUndoExecutor {
             undoIndex++;
             undoPST.setObject(undoIndex, pkField.getValue(), pkField.getType());
         }
+    }
+
+    private String generateDeleteSql(List<Row> rows, TableRecords afterImage) {
+        List<String> pkNameList = getOrderedPkList(afterImage, rows.get(0), JdbcConstants.SQLSERVER).stream().map(
+                e -> e.getName()).collect(Collectors.toList());
+        String whereSql = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList, JdbcConstants.SQLSERVER);
+        return String.format(DELETE_SQL_TEMPLATE, sqlUndoLog.getTableName(), whereSql);
     }
 
     /**

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoInsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoInsertExecutor.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo.sqlserver;
+
+import io.seata.common.exception.ShouldNeverHappenException;
+import io.seata.common.util.CollectionUtils;
+import io.seata.rm.datasource.ColumnUtils;
+import io.seata.rm.datasource.SqlGenerateUtils;
+import io.seata.rm.datasource.sql.struct.Field;
+import io.seata.rm.datasource.sql.struct.Row;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import io.seata.rm.datasource.undo.AbstractUndoExecutor;
+import io.seata.rm.datasource.undo.SQLUndoLog;
+import io.seata.sqlparser.util.JdbcConstants;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The type SQLServer undo insert executor.
+ *
+ * @author Paranoia
+ */
+public class SQLServerUndoInsertExecutor extends AbstractUndoExecutor {
+
+    /**
+     * DELETE FROM a WHERE pk = ?
+     */
+    private static final String DELETE_SQL_TEMPLATE = "DELETE FROM %s WHERE %s ";
+
+    /**
+     * Undo Inset.
+     *
+     * @return sql
+     */
+    @Override
+    protected String buildUndoSQL() {
+        TableRecords afterImage = sqlUndoLog.getAfterImage();
+        List<Row> afterImageRows = afterImage.getRows();
+        if (CollectionUtils.isEmpty(afterImageRows)) {
+            throw new ShouldNeverHappenException("Invalid UNDO LOG");
+        }
+        Row row = afterImageRows.get(0);
+        Field pkField = row.primaryKeys().get(0);
+        // insert sql undo log after image all field come from table meta, need add escape.
+        // see BaseTransactionalExecutor#buildTableRecords
+        return String.format(DELETE_SQL_TEMPLATE, sqlUndoLog.getTableName(),
+                ColumnUtils.addEscape(pkField.getName(), JdbcConstants.SQLSERVER));
+    }
+
+    @Override
+    protected void undoPrepare(PreparedStatement undoPST, ArrayList<Field> undoValues, List<Field> pkValueList)
+            throws SQLException {
+        int undoIndex = 0;
+        for (Field pkField:pkValueList) {
+            undoIndex++;
+            undoPST.setObject(undoIndex, pkField.getValue(), pkField.getType());
+        }
+    }
+
+    /**
+     * Instantiates a new sqlserver undo insert executor.
+     *
+     * @param sqlUndoLog the sql undo log
+     */
+    public SQLServerUndoInsertExecutor(SQLUndoLog sqlUndoLog) {
+        super(sqlUndoLog);
+    }
+
+    @Override
+    protected TableRecords getUndoRows() {
+        return sqlUndoLog.getAfterImage();
+    }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoLogManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoLogManager.java
@@ -1,0 +1,250 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo.sqlserver;
+
+import io.seata.common.loader.LoadLevel;
+import io.seata.common.util.BlobUtils;
+import io.seata.core.constants.ClientTableColumnsName;
+import io.seata.core.exception.BranchTransactionException;
+import io.seata.core.exception.TransactionException;
+import io.seata.rm.datasource.DataSourceProxy;
+import io.seata.rm.datasource.sql.struct.TableMeta;
+import io.seata.rm.datasource.sql.struct.TableMetaCacheFactory;
+import io.seata.rm.datasource.undo.*;
+import io.seata.sqlparser.util.JdbcConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static io.seata.core.exception.TransactionExceptionCode.BranchRollbackFailed_Retriable;
+
+/**
+ * @author Paranoia
+ */
+@LoadLevel(name = JdbcConstants.SQLSERVER)
+public class SQLServerUndoLogManager extends AbstractUndoLogManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SQLServerUndoLogManager.class);
+
+    /**
+     * branch_id, xid, context, rollback_info, log_status, log_created, log_modified
+     */
+    private static final String INSERT_UNDO_LOG_SQL = "INSERT INTO " + UNDO_LOG_TABLE_NAME +
+            " (" + ClientTableColumnsName.UNDO_LOG_BRANCH_XID + ", " + ClientTableColumnsName.UNDO_LOG_XID + ", "
+            + ClientTableColumnsName.UNDO_LOG_CONTEXT + ", " + ClientTableColumnsName.UNDO_LOG_ROLLBACK_INFO + ", "
+            + ClientTableColumnsName.UNDO_LOG_LOG_STATUS + ", " + ClientTableColumnsName.UNDO_LOG_LOG_CREATED + ", "
+            + ClientTableColumnsName.UNDO_LOG_LOG_MODIFIED + ")" +
+            " VALUES (?, ?, ?, ?, ?, CONVERT(BIGINT, DATEDIFF(S,'1970-01-01 00:00:00', GETDATE())), CONVERT(BIGINT, DATEDIFF(S,'1970-01-01 00:00:00', GETDATE())))";
+
+    private static final String DELETE_UNDO_LOG_BY_CREATE_SQL = "DELETE FROM " + UNDO_LOG_TABLE_NAME +
+            " WHERE id IN (SELECT top ? id FROM " + UNDO_LOG_TABLE_NAME + " WHERE log_created <= ?)";
+
+    private static final String SELECT_UNDO_LOG_SQL_FOR_SQLSERVER = "SELECT * FROM " + UNDO_LOG_TABLE_NAME
+            + " WITH (ROWLOCK,UPDLOCK)"
+            + " WHERE " + ClientTableColumnsName.UNDO_LOG_BRANCH_XID + " = ? AND "
+            + ClientTableColumnsName.UNDO_LOG_XID + " = ?";
+
+    @Override
+    public int deleteUndoLogByLogCreated(Date logCreated, int limitRows, Connection conn) throws SQLException {
+        try (PreparedStatement deletePST = conn.prepareStatement(DELETE_UNDO_LOG_BY_CREATE_SQL)) {
+            deletePST.setDate(1, new java.sql.Date(logCreated.getTime()));
+            deletePST.setInt(2, limitRows);
+            int deleteRows = deletePST.executeUpdate();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("batch delete undo log size {}", deleteRows);
+            }
+            return deleteRows;
+        } catch (Exception e) {
+            if (!(e instanceof SQLException)) {
+                e = new SQLException(e);
+            }
+            throw (SQLException) e;
+        }
+    }
+
+    @Override
+    protected void insertUndoLogWithNormal(String xid, long branchId, String rollbackCtx,
+                                           byte[] undoLogContent, Connection conn) throws SQLException {
+        insertUndoLog(xid, branchId, rollbackCtx, undoLogContent, State.Normal, conn);
+    }
+
+    @Override
+    protected byte[] getRollbackInfo(ResultSet rs) throws SQLException {
+        Blob b = rs.getBlob(ClientTableColumnsName.UNDO_LOG_ROLLBACK_INFO);
+        byte[] rollbackInfo = BlobUtils.blob2Bytes(b);
+        return rollbackInfo;
+    }
+
+    @Override
+    protected void insertUndoLogWithGlobalFinished(String xid, long branchId, UndoLogParser parser, Connection conn) throws SQLException {
+        insertUndoLog(xid, branchId, buildContext(parser.getName()),
+                parser.getDefaultContent(), State.GlobalFinished, conn);
+    }
+
+    private void insertUndoLog(String xid, long branchId, String rollbackCtx,
+                               byte[] undoLogContent, State state, Connection conn) throws SQLException {
+        try (PreparedStatement pst = conn.prepareStatement(INSERT_UNDO_LOG_SQL)) {
+            pst.setLong(1, branchId);
+            pst.setString(2, xid);
+            pst.setString(3, rollbackCtx);
+            pst.setBlob(4, BlobUtils.bytes2Blob(undoLogContent));
+            pst.setInt(5, state.getValue());
+            pst.executeUpdate();
+        } catch (Exception e) {
+            if (!(e instanceof SQLException)) {
+                e = new SQLException(e);
+            }
+            throw (SQLException) e;
+        }
+    }
+
+    @Override
+    public void undo(DataSourceProxy dataSourceProxy, String xid, long branchId) throws TransactionException {
+        Connection conn = null;
+        ResultSet rs = null;
+        PreparedStatement selectPST = null;
+        boolean originalAutoCommit = true;
+
+        for (; ; ) {
+            try {
+                conn = dataSourceProxy.getPlainConnection();
+
+                // The entire undo process should run in a local transaction.
+                if (originalAutoCommit = conn.getAutoCommit()) {
+                    conn.setAutoCommit(false);
+                }
+
+                // Find UNDO LOG
+                selectPST = conn.prepareStatement(SELECT_UNDO_LOG_SQL_FOR_SQLSERVER);
+                selectPST.setLong(1, branchId);
+                selectPST.setString(2, xid);
+                rs = selectPST.executeQuery();
+
+                boolean exists = false;
+                while (rs.next()) {
+                    exists = true;
+
+                    // It is possible that the server repeatedly sends a rollback request to roll back
+                    // the same branch transaction to multiple processes,
+                    // ensuring that only the undo_log in the normal state is processed.
+                    int state = rs.getInt(ClientTableColumnsName.UNDO_LOG_LOG_STATUS);
+                    if (!canUndo(state)) {
+                        if (LOGGER.isInfoEnabled()) {
+                            LOGGER.info("xid {} branch {}, ignore {} undo_log", xid, branchId, state);
+                        }
+                        return;
+                    }
+
+                    String contextString = rs.getString(ClientTableColumnsName.UNDO_LOG_CONTEXT);
+                    Map<String, String> context = parseContext(contextString);
+                    byte[] rollbackInfo = getRollbackInfo(rs);
+
+                    String serializer = context == null ? null : context.get(UndoLogConstants.SERIALIZER_KEY);
+                    UndoLogParser parser = serializer == null ? UndoLogParserFactory.getInstance()
+                            : UndoLogParserFactory.getInstance(serializer);
+                    BranchUndoLog branchUndoLog = parser.decode(rollbackInfo);
+
+                    try {
+                        // put serializer name to local
+                        setCurrentSerializer(parser.getName());
+                        List<SQLUndoLog> sqlUndoLogs = branchUndoLog.getSqlUndoLogs();
+                        if (sqlUndoLogs.size() > 1) {
+                            Collections.reverse(sqlUndoLogs);
+                        }
+                        for (SQLUndoLog sqlUndoLog : sqlUndoLogs) {
+                            TableMeta tableMeta = TableMetaCacheFactory.getTableMetaCache(dataSourceProxy.getDbType()).getTableMeta(
+                                    conn, sqlUndoLog.getTableName(), dataSourceProxy.getResourceId());
+                            sqlUndoLog.setTableMeta(tableMeta);
+                            AbstractUndoExecutor undoExecutor = UndoExecutorFactory.getUndoExecutor(
+                                    dataSourceProxy.getDbType(), sqlUndoLog);
+                            undoExecutor.executeOn(conn);
+                        }
+                    } finally {
+                        // remove serializer name
+                        removeCurrentSerializer();
+                    }
+                }
+
+                // If undo_log exists, it means that the branch transaction has completed the first phase,
+                // we can directly roll back and clean the undo_log
+                // Otherwise, it indicates that there is an exception in the branch transaction,
+                // causing undo_log not to be written to the database.
+                // For example, the business processing timeout, the global transaction is the initiator rolls back.
+                // To ensure data consistency, we can insert an undo_log with GlobalFinished state
+                // to prevent the local transaction of the first phase of other programs from being correctly submitted.
+                // See https://github.com/seata/seata/issues/489
+
+                if (exists) {
+                    deleteUndoLog(xid, branchId, conn);
+                    conn.commit();
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("xid {} branch {}, undo_log deleted with {}", xid, branchId,
+                                State.GlobalFinished.name());
+                    }
+                } else {
+                    insertUndoLogWithGlobalFinished(xid, branchId, UndoLogParserFactory.getInstance(), conn);
+                    conn.commit();
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("xid {} branch {}, undo_log added with {}", xid, branchId,
+                                State.GlobalFinished.name());
+                    }
+                }
+
+                return;
+            } catch (SQLIntegrityConstraintViolationException e) {
+                // Possible undo_log has been inserted into the database by other processes, retrying rollback undo_log
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("xid {} branch {}, undo_log inserted, retry rollback", xid, branchId);
+                }
+            } catch (Throwable e) {
+                if (conn != null) {
+                    try {
+                        conn.rollback();
+                    } catch (SQLException rollbackEx) {
+                        LOGGER.warn("Failed to close JDBC resource while undo ... ", rollbackEx);
+                    }
+                }
+                throw new BranchTransactionException(BranchRollbackFailed_Retriable, String
+                        .format("Branch session rollback failed and try again later xid = %s branchId = %s %s", xid,
+                                branchId, e.getMessage()), e);
+
+            } finally {
+                try {
+                    if (rs != null) {
+                        rs.close();
+                    }
+                    if (selectPST != null) {
+                        selectPST.close();
+                    }
+                    if (conn != null) {
+                        if (originalAutoCommit) {
+                            conn.setAutoCommit(true);
+                        }
+                        conn.close();
+                    }
+                } catch (SQLException closeEx) {
+                    LOGGER.warn("Failed to close JDBC resource while undo ... ", closeEx);
+                }
+            }
+        }
+    }
+
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoUpdateExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/SQLServerUndoUpdateExecutor.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo.sqlserver;
+
+import io.seata.common.exception.ShouldNeverHappenException;
+import io.seata.common.util.CollectionUtils;
+import io.seata.rm.datasource.ColumnUtils;
+import io.seata.rm.datasource.SqlGenerateUtils;
+import io.seata.rm.datasource.sql.struct.Field;
+import io.seata.rm.datasource.sql.struct.Row;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import io.seata.rm.datasource.undo.AbstractUndoExecutor;
+import io.seata.rm.datasource.undo.SQLUndoLog;
+import io.seata.sqlparser.util.JdbcConstants;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The type SQLServer undo update executor.
+ *
+ * @author Paranoia
+ */
+public class SQLServerUndoUpdateExecutor extends AbstractUndoExecutor {
+
+    /**
+     * UPDATE a SET x = ?, y = ?, z = ? WHERE pk1 in (?) pk2 in (?)
+     */
+    private static final String UPDATE_SQL_TEMPLATE = "UPDATE %s SET %s WHERE %s ";
+
+    /**
+     * Undo Update.
+     *
+     * @return sql
+     */
+    @Override
+    protected String buildUndoSQL() {
+        TableRecords beforeImage = sqlUndoLog.getBeforeImage();
+        List<Row> beforeImageRows = beforeImage.getRows();
+        if (CollectionUtils.isEmpty(beforeImageRows)) {
+            throw new ShouldNeverHappenException("Invalid UNDO LOG"); // TODO
+        }
+        Row row = beforeImageRows.get(0);
+
+        List<Field> nonPkFields = row.nonPrimaryKeys();
+        // update sql undo log before image all field come from table meta. need add escape.
+        // see BaseTransactionalExecutor#buildTableRecords
+        String updateColumns = nonPkFields.stream().map(
+            field -> ColumnUtils.addEscape(field.getName(), JdbcConstants.SQLSERVER) + " = ?").collect(
+            Collectors.joining(", "));
+
+        List<String> pkNameList = getOrderedPkList(beforeImage, row, JdbcConstants.SQLSERVER).stream().map(e -> e.getName())
+            .collect(Collectors.toList());
+        String whereSql = SqlGenerateUtils.buildWhereConditionByPKs(pkNameList, JdbcConstants.SQLSERVER);
+
+        return String.format(UPDATE_SQL_TEMPLATE, sqlUndoLog.getTableName(), updateColumns, whereSql);
+    }
+
+    /**
+     * Instantiates a new My sql undo update executor.
+     *
+     * @param sqlUndoLog the sql undo log
+     */
+    public SQLServerUndoUpdateExecutor(SQLUndoLog sqlUndoLog) {
+        super(sqlUndoLog);
+    }
+
+    @Override
+    protected TableRecords getUndoRows() {
+        return sqlUndoLog.getBeforeImage();
+    }
+}

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/keyword/SQLServerKeywordChecker.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/sqlserver/keyword/SQLServerKeywordChecker.java
@@ -1,0 +1,772 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm.datasource.undo.sqlserver.keyword;
+
+import io.seata.common.loader.LoadLevel;
+import io.seata.rm.datasource.undo.KeywordChecker;
+import io.seata.sqlparser.util.JdbcConstants;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The type SQLServer keyword checker.
+ *
+ * @author xingfudeshi@gmail.com
+ */
+@LoadLevel(name = JdbcConstants.SQLSERVER)
+public class SQLServerKeywordChecker implements KeywordChecker {
+
+    private Set<String> keywordSet = Arrays.stream(SQLServerKeywordChecker.SQLServerKeyword.values()).map(SQLServerKeyword::name).collect(Collectors.toSet());
+
+    /**
+     * sqlserver keyword
+     */
+    private enum SQLServerKeyword {
+        /**
+         * ADD is sqlserver keyword.
+         */
+        ADD("ADD"),
+        /**
+         * ALL is sqlserver keyword.
+         */
+        ALL("ALL"),
+        /**
+         * ALTER is sqlserver keyword.
+         */
+        ALTER("ALTER"),
+        /**
+         * AND is sqlserver keyword.
+         */
+        AND("AND"),
+        /**
+         * ANY is sqlserver keyword.
+         */
+        ANY("ANY"),
+        /**
+         * AS is sqlserver keyword.
+         */
+        AS("AS"),
+        /**
+         * ASC is sqlserver keyword.
+         */
+        ASC("ASC"),
+        /**
+         * AUTHORIZATION is sqlserver keyword.
+         */
+        AUTHORIZATION("AUTHORIZATION"),
+        /**
+         * BACKUP is sqlserver keyword.
+         */
+        BACKUP("BACKUP"),
+        /**
+         * BEGIN is sqlserver keyword.
+         */
+        BEGIN("BEGIN"),
+        /**
+         * BETWEEN is sqlserver keyword.
+         */
+        BETWEEN("BETWEEN"),
+        /**
+         * BREAK is sqlserver keyword.
+         */
+        BREAK("BREAK"),
+        /**
+         * BROWSE is sqlserver keyword.
+         */
+        BROWSE("BROWSE"),
+        /**
+         * BULK is sqlserver keyword.
+         */
+        BULK("BULK"),
+        /**
+         * BY is sqlserver keyword.
+         */
+        BY("BY"),
+        /**
+         * CASCADE is sqlserver keyword.
+         */
+        CASCADE("CASCADE"),
+        /**
+         * CASE is sqlserver keyword.
+         */
+        CASE("CASE"),
+        /**
+         * CHECK is sqlserver keyword.
+         */
+        CHECK("CHECK"),
+        /**
+         * CHECKPOINT is sqlserver keyword.
+         */
+        CHECKPOINT("CHECKPOINT"),
+        /**
+         * CLOSE is sqlserver keyword.
+         */
+        CLOSE("CLOSE"),
+        /**
+         * CLUSTERED is sqlserver keyword.
+         */
+        CLUSTERED("CLUSTERED"),
+        /**
+         * COALESCE is sqlserver keyword.
+         */
+        COALESCE("COALESCE"),
+        /**
+         * COLLATE is sqlserver keyword.
+         */
+        COLLATE("COLLATE"),
+        /**
+         * COLUMN is sqlserver keyword.
+         */
+        COLUMN("COLUMN"),
+        /**
+         * COMMIT is sqlserver keyword.
+         */
+        COMMIT("COMMIT"),
+        /**
+         * COMPUTE is sqlserver keyword.
+         */
+        COMPUTE("COMPUTE"),
+        /**
+         * CONSTRAINT is sqlserver keyword.
+         */
+        CONSTRAINT("CONSTRAINT"),
+        /**
+         * CONTAINS is sqlserver keyword.
+         */
+        CONTAINS("CONTAINS"),
+        /**
+         * CONTAINSTABLE is sqlserver keyword.
+         */
+        CONTAINSTABLE("CONTAINSTABLE"),
+        /**
+         * CONTINUE is sqlserver keyword.
+         */
+        CONTINUE("CONTINUE"),
+        /**
+         * CONVERT is sqlserver keyword.
+         */
+        CONVERT("CONVERT"),
+        /**
+         * CREATE is sqlserver keyword.
+         */
+        CREATE("CREATE"),
+        /**
+         * CROSS is sqlserver keyword.
+         */
+        CROSS("CROSS"),
+        /**
+         * CURRENT is sqlserver keyword.
+         */
+        CURRENT("CURRENT"),
+        /**
+         * CURRENT_DATE is sqlserver keyword.
+         */
+        CURRENT_DATE("CURRENT_DATE"),
+        /**
+         * CURRENT_TIME is sqlserver keyword.
+         */
+        CURRENT_TIME("CURRENT_TIME"),
+        /**
+         * CURRENT_TIMESTAMP is sqlserver keyword.
+         */
+        CURRENT_TIMESTAMP("CURRENT_TIMESTAMP"),
+        /**
+         * CURRENT_USER is sqlserver keyword.
+         */
+        CURRENT_USER("CURRENT_USER"),
+        /**
+         * CURSOR is sqlserver keyword.
+         */
+        CURSOR("CURSOR"),
+        /**
+         * DATABASE is sqlserver keyword.
+         */
+        DATABASE("DATABASE"),
+        /**
+         * DBCC is sqlserver keyword.
+         */
+        DBCC("DBCC"),
+        /**
+         * DEALLOCATE is sqlserver keyword.
+         */
+        DEALLOCATE("DEALLOCATE"),
+        /**
+         * DECLARE is sqlserver keyword.
+         */
+        DECLARE("DECLARE"),
+        /**
+         * DEFAULT is sqlserver keyword.
+         */
+        DEFAULT("DEFAULT"),
+        /**
+         * DELETE is sqlserver keyword.
+         */
+        DELETE("DELETE"),
+        /**
+         * DENY is sqlserver keyword.
+         */
+        DENY("DENY"),
+        /**
+         * DESC is sqlserver keyword.
+         */
+        DESC("DESC"),
+        /**
+         * DISK is sqlserver keyword.
+         */
+        DISK("DISK"),
+        /**
+         * DISTINCT is sqlserver keyword.
+         */
+        DISTINCT("DISTINCT"),
+        /**
+         * DISTRIBUTED is sqlserver keyword.
+         */
+        DISTRIBUTED("DISTRIBUTED"),
+        /**
+         * DOUBLE is sqlserver keyword.
+         */
+        DOUBLE("DOUBLE"),
+        /**
+         * DROP is sqlserver keyword.
+         */
+        DROP("DROP"),
+        /**
+         * DUMMY is sqlserver keyword.
+         */
+        DUMMY("DUMMY"),
+        /**
+         * DUMP is sqlserver keyword.
+         */
+        DUMP("DUMP"),
+        /**
+         * ELSE is sqlserver keyword.
+         */
+        ELSE("ELSE"),
+        /**
+         * END is sqlserver keyword.
+         */
+        END("END"),
+        /**
+         * ERRLVL is sqlserver keyword.
+         */
+        ERRLVL("ERRLVL"),
+        /**
+         * ESCAPED is sqlserver keyword.
+         */
+        ESCAPED("ESCAPED"),
+        /**
+         * EXCEPT is sqlserver keyword.
+         */
+        EXCEPT("EXCEPT"),
+        /**
+         * EXEC is sqlserver keyword.
+         */
+        EXEC("EXEC"),
+        /**
+         * EXECUTE is sqlserver keyword.
+         */
+        EXECUTE("EXECUTE"),
+        /**
+         * EXISTS is sqlserver keyword.
+         */
+        EXISTS("EXISTS"),
+        /**
+         * EXIT is sqlserver keyword.
+         */
+        EXIT("EXIT"),
+        /**
+         * FETCH is sqlserver keyword.
+         */
+        FETCH("FETCH"),
+        /**
+         * FILE is sqlserver keyword.
+         */
+        FILE("FILE"),
+        /**
+         * FILLFACTOR is sqlserver keyword.
+         */
+        FILLFACTOR("FILLFACTOR"),
+        /**
+         * FOR is sqlserver keyword.
+         */
+        FOR("FOR"),
+        /**
+         * FOREIGN is sqlserver keyword.
+         */
+        FOREIGN("FOREIGN"),
+        /**
+         * FREETEXT is sqlserver keyword.
+         */
+        FREETEXT("FREETEXT"),
+        /**
+         * FREETEXTTABLE is sqlserver keyword.
+         */
+        FREETEXTTABLE("FREETEXTTABLE"),
+        /**
+         * FROM is sqlserver keyword.
+         */
+        FROM("FROM"),
+        /**
+         * FULL is sqlserver keyword.
+         */
+        FULL("FULL"),
+        /**
+         * FUNCTION is sqlserver keyword.
+         */
+        FUNCTION("FUNCTION"),
+        /**
+         * GOTO is sqlserver keyword.
+         */
+        GOTO("GOTO"),
+        /**
+         * GRANT is sqlserver keyword.
+         */
+        GRANT("GRANT"),
+        /**
+         * GROUP is sqlserver keyword.
+         */
+        GROUP("GROUP"),
+        /**
+         * HAVING is sqlserver keyword.
+         */
+        HAVING("HAVING"),
+        /**
+         * HOLDLOCK is sqlserver keyword.
+         */
+        HOLDLOCK("HOLDLOCK"),
+        /**
+         * IDENTITY is sqlserver keyword.
+         */
+        IDENTITY("IDENTITY"),
+        /**
+         * IDENTITY_INSERT is sqlserver keyword.
+         */
+        IDENTITY_INSERT("IDENTITY_INSERT"),
+        /**
+         * IDENTITYCOL is sqlserver keyword.
+         */
+        IDENTITYCOL("IDENTITYCOL"),
+        /**
+         * IF is sqlserver keyword.
+         */
+        IF("IF"),
+        /**
+         * IN is sqlserver keyword.
+         */
+        IN("IN"),
+        /**
+         * INDEX is sqlserver keyword.
+         */
+        INDEX("INDEX"),
+        /**
+         * INNER is sqlserver keyword.
+         */
+        INNER("INNER"),
+        /**
+         * INSERT is sqlserver keyword.
+         */
+        INSERT("INSERT"),
+        /**
+         * INTERSECT is sqlserver keyword.
+         */
+        INTERSECT("INTERSECT"),
+        /**
+         * INTO is sqlserver keyword.
+         */
+        INTO("INTO"),
+        /**
+         * IS is sqlserver keyword.
+         */
+        IS("IS"),
+        /**
+         * JOIN is sqlserver keyword.
+         */
+        JOIN("JOIN"),
+        /**
+         * KEY is sqlserver keyword.
+         */
+        KEY("KEY"),
+        /**
+         * KILL is sqlserver keyword.
+         */
+        KILL("KILL"),
+        /**
+         * LEFT is sqlserver keyword.
+         */
+        LEFT("LEFT"),
+        /**
+         * LIKE is sqlserver keyword.
+         */
+        LIKE("LIKE"),
+        /**
+         * LIKENO is sqlserver keyword.
+         */
+        LIKENO("LIKENO"),
+        /**
+         * LOAD is sqlserver keyword.
+         */
+        LOAD("LOAD"),
+        /**
+         * NATIONAL is sqlserver keyword.
+         */
+        NATIONAL("NATIONAL"),
+        /**
+         * NOCHECK is sqlserver keyword.
+         */
+        NOCHECK("NOCHECK"),
+        /**
+         * NOCHECK is sqlserver keyword.
+         */
+        NONCLUSTERED("NONCLUSTERED"),
+        /**
+         * NOCHECK is sqlserver keyword.
+         */
+        NOT("NOT"),
+        /**
+         * NOCHECK is sqlserver keyword.
+         */
+        NULL("NULL"),
+        /**
+         * NULLIF is sqlserver keyword.
+         */
+        NULLIF("NULLIF"),
+        /**
+         * OF is sqlserver keyword.
+         */
+        OF("OF"),
+        /**
+         * OFF is sqlserver keyword.
+         */
+        OFF("OFF"),
+        /**
+         * OFFSETS is sqlserver keyword.
+         */
+        OFFSETS("OFFSETS"),
+        /**
+         * ON is sqlserver keyword.
+         */
+        ON("ON"),
+        /**
+         * OPEN is sqlserver keyword.
+         */
+        OPEN("OPEN"),
+        /**
+         * OPENDATASOURCE is sqlserver keyword.
+         */
+        OPENDATASOURCE("OPENDATASOURCE"),
+        /**
+         * OPENQUERY is sqlserver keyword.
+         */
+        OPENQUERY("OPENQUERY"),
+        /**
+         * OPENROWSET is sqlserver keyword.
+         */
+        OPENROWSET("OPENROWSET"),
+        /**
+         * OPENXML is sqlserver keyword.
+         */
+        OPENXML("OPENXML"),
+        /**
+         * OPTION is sqlserver keyword.
+         */
+        OPTION("OPTION"),
+        /**
+         * OR is sqlserver keyword.
+         */
+        OR("OR"),
+        /**
+         * ORDER is sqlserver keyword.
+         */
+        ORDER("ORDER"),
+        /**
+         * OUTER is sqlserver keyword.
+         */
+        OUTER("OUTER"),
+        /**
+         * OVER is sqlserver keyword.
+         */
+        OVER("OVER"),
+        /**
+         * PERCENT is sqlserver keyword.
+         */
+        PERCENT("PERCENT"),
+        /**
+         * PLAN is sqlserver keyword.
+         */
+        PLAN("PLAN"),
+        /**
+         * PRECISION is sqlserver keyword.
+         */
+        PRECISION("PRECISION"),
+        /**
+         * PRIMARY is sqlserver keyword.
+         */
+        PRIMARY("PRIMARY"),
+        /**
+         * PRINT is sqlserver keyword.
+         */
+        PRINT("PRINT"),
+        /**
+         * PROC is sqlserver keyword.
+         */
+        PROC("PROC"),
+        /**
+         * PROCEDURE is sqlserver keyword.
+         */
+        PROCEDURE("PROCEDURE"),
+        /**
+         * PUBLIC is sqlserver keyword.
+         */
+        PUBLIC("PUBLIC"),
+        /**
+         * RAISERROR is sqlserver keyword.
+         */
+        RAISERROR("RAISERROR"),
+        /**
+         * READ is sqlserver keyword.
+         */
+        READ("READ"),
+        /**
+         * READTEXT is sqlserver keyword.
+         */
+        READTEXT("READTEXT"),
+        /**
+         * RECONFIGURE is sqlserver keyword.
+         */
+        RECONFIGURE("RECONFIGURE"),
+        /**
+         * REFERENCES is sqlserver keyword.
+         */
+        REFERENCES("REFERENCES"),
+        /**
+         * REPLICATION is sqlserver keyword.
+         */
+        REPLICATION("REPLICATION"),
+        /**
+         * RESTORE is sqlserver keyword.
+         */
+        RESTORE("RESTORE"),
+        /**
+         * RESTRICT is sqlserver keyword.
+         */
+        RESTRICT("RESTRICT"),
+        /**
+         * RETURN is sqlserver keyword.
+         */
+        RETURN("RETURN"),
+        /**
+         * REVOKE is sqlserver keyword.
+         */
+        REVOKE("REVOKE"),
+        /**
+         * RIGHT is sqlserver keyword.
+         */
+        RIGHT("RIGHT"),
+        /**
+         * ROLLBACK is sqlserver keyword.
+         */
+        ROLLBACK("ROLLBACK"),
+        /**
+         * ROWCOUNT is sqlserver keyword.
+         */
+        ROWCOUNT("ROWCOUNT"),
+        /**
+         * ROWGUIDCOL is sqlserver keyword.
+         */
+        ROWGUIDCOL("ROWGUIDCOL"),
+        /**
+         * RULE is sqlserver keyword.
+         */
+        RULE("RULE"),
+        /**
+         * SAVE is sqlserver keyword.
+         */
+        SAVE("SAVE"),
+        /**
+         * SCHEMA is sqlserver keyword.
+         */
+        SCHEMA("SCHEMA"),
+        /**
+         * SELECT is sqlserver keyword.
+         */
+        SELECT("SELECT"),
+        /**
+         * SESSION_USER is sqlserver keyword.
+         */
+        SESSION_USER("SESSION_USER"),
+        /**
+         * SET is sqlserver keyword.
+         */
+        SET("SET"),
+        /**
+         * SETUSER is sqlserver keyword.
+         */
+        SETUSER("SETUSER"),
+        /**
+         * SHUTDOWN is sqlserver keyword.
+         */
+        SHUTDOWN("SHUTDOWN"),
+        /**
+         * SOME is sqlserver keyword.
+         */
+        SOME("SOME"),
+        /**
+         * STATISTICS is sqlserver keyword.
+         */
+        STATISTICS("STATISTICS"),
+        /**
+         * SYSTEM_USER is sqlserver keyword.
+         */
+        SYSTEM_USER("SYSTEM_USER"),
+        /**
+         * TABLE is sqlserver keyword.
+         */
+        TABLE("TABLE"),
+        /**
+         * TEXTSIZE is sqlserver keyword.
+         */
+        TEXTSIZE("TEXTSIZE"),
+        /**
+         * THEN is sqlserver keyword.
+         */
+        THEN("THEN"),
+        /**
+         * TO is sqlserver keyword.
+         */
+        TO("TO"),
+        /**
+         * TOP is sqlserver keyword.
+         */
+        TOP("TOP"),
+        /**
+         * TRAN is sqlserver keyword.
+         */
+        TRAN("TRAN"),
+        /**
+         * TRANSACTION is sqlserver keyword.
+         */
+        TRANSACTION("TRANSACTION"),
+        /**
+         * TRIGGER is sqlserver keyword.
+         */
+        TRIGGER("TRIGGER"),
+        /**
+         * TRUNCATE is sqlserver keyword.
+         */
+        TRUNCATE("TRUNCATE"),
+        /**
+         * TSEQUAL is sqlserver keyword.
+         */
+        TSEQUAL("TSEQUAL"),
+        /**
+         * UNION is sqlserver keyword.
+         */
+        UNION("UNION"),
+        /**
+         * UNIQUE is sqlserver keyword.
+         */
+        UNIQUE("UNIQUE"),
+        /**
+         * UPDATE is sqlserver keyword.
+         */
+        UPDATE("UPDATE"),
+        /**
+         * UPDATETEXT is sqlserver keyword.
+         */
+        UPDATETEXT("UPDATETEXT"),
+        /**
+         * USE is sqlserver keyword.
+         */
+        USE("USE"),
+        /**
+         * USER is sqlserver keyword.
+         */
+        USER("USER"),
+        /**
+         * VALUES is sqlserver keyword.
+         */
+        VALUES("VALUES"),
+        /**
+         * VARYING is sqlserver keyword.
+         */
+        VARYING("VARYING"),
+        /**
+         * VIEW is sqlserver keyword.
+         */
+        VIEW("VIEW"),
+        /**
+         * WAITFOR is sqlserver keyword.
+         */
+        WAITFOR("WAITFOR"),
+        /**
+         * WHEN is sqlserver keyword.
+         */
+        WHEN("WHEN"),
+        /**
+         * WHERE is sqlserver keyword.
+         */
+        WHERE("WHERE"),
+        /**
+         * WHILE is sqlserver keyword.
+         */
+        WHILE("WHILE"),
+        /**
+         * WITH is sqlserver keyword.
+         */
+        WITH("WITH"),
+        /**
+         * WRITETEXT is sqlserver keyword.
+         */
+        WRITETEXT("WRITETEXT");
+        /**
+         * The Name.
+         */
+        public final String keywordName;
+
+        SQLServerKeyword(String keywordName) {
+            this.keywordName = keywordName;
+        }
+
+        public final String getKeywordName() {
+            return keywordName;
+        }
+    }
+
+
+    @Override
+    public boolean check(String fieldOrTableName) {
+        if (keywordSet.contains(fieldOrTableName)) {
+            return true;
+        }
+        if (fieldOrTableName != null) {
+            fieldOrTableName = fieldOrTableName.toUpperCase();
+        }
+        return keywordSet.contains(fieldOrTableName);
+
+    }
+
+    @Override
+    public boolean checkEscape(String fieldOrTableName) {
+        return check(fieldOrTableName);
+    }
+
+    public String checkAndReplace(String fieldOrTableName) {
+        return check(fieldOrTableName) ? "`" + fieldOrTableName + "`" : fieldOrTableName;
+    }
+
+}

--- a/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.exec.InsertExecutor
+++ b/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.exec.InsertExecutor
@@ -17,3 +17,4 @@
 io.seata.rm.datasource.exec.mysql.MySQLInsertExecutor
 io.seata.rm.datasource.exec.oracle.OracleInsertExecutor
 io.seata.rm.datasource.exec.postgresql.PostgresqlInsertExecutor
+io.seata.rm.datasource.exec.sqlserver.SQLServerInsertExecutor

--- a/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.sql.struct.TableMetaCache
+++ b/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.sql.struct.TableMetaCache
@@ -1,3 +1,4 @@
 io.seata.rm.datasource.sql.struct.cache.MysqlTableMetaCache
 io.seata.rm.datasource.sql.struct.cache.OracleTableMetaCache
 io.seata.rm.datasource.sql.struct.cache.PostgresqlTableMetaCache
+io.seata.rm.datasource.sql.struct.cache.SQLServerTableMetaCache

--- a/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.KeywordChecker
+++ b/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.KeywordChecker
@@ -1,3 +1,4 @@
 io.seata.rm.datasource.undo.oracle.keyword.OracleKeywordChecker
 io.seata.rm.datasource.undo.mysql.keyword.MySQLKeywordChecker
 io.seata.rm.datasource.undo.postgresql.keyword.PostgresqlKeywordChecker
+io.seata.rm.datasource.undo.sqlserver.keyword.SQLServerKeywordChecker

--- a/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.UndoExecutorHolder
+++ b/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.UndoExecutorHolder
@@ -1,3 +1,4 @@
 io.seata.rm.datasource.undo.mysql.MySQLUndoExecutorHolder
 io.seata.rm.datasource.undo.oracle.OracleUndoExecutorHolder
 io.seata.rm.datasource.undo.postgresql.PostgresqlUndoExecutorHolder
+io.seata.rm.datasource.undo.sqlserver.SQLServerUndoExecutorHolder

--- a/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.UndoLogManager
+++ b/rm-datasource/src/main/resources/META-INF/services/io.seata.rm.datasource.undo.UndoLogManager
@@ -1,3 +1,4 @@
 io.seata.rm.datasource.undo.mysql.MySQLUndoLogManager
 io.seata.rm.datasource.undo.oracle.OracleUndoLogManager
 io.seata.rm.datasource.undo.postgresql.PostgresqlUndoLogManager
+io.seata.rm.datasource.undo.sqlserver.SQLServerUndoLogManager

--- a/sqlparser/seata-sqlparser-core/src/main/java/io/seata/sqlparser/util/JdbcConstants.java
+++ b/sqlparser/seata-sqlparser-core/src/main/java/io/seata/sqlparser/util/JdbcConstants.java
@@ -30,4 +30,6 @@ public interface JdbcConstants {
     String MARIADB = "mariadb";
 
     String POSTGRESQL = "postgresql";
+
+    String SQLSERVER = "sqlserver";
 }

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/BaseSQLServerRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/BaseSQLServerRecognizer.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid.sqlserver;
+
+import com.alibaba.druid.sql.ast.*;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
+import com.alibaba.druid.sql.ast.statement.SQLSelectOrderByItem;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlOutputVisitor;
+import com.alibaba.druid.sql.dialect.sqlserver.visitor.SQLServerOutputVisitor;
+import io.seata.common.util.StringUtils;
+import io.seata.sqlparser.ParametersHolder;
+import io.seata.sqlparser.SQLType;
+import io.seata.sqlparser.druid.BaseRecognizer;
+import io.seata.sqlparser.struct.Null;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author will
+ */
+public abstract class BaseSQLServerRecognizer extends BaseRecognizer {
+
+    /**
+     * Instantiates a new sqlserver base recognizer
+     *
+     * @param originalSql the original sql
+     */
+    public BaseSQLServerRecognizer(String originalSql) {
+        super(originalSql);
+    }
+
+    public SQLServerOutputVisitor createOutputVisitor(final ParametersHolder parametersHolder,
+                                                      final ArrayList<List<Object>> paramAppenderList,
+                                                      final StringBuilder sb) {
+        return new SQLServerOutputVisitor(sb) {
+
+            @Override
+            public boolean visit(SQLVariantRefExpr x) {
+                if ("?".equals(x.getName())) {
+                    ArrayList<Object> oneParamValues = parametersHolder.getParameters().get(x.getIndex() + 1);
+                    if (paramAppenderList.isEmpty()) {
+                        oneParamValues.forEach(t -> paramAppenderList.add(new ArrayList<>()));
+                    }
+                    for (int i = 0; i < oneParamValues.size(); i++) {
+                        Object o = oneParamValues.get(i);
+                        paramAppenderList.get(i).add(o instanceof Null ? null : o);
+                    }
+                }
+                return super.visit(x);
+            }
+        };
+    }
+
+    public String getWhereCondition(SQLExpr where, final ParametersHolder parametersHolder,
+                                    final ArrayList<List<Object>> paramAppenderList) {
+        if (Objects.isNull(where)) {
+            return StringUtils.EMPTY;
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        executeVisit(where, createOutputVisitor(parametersHolder, paramAppenderList, sb));
+        return sb.toString();
+    }
+
+    public String getWhereCondition(SQLExpr where) {
+        if (Objects.isNull(where)) {
+            return StringUtils.EMPTY;
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        executeVisit(where, new MySqlOutputVisitor(sb));
+        return sb.toString();
+    }
+
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLDeleteServerRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLDeleteServerRecognizer.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid.sqlserver;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLDeleteStatement;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.dialect.sqlserver.visitor.SQLServerOutputVisitor;
+import io.seata.sqlparser.ParametersHolder;
+import io.seata.sqlparser.SQLDeleteRecognizer;
+import io.seata.sqlparser.SQLType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The type SQLServer delete recognizer.
+ *
+ * @author Paranoia
+ */
+public class SQLDeleteServerRecognizer extends BaseSQLServerRecognizer implements SQLDeleteRecognizer {
+
+    private final SQLDeleteStatement ast;
+
+    /**
+     * Instantiates a new SQLServer delete recognizer.
+     *
+     * @param originalSQL the original sql
+     * @param ast         the ast
+     */
+
+    public SQLDeleteServerRecognizer(String originalSql, SQLStatement ast) {
+        super(originalSql);
+        this.ast = (SQLDeleteStatement) ast;
+    }
+
+    /**
+     * Instantiates a new sqlserver base recognizer
+     *
+     * @param originalSql the original sql
+     */
+
+    @Override
+    public SQLType getSQLType() {
+        return SQLType.DELETE;
+    }
+
+    @Override
+    public String getTableAlias() {
+        return ast.getTableSource().getAlias();
+    }
+
+    @Override
+    public String getTableName() {
+        StringBuilder sb = new StringBuilder();
+        SQLServerOutputVisitor visitor = new SQLServerOutputVisitor(sb) {
+            @Override
+            public boolean visit(SQLExprTableSource x) {
+                printTableSourceExpr(x.getExpr());
+                return false;
+            }
+        };
+        visitor.visit((SQLExprTableSource)ast.getTableSource());
+        return sb.toString();
+    }
+
+    @Override
+    public String getWhereCondition(final ParametersHolder parametersHolder,
+                                    final ArrayList<List<Object>> paramAppenderList) {
+        SQLExpr where = ast.getWhere();
+        return super.getWhereCondition(where, parametersHolder, paramAppenderList);
+    }
+
+    @Override
+    public String getWhereCondition() {
+        SQLExpr where = ast.getWhere();
+        return super.getWhereCondition(where);
+    }
+
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLServerInsertServerRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLServerInsertServerRecognizer.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid.sqlserver;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.*;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLInsertStatement;
+import com.alibaba.druid.sql.dialect.mysql.visitor.MySqlOutputVisitor;
+import com.alibaba.druid.sql.dialect.sqlserver.visitor.SQLServerOutputVisitor;
+import io.seata.common.util.CollectionUtils;
+import io.seata.sqlparser.SQLInsertRecognizer;
+import io.seata.sqlparser.SQLParsingException;
+import io.seata.sqlparser.SQLType;
+import io.seata.sqlparser.struct.NotPlaceholderExpr;
+import io.seata.sqlparser.struct.Null;
+import io.seata.sqlparser.struct.SqlMethodExpr;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * The type SQLServer insert recognizer.
+ *
+ * @author Paranoia
+ */
+public class SQLServerInsertServerRecognizer extends BaseSQLServerRecognizer implements SQLInsertRecognizer {
+
+    private final SQLInsertStatement ast;
+
+    /**
+     * Instantiates a new  SQLServer insert recognizer.
+     *
+     * @param originalSQL the original sql
+     * @param ast         the ast
+     */
+    public SQLServerInsertServerRecognizer(String originalSQL, SQLStatement ast) {
+        super(originalSQL);
+        this.ast = (SQLInsertStatement)ast;
+    }
+
+    @Override
+    public SQLType getSQLType() {
+        return SQLType.INSERT;
+    }
+
+    @Override
+    public String getTableAlias() {
+        return ast.getTableSource().getAlias();
+    }
+
+    @Override
+    public String getTableName() {
+        StringBuilder sb = new StringBuilder();
+        MySqlOutputVisitor visitor = new MySqlOutputVisitor(sb) {
+
+            @Override
+            public boolean visit(SQLExprTableSource x) {
+                printTableSourceExpr(x.getExpr());
+                return false;
+            }
+        };
+        visitor.visit(ast.getTableSource());
+        return sb.toString();
+    }
+
+    @Override
+    public boolean insertColumnsIsEmpty() {
+        return CollectionUtils.isEmpty(ast.getColumns());
+    }
+
+    @Override
+    public List<String> getInsertColumns() {
+        List<SQLExpr> columnSQLExprs = ast.getColumns();
+        if (columnSQLExprs.isEmpty()) {
+            // INSERT INTO ta VALUES (...), without fields clarified
+            return null;
+        }
+        List<String> list = new ArrayList<>(columnSQLExprs.size());
+        for (SQLExpr expr : columnSQLExprs) {
+            if (expr instanceof SQLIdentifierExpr) {
+                list.add(((SQLIdentifierExpr)expr).getName());
+            } else {
+                throw new SQLParsingException("Unknown SQLExpr: " + expr.getClass() + " " + expr);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public List<List<Object>> getInsertRows(Collection<Integer> primaryKeyIndex) {
+        List<SQLInsertStatement.ValuesClause> valuesClauses = ast.getValuesList();
+        List<List<Object>> rows = new ArrayList<>(valuesClauses.size());
+        for (SQLInsertStatement.ValuesClause valuesClause : valuesClauses) {
+            List<SQLExpr> exprs = valuesClause.getValues();
+            List<Object> row = new ArrayList<>(exprs.size());
+            rows.add(row);
+            for (SQLExpr expr : valuesClause.getValues()) {
+                if (expr instanceof SQLNullExpr) {
+                    row.add(Null.get());
+                } else if (expr instanceof SQLValuableExpr) {
+                    row.add(((SQLValuableExpr)expr).getValue());
+                } else if (expr instanceof SQLVariantRefExpr) {
+                    row.add(((SQLVariantRefExpr)expr).getName());
+                } else if (expr instanceof SQLMethodInvokeExpr) {
+                    row.add(SqlMethodExpr.get());
+                } else {
+                    throw new SQLParsingException("Unknown SQLExpr: " + expr.getClass() + " " + expr);
+                }
+            }
+        }
+        return rows;
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLServerOperateRecognizerHolder.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLServerOperateRecognizerHolder.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid.sqlserver;
+
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
+import io.seata.common.loader.LoadLevel;
+import io.seata.sqlparser.SQLRecognizer;
+import io.seata.sqlparser.druid.SQLOperateRecognizerHolder;
+import io.seata.sqlparser.util.JdbcConstants;
+
+/**
+ * The class SQLServerOperateRecognizerHolder
+ *
+ * @author: Zhibei Hao
+ */
+@LoadLevel(name = JdbcConstants.SQLSERVER)
+public class SQLServerOperateRecognizerHolder implements SQLOperateRecognizerHolder {
+
+    @Override
+    public SQLRecognizer getDeleteRecognizer(String sql, SQLStatement ast) {
+        return new SQLDeleteServerRecognizer(sql, ast);
+    }
+
+    @Override
+    public SQLRecognizer getInsertRecognizer(String sql, SQLStatement ast) {
+        return new SQLServerInsertServerRecognizer(sql, ast);
+    }
+
+    @Override
+    public SQLRecognizer getUpdateRecognizer(String sql, SQLStatement ast) {
+        return new SQLServerUpdateServerRecognizer(sql, ast);
+    }
+
+    @Override
+    public SQLRecognizer getSelectForUpdateRecognizer(String sql, SQLStatement ast) {
+        if (((SQLSelectStatement) ast).getSelect().getFirstQueryBlock().isForUpdate()) {
+            return new SQLServerSelectForUpdateServerRecognizer(sql, ast);
+        }
+        return null;
+    }
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLServerSelectForUpdateServerRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLServerSelectForUpdateServerRecognizer.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid.sqlserver;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.statement.*;
+import com.alibaba.druid.sql.dialect.sqlserver.visitor.SQLServerOutputVisitor;
+import io.seata.sqlparser.ParametersHolder;
+import io.seata.sqlparser.SQLParsingException;
+import io.seata.sqlparser.SQLSelectRecognizer;
+import io.seata.sqlparser.SQLType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The type SQLServer select for update recognizer.
+ *
+ * @author Paranoia
+ */
+public class SQLServerSelectForUpdateServerRecognizer extends BaseSQLServerRecognizer implements SQLSelectRecognizer {
+
+    private final SQLSelectStatement ast;
+
+    /**
+     * Instantiates a new SqlServer select for update recognizer.
+     *
+     * @param originalSQL the original sql
+     * @param ast         the ast
+     */
+    public SQLServerSelectForUpdateServerRecognizer(String originalSQL, SQLStatement ast) {
+        super(originalSQL);
+        this.ast = (SQLSelectStatement)ast;
+    }
+
+    @Override
+    public SQLType getSQLType() {
+        return SQLType.SELECT_FOR_UPDATE;
+    }
+
+    @Override
+    public String getWhereCondition(final ParametersHolder parametersHolder,
+                                    final ArrayList<List<Object>> paramAppenderList) {
+        SQLSelectQueryBlock selectQueryBlock = getSelect();
+        SQLExpr where = selectQueryBlock.getWhere();
+        return super.getWhereCondition(where, parametersHolder, paramAppenderList);
+    }
+
+    @Override
+    public String getWhereCondition() {
+        SQLSelectQueryBlock selectQueryBlock = getSelect();
+        SQLExpr where = selectQueryBlock.getWhere();
+        return super.getWhereCondition(where);
+    }
+
+    private SQLSelectQueryBlock getSelect() {
+        SQLSelect select = ast.getSelect();
+        if (select == null) {
+            throw new SQLParsingException("should never happen!");
+        }
+        SQLSelectQueryBlock selectQueryBlock = select.getQueryBlock();
+        if (selectQueryBlock == null) {
+            throw new SQLParsingException("should never happen!");
+        }
+        return selectQueryBlock;
+    }
+
+    @Override
+    public String getTableAlias() {
+        SQLSelectQueryBlock selectQueryBlock = getSelect();
+        SQLTableSource tableSource = selectQueryBlock.getFrom();
+        return tableSource.getAlias();
+    }
+
+    @Override
+    public String getTableName() {
+        SQLSelectQueryBlock selectQueryBlock = getSelect();
+        SQLTableSource tableSource = selectQueryBlock.getFrom();
+        StringBuilder sb = new StringBuilder();
+        SQLServerOutputVisitor visitor = new SQLServerOutputVisitor(sb) {
+
+            @Override
+            public boolean visit(SQLExprTableSource x) {
+                printTableSourceExpr(x.getExpr());
+                return false;
+            }
+        };
+        visitor.visit((SQLExprTableSource)tableSource);
+        return sb.toString();
+    }
+
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLServerUpdateServerRecognizer.java
+++ b/sqlparser/seata-sqlparser-druid/src/main/java/io/seata/sqlparser/druid/sqlserver/SQLServerUpdateServerRecognizer.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.sqlparser.druid.sqlserver;
+
+import com.alibaba.druid.sql.ast.SQLExpr;
+import com.alibaba.druid.sql.ast.SQLStatement;
+import com.alibaba.druid.sql.ast.expr.SQLIdentifierExpr;
+import com.alibaba.druid.sql.ast.expr.SQLPropertyExpr;
+import com.alibaba.druid.sql.ast.expr.SQLValuableExpr;
+import com.alibaba.druid.sql.ast.expr.SQLVariantRefExpr;
+import com.alibaba.druid.sql.ast.statement.SQLExprTableSource;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateSetItem;
+import com.alibaba.druid.sql.ast.statement.SQLUpdateStatement;
+import com.alibaba.druid.sql.dialect.sqlserver.visitor.SQLServerOutputVisitor;
+import io.seata.sqlparser.ParametersHolder;
+import io.seata.sqlparser.SQLParsingException;
+import io.seata.sqlparser.SQLType;
+import io.seata.sqlparser.SQLUpdateRecognizer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The type SQLServer update recognizer.
+ *
+ * @author Paranoia
+ */
+public class SQLServerUpdateServerRecognizer extends BaseSQLServerRecognizer implements SQLUpdateRecognizer {
+
+    private SQLUpdateStatement ast;
+
+    /**
+     * Instantiates a new My sql update recognizer.
+     *
+     * @param originalSQL the original sql
+     * @param ast         the ast
+     */
+    public SQLServerUpdateServerRecognizer(String originalSQL, SQLStatement ast) {
+        super(originalSQL);
+        this.ast = (SQLUpdateStatement)ast;
+    }
+
+    @Override
+    public SQLType getSQLType() {
+        return SQLType.UPDATE;
+    }
+
+    @Override
+    public String getTableAlias() {
+        return ast.getTableSource().getAlias();
+    }
+
+    @Override
+    public String getTableName() {
+        StringBuilder sb = new StringBuilder();
+        SQLServerOutputVisitor visitor = new SQLServerOutputVisitor(sb) {
+
+            @Override
+            public boolean visit(SQLExprTableSource x) {
+                printTableSourceExpr(x.getExpr());
+                return false;
+            }
+        };
+        SQLExprTableSource tableSource = (SQLExprTableSource)ast.getTableSource();
+        visitor.visit(tableSource);
+        return sb.toString();
+    }
+
+    @Override
+    public List<String> getUpdateColumns() {
+        List<SQLUpdateSetItem> updateSetItems = ast.getItems();
+        List<String> list = new ArrayList<>(updateSetItems.size());
+        for (SQLUpdateSetItem updateSetItem : updateSetItems) {
+            SQLExpr expr = updateSetItem.getColumn();
+            if (expr instanceof SQLIdentifierExpr) {
+                list.add(((SQLIdentifierExpr)expr).getName());
+            } else if (expr instanceof SQLPropertyExpr) {
+                // This is alias case, like UPDATE xxx_tbl a SET a.name = ? WHERE a.id = ?
+                SQLExpr owner = ((SQLPropertyExpr)expr).getOwner();
+                if (owner instanceof SQLIdentifierExpr) {
+                    list.add(((SQLIdentifierExpr)owner).getName() + "." + ((SQLPropertyExpr)expr).getName());
+                }
+            } else {
+                throw new SQLParsingException("Unknown SQLExpr: " + expr.getClass() + " " + expr);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public List<Object> getUpdateValues() {
+        List<SQLUpdateSetItem> updateSetItems = ast.getItems();
+        List<Object> list = new ArrayList<>(updateSetItems.size());
+        for (SQLUpdateSetItem updateSetItem : updateSetItems) {
+            SQLExpr expr = updateSetItem.getValue();
+            if (expr instanceof SQLValuableExpr) {
+                list.add(((SQLValuableExpr)expr).getValue());
+            } else if (expr instanceof SQLVariantRefExpr) {
+                list.add(new VMarker());
+            } else {
+                throw new SQLParsingException("Unknown SQLExpr: " + expr.getClass() + " " + expr);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public String getWhereCondition(final ParametersHolder parametersHolder,
+                                    final ArrayList<List<Object>> paramAppenderList) {
+        SQLExpr where = ast.getWhere();
+        return super.getWhereCondition(where, parametersHolder, paramAppenderList);
+    }
+
+    @Override
+    public String getWhereCondition() {
+        SQLExpr where = ast.getWhere();
+        return super.getWhereCondition(where);
+    }
+
+}

--- a/sqlparser/seata-sqlparser-druid/src/main/resources/META-INF/services/io.seata.sqlparser.druid.SQLOperateRecognizerHolder
+++ b/sqlparser/seata-sqlparser-druid/src/main/resources/META-INF/services/io.seata.sqlparser.druid.SQLOperateRecognizerHolder
@@ -1,3 +1,4 @@
 io.seata.sqlparser.druid.mysql.MySQLOperateRecognizerHolder
 io.seata.sqlparser.druid.oracle.OracleOperateRecognizerHolder
 io.seata.sqlparser.druid.postgresql.PostgresqlOperateRecognizerHolder
+io.seata.sqlparser.druid.sqlserver.SQLServerOperateRecognizerHolder


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

参照汉得对SQLServer 提供的支持，以及 Jerry Yin  feature: support Multi pk  (#2398) 对联合主键的处理添加了AT 模式 SQLServer的实现。

add support for SQLServer databases 

fix SQLServer not support multi pk 

But I have the following problems 

 列阵列无效 其长度不能为1

@81519434   

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

add support for SQLServer databases 

fix SQLServer not support multi pk 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews



