### PR TITLE
bugfix: fix getGeneratedKeys may get history pk

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -27,6 +27,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3293](https://github.com/seata/seata/pull/3293)] 修复配置缓存获取值时类型不匹配的bug
   - [[#3241](https://github.com/seata/seata/pull/3241)] 禁止在多SQL的情况下使用 limit 和 order by 语法
   - [[#3406](https://github.com/seata/seata/pull/3406)] 修复当config.txt中包含特殊字符时，键值对无法被推上nacos
+  - [[#3418](https://github.com/seata/seata/pull/3418)] 修复 getGeneratedKeys 可能会取到历史的主键的问题
 
 
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -27,6 +27,7 @@
   - [[#3293](https://github.com/seata/seata/pull/3293)] configuration cache get value cast exception
   - [[#3241](https://github.com/seata/seata/pull/3241)] forbidden use order by or limit in multi sql
   - [[#3406](https://github.com/seata/seata/pull/3406)] fix the value can not be push to nacos when special charset in config.txt
+  - [[#3418](https://github.com/seata/seata/pull/3418)] fix getGeneratedKeys may get history pk
 
 
   ### optimize： 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/AbstractStatementProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/AbstractStatementProxy.java
@@ -43,11 +43,6 @@ public abstract class AbstractStatementProxy<T extends Statement> implements Sta
     protected T targetStatement;
 
     /**
-     * The generated keys cached row set.
-     */
-    private CachedRowSet generatedKeysRowSet;
-
-    /**
      * The Target sql.
      */
     protected String targetSQL;
@@ -249,11 +244,8 @@ public abstract class AbstractStatementProxy<T extends Statement> implements Sta
 
     @Override
     public ResultSet getGeneratedKeys() throws SQLException {
-        if (generatedKeysRowSet != null) {
-            return generatedKeysRowSet;
-        }
         ResultSet rs = targetStatement.getGeneratedKeys();
-        generatedKeysRowSet = RowSetProvider.newFactory().createCachedRowSet();
+        CachedRowSet generatedKeysRowSet = RowSetProvider.newFactory().createCachedRowSet();
         generatedKeysRowSet.populate(rs);
         return generatedKeysRowSet;
     }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
去掉getGeneratedKeys的时候的缓存，让每次拿到的数据都是正确的主键。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3417 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

