### PR TITLE
feature: send the `seata-server` log to `logstash` or `kafka`

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -22,6 +22,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3411](https://github.com/seata/seata/pull/3411)] 支持配置seata服务器的线程池参数
   - [[#3348](https://github.com/seata/seata/pull/3348)] 支持redis哨兵模式
   - [[#2667](https://github.com/seata/seata/pull/2667)] 支持db和redis密码加解密
+  - [[#3443](https://github.com/seata/seata/pull/3443)] 将`seata-server`的日志发送到`logstash`中，再存入`ElasticSearch`
 
 
   ### bugfix：

--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -22,7 +22,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3411](https://github.com/seata/seata/pull/3411)] 支持配置seata服务器的线程池参数
   - [[#3348](https://github.com/seata/seata/pull/3348)] 支持redis哨兵模式
   - [[#2667](https://github.com/seata/seata/pull/2667)] 支持db和redis密码加解密
-  - [[#3443](https://github.com/seata/seata/pull/3443)] 将`seata-server`的日志发送到`logstash`中，再存入`ElasticSearch`
+  - [[#3443](https://github.com/seata/seata/pull/3443)] 将`seata-server`的日志发送到`logstash`或`kafka`中，再存入`ElasticSearch`
 
 
   ### bugfix：

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -22,6 +22,7 @@
   - [[#3411](https://github.com/seata/seata/pull/3411)] support seata server thread pool parameters configuration
   - [[#3348](https://github.com/seata/seata/pull/3348)] support redis sentinel mode
   - [[#2667](https://github.com/seata/seata/pull/2667)] support password decryption
+  - [[#3443](https://github.com/seata/seata/pull/3443)] send the `seata-server` log to `logstash`
   
   ### bugfix：
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -22,7 +22,7 @@
   - [[#3411](https://github.com/seata/seata/pull/3411)] support seata server thread pool parameters configuration
   - [[#3348](https://github.com/seata/seata/pull/3348)] support redis sentinel mode
   - [[#2667](https://github.com/seata/seata/pull/2667)] support password decryption
-  - [[#3443](https://github.com/seata/seata/pull/3443)] send the `seata-server` log to `logstash`
+  - [[#3443](https://github.com/seata/seata/pull/3443)] send the `seata-server` log to `logstash` or `kafka`
   
   ### bugfix：
 

--- a/script/logstash/config/logstash-kafka.conf
+++ b/script/logstash/config/logstash-kafka.conf
@@ -1,0 +1,17 @@
+# App -> Kafka -> Logstash -> Elasticsearch pipeline.
+
+input {
+	kafka {
+		bootstrap_servers => "localhost:9092"
+		topics => ["to_logstash"]
+	}
+}
+
+output{
+	elasticsearch {
+		hosts => ["localhost:9200"]
+	}
+	stdout {
+		codec => rubydebug
+	}
+}

--- a/script/logstash/config/logstash-logback.conf
+++ b/script/logstash/config/logstash-logback.conf
@@ -1,33 +1,19 @@
-# Copyright 1999-2019 Seata.io Group.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at、
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Logback -> Logstash -> Elasticsearch pipeline.
+# App -> Logback -> Logstash -> Elasticsearch pipeline.
 
 input {
-    # Using TCP protocol
-    tcp {
-        port => 4560
-        # execute command `./logstash-plugin install logstash-codec-json_lines` to install this plugin.
-        codec => json_lines
-    }
+	# Using TCP protocol
+	tcp {
+		port => 4560
+		# execute command `./logstash-plugin install logstash-codec-json_lines` to install this plugin.
+		codec => json_lines
+	}
 }
 
 output{
-    elasticsearch {
-        hosts => ["localhost:9200"]
-    }
-    stdout {
-        codec => rubydebug
-    }
+	elasticsearch {
+		hosts => ["localhost:9200"]
+	}
+	stdout {
+		codec => rubydebug
+	}
 }

--- a/script/logstash/config/logstash-logback.conf
+++ b/script/logstash/config/logstash-logback.conf
@@ -18,6 +18,7 @@ input {
     # Using TCP protocol
     tcp {
         port => 4560
+        # execute command `./logstash-plugin install logstash-codec-json_lines` to install this plugin.
         codec => json_lines
     }
 }

--- a/script/logstash/logstash-logback.conf
+++ b/script/logstash/logstash-logback.conf
@@ -1,0 +1,32 @@
+# Copyright 1999-2019 Seata.io Group.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at、
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Logback -> Logstash -> Elasticsearch pipeline.
+
+input {
+    # Using TCP protocol
+    tcp {
+        port => 4560
+        codec => json_lines
+    }
+}
+
+output{
+    elasticsearch {
+        hosts => ["localhost:9200"]
+    }
+    stdout {
+        codec => rubydebug
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -29,6 +29,7 @@
 
     <properties>
         <logstash-logback-encoder.version>6.5</logstash-logback-encoder.version>
+        <kafka-appender.version>0.2.0-RC2</kafka-appender.version>
     </properties>
 
     <dependencies>
@@ -127,6 +128,11 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>${logstash-logback-encoder.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.danielwegener</groupId>
+            <artifactId>logback-kafka-appender</artifactId>
+            <version>${kafka-appender.version}</version>
         </dependency>
     </dependencies>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -26,8 +26,12 @@
     <artifactId>seata-server</artifactId>
     <packaging>jar</packaging>
     <name>seata-server ${project.version}</name>
-    <dependencies>
 
+    <properties>
+        <logstash-logback-encoder.version>6.5</logstash-logback-encoder.version>
+    </properties>
+
+    <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>seata-core</artifactId>
@@ -119,6 +123,11 @@
             <artifactId>fastjson</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash-logback-encoder.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/server/src/main/java/io/seata/server/logging/logback/WhitespaceThrowableProxyConverter.java
+++ b/server/src/main/java/io/seata/server/logging/logback/WhitespaceThrowableProxyConverter.java
@@ -29,7 +29,7 @@ public class WhitespaceThrowableProxyConverter extends ThrowableProxyConverter {
 
     @Override
     protected String throwableProxyToString(IThrowableProxy tp) {
-        return "==>" + CoreConstants.LINE_SEPARATOR + super.throwableProxyToString(tp)
-                + "<==" + CoreConstants.LINE_SEPARATOR + CoreConstants.LINE_SEPARATOR;
+        return CoreConstants.LINE_SEPARATOR + super.throwableProxyToString(tp)
+                + CoreConstants.LINE_SEPARATOR + CoreConstants.LINE_SEPARATOR;
     }
 }

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -17,90 +17,32 @@
 
 <configuration scan="true" scanPeriod="60 seconds" debug="false">
     <!-- Context listeners -->
-    <contextListener class="io.seata.server.logging.listener.SystemPropertyLoggerContextListener" />
+    <contextListener class="io.seata.server.logging.listener.SystemPropertyLoggerContextListener"/>
 
     <!-- Copied from spring-boot.jar -->
-    <conversionRule conversionWord="clr" converterClass="io.seata.server.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="io.seata.server.logging.logback.WhitespaceThrowableProxyConverter" />
-    <conversionRule conversionWord="wEx" converterClass="io.seata.server.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
-    <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"/>
-    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%30.30t] %-40.40logger{39} : %m%n%wEx"/>
+    <conversionRule conversionWord="clr" converterClass="io.seata.server.logging.logback.ColorConverter"/>
+    <conversionRule conversionWord="wex" converterClass="io.seata.server.logging.logback.WhitespaceThrowableProxyConverter"/>
+    <conversionRule conversionWord="wEx" converterClass="io.seata.server.logging.logback.ExtendedWhitespaceThrowableProxyConverter"/>
 
-    <property name="LOG_HOME" value="${user.home}/logs/seata"/>
+    <!-- console-appender -->
+    <include resource="logback/console-appender.xml"/>
 
-    <!--CONSOLE-->
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
+    <!-- file-appender -->
+    <include resource="logback/file-appender.xml"/>
 
-    <!--ALL-->
-    <appender name="ALL" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_HOME}/seata-server.${PORT}.all.log</file>
-        <append>true</append>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.all.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <maxFileSize>2GB</maxFileSize>
-            <MaxHistory>7</MaxHistory>
-            <totalSizeCap>7GB</totalSizeCap>
-            <cleanHistoryOnStart>true</cleanHistoryOnStart>
-        </rollingPolicy>
-        <encoder>
-            <Pattern>${FILE_LOG_PATTERN}</Pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
-    <!--WARN-->
-    <appender name="WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>WARN</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-        <file>${LOG_HOME}/seata-server.${PORT}.warn.log</file>
-        <append>true</append>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.warn.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <maxFileSize>2GB</maxFileSize>
-            <MaxHistory>7</MaxHistory>
-            <totalSizeCap>7GB</totalSizeCap>
-            <cleanHistoryOnStart>true</cleanHistoryOnStart>
-        </rollingPolicy>
-        <encoder>
-            <Pattern>${FILE_LOG_PATTERN}</Pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
-
-    <!--ERROR-->
-    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>ERROR</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-        <file>${LOG_HOME}/seata-server.${PORT}.error.log</file>
-        <append>true</append>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <maxFileSize>2GB</maxFileSize>
-            <MaxHistory>7</MaxHistory>
-            <totalSizeCap>7GB</totalSizeCap>
-            <cleanHistoryOnStart>true</cleanHistoryOnStart>
-        </rollingPolicy>
-        <encoder>
-            <Pattern>${FILE_LOG_PATTERN}</Pattern>
-            <charset>UTF-8</charset>
-        </encoder>
-    </appender>
+    <!-- logstash-appender: off by default -->
+    <!--<include resource="logback/logstash-appender.xml"/>-->
 
     <root level="INFO">
-        <appender-ref ref="ALL"/>
-        <appender-ref ref="WARN"/>
-        <appender-ref ref="ERROR"/>
+        <!-- console-appender -->
         <appender-ref ref="CONSOLE"/>
+
+        <!-- file-appender -->
+        <appender-ref ref="FILE_ALL"/>
+        <appender-ref ref="FILE_WARN"/>
+        <appender-ref ref="FILE_ERROR"/>
+
+        <!-- logstash-appender: off by default -->
+        <!--<appender-ref ref="LOGSTASH"/>-->
     </root>
 </configuration>

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -33,6 +33,9 @@
     <!-- logstash-appender: off by default -->
     <!--<include resource="logback/logstash-appender.xml"/>-->
 
+    <!-- kafka-appender: off by default -->
+    <!--<include resource="logback/kafka-appender.xml"/>-->
+
     <root level="INFO">
         <!-- console-appender -->
         <appender-ref ref="CONSOLE"/>
@@ -44,5 +47,8 @@
 
         <!-- logstash-appender: off by default -->
         <!--<appender-ref ref="LOGSTASH"/>-->
+
+        <!-- kafka-appender: off by default -->
+        <!--<appender-ref ref="KAFKA"/>-->
     </root>
 </configuration>

--- a/server/src/main/resources/logback/console-appender.xml
+++ b/server/src/main/resources/logback/console-appender.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <!-- console-appender properties -->
+    <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%25.25t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n%wEx"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+</included>

--- a/server/src/main/resources/logback/file-appender.xml
+++ b/server/src/main/resources/logback/file-appender.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <!-- file-appender properties -->
+    <property name="LOG_HOME" value="${user.home}/logs/seata"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p --- [%30.30t] %-40.40logger{39} : %m%n%wEx"/>
+
+    <!--ALL-->
+    <appender name="FILE_ALL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_HOME}/seata-server.${PORT}.all.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.all.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>2GB</maxFileSize>
+            <MaxHistory>7</MaxHistory>
+            <totalSizeCap>7GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+        <encoder>
+            <Pattern>${FILE_LOG_PATTERN}</Pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!--WARN-->
+    <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <file>${LOG_HOME}/seata-server.${PORT}.warn.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.warn.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>2GB</maxFileSize>
+            <MaxHistory>7</MaxHistory>
+            <totalSizeCap>7GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+        <encoder>
+            <Pattern>${FILE_LOG_PATTERN}</Pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!--ERROR-->
+    <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <file>${LOG_HOME}/seata-server.${PORT}.error.log</file>
+        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_HOME}/history/seata-server.${PORT}.error.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>2GB</maxFileSize>
+            <MaxHistory>7</MaxHistory>
+            <totalSizeCap>7GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+        <encoder>
+            <Pattern>${FILE_LOG_PATTERN}</Pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+</included>

--- a/server/src/main/resources/logback/kafka-appender.xml
+++ b/server/src/main/resources/logback/kafka-appender.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <!-- kafka-appender properties -->
+    <property name="KAFKA_BOOTSTRAP_SERVERS" value="localhost:9092"/>
+    <property name="KAFKA_TOPIC" value="to_logstash"/>
+
+    <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+        <encoder>
+            <!--<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS}|%p|seata-server|${PORT:-0}|%t|%logger|%m|%wex</pattern>-->
+            <pattern>
+                {
+                "@timestamp": "%d{yyyy-MM-dd HH:mm:ss.SSS}",
+                "level":"%p",
+                "app_name":"seata-server",
+                "PORT": ${PORT:-0},
+                "thread_name": "%t",
+                "logger_name": "%logger",
+                "message": "%m",
+                "stack_trace": "%wex"
+                }
+            </pattern>
+        </encoder>
+        <topic>${KAFKA_TOPIC}</topic>
+        <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.NoKeyKeyingStrategy"/>
+        <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy"/>
+        <producerConfig>bootstrap.servers=${KAFKA_BOOTSTRAP_SERVERS}</producerConfig>
+        <producerConfig>acks=0</producerConfig>
+        <producerConfig>linger.ms=1000</producerConfig>
+        <producerConfig>max.block.ms=0</producerConfig>
+    </appender>
+</included>

--- a/server/src/main/resources/logback/logstash-appender.xml
+++ b/server/src/main/resources/logback/logstash-appender.xml
@@ -8,7 +8,7 @@
         <encoder charset="UTF-8" class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {
-                    "app_name": "seata-server",
+                    "app_name": "seata-server"
                 }
             </customFields>
         </encoder>

--- a/server/src/main/resources/logback/logstash-appender.xml
+++ b/server/src/main/resources/logback/logstash-appender.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <!-- logstash-appender properties -->
+    <property name="LOGSTASH_DESTINATION" value="10.1.50.106:4560"/>
+
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${LOGSTASH_DESTINATION}</destination>
+        <encoder charset="UTF-8" class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>
+                {
+                    "app_name": "seata-server",
+                }
+            </customFields>
+        </encoder>
+    </appender>
+</included>

--- a/server/src/main/resources/logback/logstash-appender.xml
+++ b/server/src/main/resources/logback/logstash-appender.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
     <!-- logstash-appender properties -->
-    <property name="LOGSTASH_DESTINATION" value="10.1.50.106:4560"/>
+    <property name="LOGSTASH_DESTINATION" value="localhost:4560"/>
 
     <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>${LOGSTASH_DESTINATION}</destination>


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
feature: send the `seata-server` log to `logstash` or `kafka`.
新功能：将`seata-server`的日志推送到`logstash`或`kafka`中，再存入`elasticsearch`中。（默认情况下，该功能处于关闭状态。需要用户自己修改`logback.xml`。）

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

