### PR TITLE
optimize: enable NamedThreadFactory to get ThreadGroup from the SecurityManager or Current thread

### DIFF
--- a/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
+++ b/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
@@ -65,4 +65,11 @@ public class NamedThreadFactoryTest {
                 .isEqualTo(thread.getName());
         }
     }
+    @Test
+    public void testNamedThreadFactoryWithSecurityManager() {
+        NamedThreadFactory factory = new NamedThreadFactory("testThreadGroup", true);
+        Thread thread = factory.newThread(() -> {});
+        assertThat(thread.getThreadGroup()).isNotNull();
+    }
+
 }

--- a/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
+++ b/common/src/test/java/io/seata/common/thread/NamedThreadFactoryTest.java
@@ -65,6 +65,7 @@ public class NamedThreadFactoryTest {
                 .isEqualTo(thread.getName());
         }
     }
+    
     @Test
     public void testNamedThreadFactoryWithSecurityManager() {
         NamedThreadFactory factory = new NamedThreadFactory("testThreadGroup", true);


### PR DESCRIPTION
Ⅰ. Describe what this PR did
enable NamedThreadFactory to get ThreadGroup from the SecurityManager or Current thread
Reference JDK's implementation of DefaultThreadFactory
Ⅱ. Does this pull request fix one issue?
Ⅲ. Why don't you add test cases (unit test/integration test)?
Ⅳ. Describe how to verify it
Ⅴ. Special notes for reviews


