### PR TITLE
optimize: get config from file system even without file: prefix

### DIFF
--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -20,7 +20,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -166,7 +165,7 @@ public class FileConfiguration extends AbstractConfiguration {
     private File getFileFromFileSystem(String decodedPath) {
         String[] tryPaths = new String[] {
             // first: project dir
-            Paths.get(this.getClass().getClassLoader().getResource("").getPath(), decodedPath).toString(),
+            this.getClass().getClassLoader().getResource("").getPath() + decodedPath,
             // second: system path
             decodedPath
         };

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -182,9 +182,6 @@ public class FileConfiguration extends AbstractConfiguration {
             for (String s : FileConfigFactory.getSuffixSet()) {
                 targetFile = new File(tryPath + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + s);
                 if (targetFile.exists()) {
-                    if (LOGGER.isInfoEnabled()) {
-                        LOGGER.info("The configuration file used is {}", targetFile.getPath());
-                    }
                     return targetFile;
                 }
             }

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -188,10 +188,7 @@ public class FileConfiguration extends AbstractConfiguration {
             LOGGER.error("file not found--" + e.getMessage(), e);
         }
 
-        // try to get filename
-        String basename = StringUtils.isNullOrEmpty(name) ? "my-config.conf" : new File(name).getName();
-        LOGGER.warn("The configuration file not found: {}. If your file is on the file system, " +
-            "please use a format like \"file:/path/to/{}\"", name, basename);
+        LOGGER.warn("The configuration file not found: {}", name);
         return null;
     }
 

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -160,7 +160,6 @@ public class FileConfiguration extends AbstractConfiguration {
             LOGGER.error("file not found--" + e.getMessage(), e);
         }
 
-        LOGGER.warn("The configuration file not found: {}", name);
         return null;
     }
 

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -188,8 +188,10 @@ public class FileConfiguration extends AbstractConfiguration {
             LOGGER.error("file not found--" + e.getMessage(), e);
         }
 
+        // try to get filename
+        String basename = StringUtils.isNullOrEmpty(name) ? "my-config.conf" : new File(name).getName();
         LOGGER.warn("The configuration file not found: {}. If your file is on the file system, " +
-            "please use a format like \"file:/path/to/file.conf\"", name);
+            "please use a format like \"file:/path/to/{}\"", name, basename);
         return null;
     }
 

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -138,7 +138,6 @@ public class FileConfiguration extends AbstractConfiguration {
                 throw new IllegalArgumentException("name can't be null");
             }
 
-            // 是否指定文件系统上的路径
             boolean filePathCustom = name.startsWith(SYS_FILE_RESOURCE_PREFIX);
             String filePath = filePathCustom ? name.substring(SYS_FILE_RESOURCE_PREFIX.length()) : name;
             String decodedPath = URLDecoder.decode(filePath, StandardCharsets.UTF_8.name());

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -187,6 +187,9 @@ public class FileConfiguration extends AbstractConfiguration {
         } catch (UnsupportedEncodingException e) {
             LOGGER.error("file not found--" + e.getMessage(), e);
         }
+
+        LOGGER.warn("The configuration file not found: {}. If your file is on the file system, " +
+            "please use a format like \"file:/path/to/file.conf\"", name);
         return null;
     }
 

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -157,7 +157,7 @@ public class FileConfiguration extends AbstractConfiguration {
                 }
             }
         } catch (UnsupportedEncodingException e) {
-            LOGGER.error("file not found--" + e.getMessage(), e);
+            LOGGER.error("decode name error", e);
         }
 
         return null;

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -112,7 +113,7 @@ public class FileConfiguration extends AbstractConfiguration {
             targetFilePath = file.getPath();
             fileConfig = FileConfigFactory.load(file, name);
         }
-        /**
+        /*
          * For seata-server side the conf file should always exists.
          * For application(or client) side,conf file may not exists when using seata-spring-boot-starter
          */
@@ -135,53 +136,24 @@ public class FileConfiguration extends AbstractConfiguration {
             if (name == null) {
                 throw new IllegalArgumentException("name can't be null");
             }
-            String filePath = null;
+
+            // 是否指定文件系统上的路径
             boolean filePathCustom = name.startsWith(SYS_FILE_RESOURCE_PREFIX);
-            if (filePathCustom) {
-                filePath = name.substring(SYS_FILE_RESOURCE_PREFIX.length());
-            } else {
-                // projectDir first
-                filePath = this.getClass().getClassLoader().getResource("").getPath() + name;
-            }
-            filePath = URLDecoder.decode(filePath, "utf-8");
-            File targetFile = new File(filePath);
-            if (!targetFile.exists()) {
-                for (String s : FileConfigFactory.getSuffixSet()) {
-                    targetFile = new File(filePath + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + s);
-                    if (targetFile.exists()) {
-                        if (LOGGER.isInfoEnabled()) {
-                            LOGGER.info("The configuration file used is {}", targetFile.getPath());
-                        }
-                        return targetFile;
-                    }
-                }
-            } else {
+            String filePath = filePathCustom ? name.substring(SYS_FILE_RESOURCE_PREFIX.length()) : name;
+            String decodedPath = URLDecoder.decode(filePath, "utf-8");
+
+            File targetFile = getFileFromFileSystem(decodedPath);
+            if (targetFile != null) {
                 if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info("The configuration file used is {}", name);
+                    LOGGER.info("The configuration file used is {}", targetFile.getPath());
                 }
                 return targetFile;
             }
+
             if (!filePathCustom) {
-                URL resource = this.getClass().getClassLoader().getResource(name);
-                if (resource == null) {
-                    for (String s : FileConfigFactory.getSuffixSet()) {
-                        resource = this.getClass().getClassLoader().getResource(name + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + s);
-                        if (resource != null) {
-                            if (LOGGER.isInfoEnabled()) {
-                                LOGGER.info("The configuration file used is {}", resource.getPath());
-                            }
-                            String path = resource.getPath();
-                            path = URLDecoder.decode(path, "utf-8");
-                            return new File(path);
-                        }
-                    }
-                } else {
-                    if (LOGGER.isInfoEnabled()) {
-                        LOGGER.info("The configuration file used is {}", name);
-                    }
-                    String path = resource.getPath();
-                    path = URLDecoder.decode(path, "utf-8");
-                    return new File(path);
+                File classpathFile = getFileFromClasspath(name);
+                if (classpathFile != null) {
+                    return classpathFile;
                 }
             }
         } catch (UnsupportedEncodingException e) {
@@ -189,6 +161,61 @@ public class FileConfiguration extends AbstractConfiguration {
         }
 
         LOGGER.warn("The configuration file not found: {}", name);
+        return null;
+    }
+
+    private File getFileFromFileSystem(String decodedPath) {
+        String[] tryPaths = new String[] {
+            // first: project dir
+            Paths.get(this.getClass().getClassLoader().getResource("").getPath(), decodedPath).toString(),
+            // second: system path
+            decodedPath
+        };
+
+        for (String tryPath : tryPaths) {
+            File targetFile = new File(tryPath);
+            if (targetFile.exists()) {
+                return targetFile;
+            }
+
+            // try to append config suffix
+            for (String s : FileConfigFactory.getSuffixSet()) {
+                targetFile = new File(tryPath + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + s);
+                if (targetFile.exists()) {
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("The configuration file used is {}", targetFile.getPath());
+                    }
+                    return targetFile;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private File getFileFromClasspath(String name) throws UnsupportedEncodingException {
+        URL resource = this.getClass().getClassLoader().getResource(name);
+        if (resource == null) {
+            for (String s : FileConfigFactory.getSuffixSet()) {
+                resource = this.getClass().getClassLoader().getResource(name + ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR + s);
+                if (resource != null) {
+                    if (LOGGER.isInfoEnabled()) {
+                        LOGGER.info("The configuration file used is {}", resource.getPath());
+                    }
+                    String path = resource.getPath();
+                    path = URLDecoder.decode(path, "utf-8");
+                    return new File(path);
+                }
+            }
+        } else {
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("The configuration file used is {}", name);
+            }
+            String path = resource.getPath();
+            path = URLDecoder.decode(path, "utf-8");
+            return new File(path);
+        }
+
         return null;
     }
 

--- a/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
+++ b/config/seata-config-core/src/main/java/io/seata/config/FileConfiguration.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -140,7 +141,7 @@ public class FileConfiguration extends AbstractConfiguration {
             // 是否指定文件系统上的路径
             boolean filePathCustom = name.startsWith(SYS_FILE_RESOURCE_PREFIX);
             String filePath = filePathCustom ? name.substring(SYS_FILE_RESOURCE_PREFIX.length()) : name;
-            String decodedPath = URLDecoder.decode(filePath, "utf-8");
+            String decodedPath = URLDecoder.decode(filePath, StandardCharsets.UTF_8.name());
 
             File targetFile = getFileFromFileSystem(decodedPath);
             if (targetFile != null) {
@@ -157,7 +158,7 @@ public class FileConfiguration extends AbstractConfiguration {
                 }
             }
         } catch (UnsupportedEncodingException e) {
-            LOGGER.error("decode name error", e);
+            LOGGER.error("decode name error: {}", e.getMessage(), e);
         }
 
         return null;
@@ -199,7 +200,7 @@ public class FileConfiguration extends AbstractConfiguration {
                         LOGGER.info("The configuration file used is {}", resource.getPath());
                     }
                     String path = resource.getPath();
-                    path = URLDecoder.decode(path, "utf-8");
+                    path = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
                     return new File(path);
                 }
             }
@@ -208,7 +209,7 @@ public class FileConfiguration extends AbstractConfiguration {
                 LOGGER.info("The configuration file used is {}", name);
             }
             String path = resource.getPath();
-            path = URLDecoder.decode(path, "utf-8");
+            path = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
             return new File(path);
         }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

指定配置文件路径时，即使没有使用 file: 前缀，依然尝试在文件系统查找并加载

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3344 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

在 registry.conf 文件中配置文件路径的时候，不添加 `file:` 前缀。例如：

```
config {
  type = "file"

  file {
    name = "/root/seata-config/file.conf"
  }
}
```

期望的结果：配置文件能被加载

### Ⅴ. Special notes for reviews

