### PR TITLE
bugfix:Set auto-commit to true when local transactions are not being …

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
@@ -276,6 +276,7 @@ public class ConnectionContext {
         this.xid = xid;
         branchId = null;
         this.isGlobalLockRequire = false;
+        this.autoCommitChanged = false;
         savepoints.clear();
         lockKeysBuffer.clear();
         sqlUndoItemsBuffer.clear();

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
@@ -15,20 +15,13 @@
  */
 package io.seata.rm.datasource;
 
-import java.sql.SQLException;
-import java.sql.Savepoint;
-import java.util.Set;
-import java.util.Map;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-
-
 import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.common.util.CollectionUtils;
 import io.seata.rm.datasource.undo.SQLUndoLog;
+
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.util.*;
 
 /**
  * The type Connection context.
@@ -47,12 +40,6 @@ public class ConnectionContext {
             return "DEFAULT_SEATA_SAVEPOINT";
         }
     };
-
-    private String xid;
-    private Long branchId;
-    private boolean isGlobalLockRequire;
-    private Savepoint currentSavepoint = DEFAULT_SAVEPOINT;
-
     /**
      * the lock keys buffer
      */
@@ -61,8 +48,12 @@ public class ConnectionContext {
      * the undo items buffer
      */
     private final Map<Savepoint, List<SQLUndoLog>> sqlUndoItemsBuffer = new LinkedHashMap<>();
-
     private final List<Savepoint> savepoints = new ArrayList<>(8);
+    private String xid;
+    private Long branchId;
+    private boolean isGlobalLockRequire;
+    private Savepoint currentSavepoint = DEFAULT_SAVEPOINT;
+    private boolean autoCommitChanged;
 
     /**
      * whether requires global lock in this connection
@@ -102,6 +93,7 @@ public class ConnectionContext {
 
     /**
      * Append savepoint
+     *
      * @param savepoint the savepoint
      */
     void appendSavepoint(Savepoint savepoint) {
@@ -164,6 +156,25 @@ public class ConnectionContext {
      */
     public boolean isBranchRegistered() {
         return branchId != null;
+    }
+
+    /**
+     * is seata change  targetConnection autoCommit
+     *
+     * @return the boolean
+     */
+    public boolean isAutoCommitChanged() {
+        return this.autoCommitChanged;
+    }
+
+    /**
+     *
+     * set seata change targetConnection autoCommit record
+     *
+     * @param autoCommitChanged the record
+     */
+    public void setAutoCommitChanged(boolean autoCommitChanged) {
+        this.autoCommitChanged = autoCommitChanged;
     }
 
     /**
@@ -255,6 +266,7 @@ public class ConnectionContext {
         this.xid = xid;
         branchId = null;
         this.isGlobalLockRequire = false;
+        this.autoCommitChanged = false;
         savepoints.clear();
         lockKeysBuffer.clear();
         sqlUndoItemsBuffer.clear();
@@ -305,6 +317,7 @@ public class ConnectionContext {
 
     /**
      * Get the savepoints after target savepoint(include the param savepoint)
+     *
      * @param savepoint the target savepoint
      * @return after savepoints
      */
@@ -319,7 +332,7 @@ public class ConnectionContext {
     @Override
     public String toString() {
         return "ConnectionContext [xid=" + xid + ", branchId=" + branchId + ", lockKeysBuffer=" + lockKeysBuffer
-            + ", sqlUndoItemsBuffer=" + sqlUndoItemsBuffer + "]";
+                + ", sqlUndoItemsBuffer=" + sqlUndoItemsBuffer + "]";
     }
 
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
@@ -47,6 +47,13 @@ public class ConnectionContext {
             return "DEFAULT_SEATA_SAVEPOINT";
         }
     };
+
+    private String xid;
+    private Long branchId;
+    private boolean isGlobalLockRequire;
+    private Savepoint currentSavepoint = DEFAULT_SAVEPOINT;
+    private boolean autoCommitChanged;
+
     /**
      * the lock keys buffer
      */
@@ -55,12 +62,8 @@ public class ConnectionContext {
      * the undo items buffer
      */
     private final Map<Savepoint, List<SQLUndoLog>> sqlUndoItemsBuffer = new LinkedHashMap<>();
+
     private final List<Savepoint> savepoints = new ArrayList<>(8);
-    private String xid;
-    private Long branchId;
-    private boolean isGlobalLockRequire;
-    private Savepoint currentSavepoint = DEFAULT_SAVEPOINT;
-    private boolean autoCommitChanged;
 
     /**
      * whether requires global lock in this connection
@@ -100,7 +103,6 @@ public class ConnectionContext {
 
     /**
      * Append savepoint
-     *
      * @param savepoint the savepoint
      */
     void appendSavepoint(Savepoint savepoint) {
@@ -183,6 +185,7 @@ public class ConnectionContext {
     public void setAutoCommitChanged(boolean autoCommitChanged) {
         this.autoCommitChanged = autoCommitChanged;
     }
+
 
     /**
      * Bind.
@@ -273,7 +276,6 @@ public class ConnectionContext {
         this.xid = xid;
         branchId = null;
         this.isGlobalLockRequire = false;
-        this.autoCommitChanged = false;
         savepoints.clear();
         lockKeysBuffer.clear();
         sqlUndoItemsBuffer.clear();
@@ -324,7 +326,6 @@ public class ConnectionContext {
 
     /**
      * Get the savepoints after target savepoint(include the param savepoint)
-     *
      * @param savepoint the target savepoint
      * @return after savepoints
      */

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
@@ -21,7 +21,13 @@ import io.seata.rm.datasource.undo.SQLUndoLog;
 
 import java.sql.SQLException;
 import java.sql.Savepoint;
-import java.util.*;
+import java.util.Set;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 
 /**
  * The type Connection context.

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionContext.java
@@ -15,10 +15,6 @@
  */
 package io.seata.rm.datasource;
 
-import io.seata.common.exception.ShouldNeverHappenException;
-import io.seata.common.util.CollectionUtils;
-import io.seata.rm.datasource.undo.SQLUndoLog;
-
 import java.sql.SQLException;
 import java.sql.Savepoint;
 import java.util.Set;
@@ -28,6 +24,11 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+
+
+import io.seata.common.exception.ShouldNeverHappenException;
+import io.seata.common.util.CollectionUtils;
+import io.seata.rm.datasource.undo.SQLUndoLog;
 
 /**
  * The type Connection context.

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -87,19 +87,19 @@ public class ConnectionProxy extends AbstractConnectionProxy {
     }
 
     /**
-     * get global lock requires flag
-     */
-    public boolean isGlobalLockRequire() {
-        return context.isGlobalLockRequire();
-    }
-
-    /**
      * set global lock requires flag
      *
      * @param isLock whether to lock
      */
     public void setGlobalLockRequire(boolean isLock) {
         context.setGlobalLockRequire(isLock);
+    }
+
+    /**
+     * get global lock requires flag
+     */
+    public boolean isGlobalLockRequire() {
+        return context.isGlobalLockRequire();
     }
 
     /**
@@ -123,17 +123,6 @@ public class ConnectionProxy extends AbstractConnectionProxy {
             recognizeLockKeyConflictException(e, lockKeys);
         }
     }
-
-    /**
-     * change connection autoCommit to false by seata
-     *
-     * @throws SQLException
-     */
-    public void changeAutoCommit() throws SQLException {
-        getContext().setAutoCommitChanged(true);
-        setAutoCommit(false);
-    }
-
 
     /**
      * Lock query.
@@ -197,7 +186,7 @@ public class ConnectionProxy extends AbstractConnectionProxy {
                 return null;
             });
         } catch (SQLException e) {
-            if (targetConnection != null && !getAutoCommit() && !getContext().isAutoCommitChanged()) {
+            if (targetConnection != null && !getAutoCommit()) {
                 rollback();
             }
             throw e;
@@ -289,6 +278,16 @@ public class ConnectionProxy extends AbstractConnectionProxy {
             report(false);
         }
         context.reset();
+    }
+
+    /**
+     * change connection autoCommit to false by seata
+     *
+     * @throws SQLException
+     */
+    public void changeAutoCommit() throws SQLException {
+        getContext().setAutoCommitChanged(true);
+        setAutoCommit(false);
     }
 
     @Override

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -15,6 +15,11 @@
  */
 package io.seata.rm.datasource;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.util.concurrent.Callable;
+
 import io.seata.common.util.StringUtils;
 import io.seata.config.ConfigurationFactory;
 import io.seata.core.constants.ConfigurationKeys;
@@ -30,11 +35,6 @@ import io.seata.rm.datasource.undo.UndoLogManagerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Savepoint;
-import java.util.concurrent.Callable;
-
 import static io.seata.common.DefaultValues.DEFAULT_CLIENT_LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT;
 import static io.seata.common.DefaultValues.DEFAULT_CLIENT_REPORT_RETRY_COUNT;
 import static io.seata.common.DefaultValues.DEFAULT_CLIENT_REPORT_SUCCESS_ENABLE;
@@ -46,13 +46,17 @@ import static io.seata.common.DefaultValues.DEFAULT_CLIENT_REPORT_SUCCESS_ENABLE
  */
 public class ConnectionProxy extends AbstractConnectionProxy {
 
-    public static final boolean IS_REPORT_SUCCESS_ENABLE = ConfigurationFactory.getInstance().getBoolean(
-            ConfigurationKeys.CLIENT_REPORT_SUCCESS_ENABLE, DEFAULT_CLIENT_REPORT_SUCCESS_ENABLE);
     private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionProxy.class);
+
+    private ConnectionContext context = new ConnectionContext();
+
     private static final int REPORT_RETRY_COUNT = ConfigurationFactory.getInstance().getInt(
             ConfigurationKeys.CLIENT_REPORT_RETRY_COUNT, DEFAULT_CLIENT_REPORT_RETRY_COUNT);
+
+    public static final boolean IS_REPORT_SUCCESS_ENABLE = ConfigurationFactory.getInstance().getBoolean(
+            ConfigurationKeys.CLIENT_REPORT_SUCCESS_ENABLE, DEFAULT_CLIENT_REPORT_SUCCESS_ENABLE);
+
     private final static LockRetryPolicy LOCK_RETRY_POLICY = new LockRetryPolicy();
-    private ConnectionContext context = new ConnectionContext();
 
     /**
      * Instantiates a new Connection proxy.

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -186,7 +186,7 @@ public class ConnectionProxy extends AbstractConnectionProxy {
                 return null;
             });
         } catch (SQLException e) {
-            if (targetConnection != null && !getAutoCommit()) {
+            if (targetConnection != null && !getAutoCommit() && !getContext().isAutoCommitChanged()) {
                 rollback();
             }
             throw e;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -35,7 +35,9 @@ import java.sql.SQLException;
 import java.sql.Savepoint;
 import java.util.concurrent.Callable;
 
-import static io.seata.common.DefaultValues.*;
+import static io.seata.common.DefaultValues.DEFAULT_CLIENT_LOCK_RETRY_POLICY_BRANCH_ROLLBACK_ON_CONFLICT;
+import static io.seata.common.DefaultValues.DEFAULT_CLIENT_REPORT_RETRY_COUNT;
+import static io.seata.common.DefaultValues.DEFAULT_CLIENT_REPORT_SUCCESS_ENABLE;
 
 /**
  * The type Connection proxy.

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -127,10 +127,16 @@ public class ConnectionProxy extends AbstractConnectionProxy {
     }
 
 
+    /**
+     * record seata-AT mode to change the connection autoCommit field
+     */
     public void seataChangeAutoCommit(){
         this.seataChangeAutoCommit = true;
     }
 
+    /**
+     * reset seata-AT mode to change the connection autoCommit field
+     */
     public void resetSeataChangeAutoCommitRecord(){
         this.seataChangeAutoCommit = false;
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/ConnectionProxy.java
@@ -58,6 +58,8 @@ public class ConnectionProxy extends AbstractConnectionProxy {
 
     private final static LockRetryPolicy LOCK_RETRY_POLICY = new LockRetryPolicy();
 
+    private boolean seataChangeAutoCommit = false;
+
     /**
      * Instantiates a new Connection proxy.
      *
@@ -124,6 +126,15 @@ public class ConnectionProxy extends AbstractConnectionProxy {
         }
     }
 
+
+    public void seataChangeAutoCommit(){
+        this.seataChangeAutoCommit = true;
+    }
+
+    public void resetSeataChangeAutoCommitRecord(){
+        this.seataChangeAutoCommit = false;
+    }
+
     /**
      * Lock query.
      *
@@ -186,7 +197,7 @@ public class ConnectionProxy extends AbstractConnectionProxy {
                 return null;
             });
         } catch (SQLException e) {
-            if (targetConnection != null && !getAutoCommit()) {
+            if (targetConnection != null && !getAutoCommit() && !seataChangeAutoCommit) {
                 rollback();
             }
             throw e;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutor.java
@@ -136,6 +136,7 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
         ConnectionProxy connectionProxy = statementProxy.getConnectionProxy();
         try {
             connectionProxy.setAutoCommit(false);
+            connectionProxy.seataChangeAutoCommit();
             return new LockRetryPolicy(connectionProxy).execute(() -> {
                 T result = executeAutoCommitFalse(args);
                 connectionProxy.commit();
@@ -150,7 +151,9 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
             throw e;
         } finally {
             connectionProxy.getContext().reset();
+            connectionProxy.resetSeataChangeAutoCommitRecord();
             connectionProxy.setAutoCommit(true);
+
         }
     }
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/AbstractDMLBaseExecutor.java
@@ -135,8 +135,7 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
     protected T executeAutoCommitTrue(Object[] args) throws Throwable {
         ConnectionProxy connectionProxy = statementProxy.getConnectionProxy();
         try {
-            connectionProxy.setAutoCommit(false);
-            connectionProxy.seataChangeAutoCommit();
+            connectionProxy.changeAutoCommit();
             return new LockRetryPolicy(connectionProxy).execute(() -> {
                 T result = executeAutoCommitFalse(args);
                 connectionProxy.commit();
@@ -151,9 +150,7 @@ public abstract class AbstractDMLBaseExecutor<T, S extends Statement> extends Ba
             throw e;
         } finally {
             connectionProxy.getContext().reset();
-            connectionProxy.resetSeataChangeAutoCommitRecord();
             connectionProxy.setAutoCommit(true);
-
         }
     }
 


### PR DESCRIPTION
…used. Failure to compete for a lock causes the global transaction to exit, invaliding the global row lock and dirty writing of the data.

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
bugfix

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix #3442 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
可以下载该代码，https://github.com/ben905713861/seataTest，去除本地事务注解，并发访问测试

### Ⅴ. Special notes for reviews

