### PR TITLE
feature:add function for sending messages to server affinity by xid

### DIFF
--- a/common/src/main/java/io/seata/common/DefaultValues.java
+++ b/common/src/main/java/io/seata/common/DefaultValues.java
@@ -47,6 +47,7 @@ public interface DefaultValues {
     String DEFAULT_SELECTOR_THREAD_PREFIX = "NettyClientSelector";
     String DEFAULT_WORKER_THREAD_PREFIX = "NettyClientWorkerThread";
     boolean DEFAULT_ENABLE_CLIENT_BATCH_SEND_REQUEST = true;
+    boolean ENABLE_MSG_SERVER_AFFINITY_BY_XID = false;
 
 
     String DEFAULT_BOSS_THREAD_PREFIX = "NettyBoss";

--- a/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
+++ b/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
@@ -476,6 +476,12 @@ public interface ConfigurationKeys {
     String ENABLE_CLIENT_BATCH_SEND_REQUEST = TRANSPORT_PREFIX + "enableClientBatchSendRequest";
 
     /**
+     * The constant ENABLE_ENABLE_XID_SERVER_AFFINITY
+     */
+    String ENABLE_MSG_SERVER_AFFINITY_BY_XID = TRANSPORT_PREFIX + "enableMsgServerAffinityByXid";
+
+
+    /**
      * The constant DISABLE_GLOBAL_TRANSACTION.
      */
     String DISABLE_GLOBAL_TRANSACTION = SERVICE_PREFIX + "disableGlobalTransaction";

--- a/core/src/main/java/io/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -150,7 +150,7 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
             serverAddress = xid.substring(0, xid.lastIndexOf(":"));
 
         }
-        LOGGER.info("sendSyncRequest xid={},serverAddress={}",xid,serverAddress);
+        LOGGER.debug("sendSyncRequest xid={},serverAddress={}",xid,serverAddress);
 
         //String serverAddress =  String serverAddress = loadBalance(getTransactionServiceGroup(), msg);
         int timeoutMillis = NettyClientConfig.getRpcRequestTimeout();

--- a/core/src/main/java/io/seata/core/rpc/netty/NettyClientConfig.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/NettyClientConfig.java
@@ -16,6 +16,7 @@
 package io.seata.core.rpc.netty;
 
 import io.netty.channel.Channel;
+import io.seata.common.DefaultValues;
 import io.seata.core.constants.ConfigurationKeys;
 import io.seata.core.rpc.TransportServerType;
 
@@ -56,7 +57,8 @@ public class NettyClientConfig extends NettyBaseConfig {
     private static final boolean DEFAULT_POOL_TEST_RETURN = true;
     private static final boolean DEFAULT_POOL_LIFO = true;
     private static final boolean ENABLE_CLIENT_BATCH_SEND_REQUEST = CONFIG.getBoolean(ConfigurationKeys.ENABLE_CLIENT_BATCH_SEND_REQUEST, DEFAULT_ENABLE_CLIENT_BATCH_SEND_REQUEST);
-
+    private static final boolean ENABLE_MSG_SERVER_AFFINITY_BY_XID
+            = CONFIG.getBoolean(ConfigurationKeys.ENABLE_MSG_SERVER_AFFINITY_BY_XID, DefaultValues.ENABLE_MSG_SERVER_AFFINITY_BY_XID);
     /**
      * Gets connect timeout millis.
      *
@@ -442,4 +444,9 @@ public class NettyClientConfig extends NettyBaseConfig {
     public static boolean isEnableClientBatchSendRequest() {
         return ENABLE_CLIENT_BATCH_SEND_REQUEST;
     }
+
+    public static boolean isEnableMsgServerAffinityByXid() {
+        return ENABLE_MSG_SERVER_AFFINITY_BY_XID;
+    }
+
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
This RP enabled msg server affinity by xid , if we configure transport.enableMsgServerAffinityByXid=true,
  all the  message with same XID will be sent to the same TC server. Then we can optimize the server with cache or concurrent 2 phase commit etc for high performance.
当设置 transport.enableMsgServerAffinityByXid=true 后，所有具有相同xid的消息发送到同一TC 服务器。这样，将来就可以进行如缓存，并发异步提交等各种优化来提升性能。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

