### PR TITLE
optimize: remove duplicate validAddress code

### DIFF
--- a/discovery/seata-discovery-nacos/src/main/java/io/seata/discovery/registry/nacos/NacosRegistryServiceImpl.java
+++ b/discovery/seata-discovery-nacos/src/main/java/io/seata/discovery/registry/nacos/NacosRegistryServiceImpl.java
@@ -21,6 +21,7 @@ import com.alibaba.nacos.api.naming.listener.EventListener;
 import com.alibaba.nacos.api.naming.listener.NamingEvent;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.client.naming.utils.CollectionUtils;
+import io.seata.common.util.NetUtil;
 import io.seata.common.util.StringUtils;
 import io.seata.config.Configuration;
 import io.seata.config.ConfigurationFactory;
@@ -81,13 +82,13 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
 
     @Override
     public void register(InetSocketAddress address) throws Exception {
-        validAddress(address);
+        NetUtil.validAddress(address);
         getNamingInstance().registerInstance(getServiceName(), getServiceGroup(), address.getAddress().getHostAddress(), address.getPort(), getClusterName());
     }
 
     @Override
     public void unregister(InetSocketAddress address) throws Exception {
-        validAddress(address);
+        NetUtil.validAddress(address);
         getNamingInstance().deregisterInstance(getServiceName(), getServiceGroup(), address.getAddress().getHostAddress(), address.getPort(), getClusterName());
     }
 
@@ -154,12 +155,6 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
     @Override
     public void close() throws Exception {
 
-    }
-
-    private void validAddress(InetSocketAddress address) {
-        if (address.getHostName() == null || 0 == address.getPort()) {
-            throw new IllegalArgumentException("invalid address:" + address);
-        }
     }
 
     /**


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
移除`NacosRegistryServiceImpl`类中重复的`validAddress`方法，保持和其他`RegistryService`实现一样，使用`NetUtil.validAddress`方法。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

