### PR TITLE
bugfix: fix throw IllegalArgumentException when using hystrix and version 2.2.3.RELEASE and below of SCA

### DIFF
--- a/core/src/main/java/io/seata/core/context/RootContext.java
+++ b/core/src/main/java/io/seata/core/context/RootContext.java
@@ -89,7 +89,7 @@ public class RootContext {
      */
     public static void bind(@Nonnull String xid) {
         if (StringUtils.isBlank(xid)) {
-            throw new IllegalArgumentException("xid must be not blank");
+            xid = null;
         }
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("bind {}", xid);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
bugfix: fix throw `IllegalArgumentException` when using `hystrix` and `version 2.2.3.RELEASE and below of SCA`.
修复使用`hystrix`和`SCA 2.2.3.RELEASE及以下版本`时抛出`IllegalArgumentException`异常的问题。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

