### PR TITLE
bugfix:fix the NPE of RedisTransactionStoreManager when get branch tr…

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -42,7 +42,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3451](https://github.com/seata/seata/pull/3451)] 修复当不使用本地事务且设置自动提交为true时，全局锁竞争失败会使得rm退出全局事务，导致全局锁在rm重试时失效，数据被脏写
   - [[#3481](https://github.com/seata/seata/pull/3481)] 修复当 consul client 获取集群信息报错时会导致刷新任务中断
   - [[#3491](https://github.com/seata/seata/pull/3491)] 修复README.md文件中的拼写错误
-  - [[#3531](https://github.com/seata/seata/pull/3531)] 修复RedisTransactionStoreManager读取brachTransaction中的NEP
+  - [[#3531](https://github.com/seata/seata/pull/3531)] 修复RedisTransactionStoreManager读取brachTransaction中的NPE
 
   ### optimize： 
 

--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -42,7 +42,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3451](https://github.com/seata/seata/pull/3451)] 修复当不使用本地事务且设置自动提交为true时，全局锁竞争失败会使得rm退出全局事务，导致全局锁在rm重试时失效，数据被脏写
   - [[#3481](https://github.com/seata/seata/pull/3481)] 修复当 consul client 获取集群信息报错时会导致刷新任务中断
   - [[#3491](https://github.com/seata/seata/pull/3491)] 修复README.md文件中的拼写错误
-
+  - [[#3531](https://github.com/seata/seata/pull/3531)] 修复RedisTransactionStoreManager读取brachTransaction中的NEP
 
   ### optimize： 
 
@@ -72,7 +72,6 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3236](https://github.com/seata/seata/pull/3236)] 优化执行解锁操作的条件，减少不必要的store操作。
   - [[#3485](https://github.com/seata/seata/pull/3485)] 优化 ConfigurationFactory 中无用的try/catch
   - [[#3505](https://github.com/seata/seata/pull/3505)] 优化GlobalTransactionScanner类中无用的if判断
-  
 
   ### test
 
@@ -102,6 +101,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [13414850431](https://github.com/13414850431)
   - [github-ganyu](https://github.com/github-ganyu)
   - [xuande](https://github.com/xuande)
+  - [tanggen](https://github.com/tanggen)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -43,6 +43,7 @@
   - [[#3451](https://github.com/seata/seata/pull/3451)] fix set auto-commit to true when local transactions are not being used. Failure to compete for a lock causes the global transaction to exit, invaliding the global row lock and dirty writing of the data.
   - [[#3481](https://github.com/seata/seata/pull/3481)] fix seata node refresh failure because consul crash
   - [[#3491](https://github.com/seata/seata/pull/3491)] fix typo in README.md
+  - [[#3531](https://github.com/seata/seata/pull/3531)] fix the NEP of RedisTransactionStoreManager when get branch transactions
 
 
   ### optimize： 	
@@ -105,6 +106,7 @@
   - [13414850431](https://github.com/13414850431)
   - [github-ganyu](https://github.com/github-ganyu)
   - [xuande](https://github.com/xuande)
+  - [tanggen](https://github.com/tanggen)
   
 
   Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.	

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -43,7 +43,7 @@
   - [[#3451](https://github.com/seata/seata/pull/3451)] fix set auto-commit to true when local transactions are not being used. Failure to compete for a lock causes the global transaction to exit, invaliding the global row lock and dirty writing of the data.
   - [[#3481](https://github.com/seata/seata/pull/3481)] fix seata node refresh failure because consul crash
   - [[#3491](https://github.com/seata/seata/pull/3491)] fix typo in README.md
-  - [[#3531](https://github.com/seata/seata/pull/3531)] fix the NEP of RedisTransactionStoreManager when get branch transactions
+  - [[#3531](https://github.com/seata/seata/pull/3531)] fix the NPE of RedisTransactionStoreManager when get branch transactions
 
 
   ### optimize： 	

--- a/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
@@ -453,7 +453,6 @@ public class RedisTransactionStoreManager extends AbstractTransactionStoreManage
             for (Object branchInfo : branchInfos) {
                 if (branchInfo != null) {
                     Map<String, String> branchInfoMap = (Map<String, String>) branchInfo;
-                    //maybe async_commit task has delete the map in redis,so make sure the map not null
                     Optional<BranchTransactionDO> branchTransactionDO =
                             Optional.ofNullable((BranchTransactionDO) BeanUtils.mapToObject(branchInfoMap, BranchTransactionDO.class));
                     branchTransactionDO.ifPresent(branchTransactionDOs::add);

--- a/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
@@ -15,12 +15,7 @@
  */
 package io.seata.server.storage.redis.store;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -452,9 +447,10 @@ public class RedisTransactionStoreManager extends AbstractTransactionStoreManage
             for (Object branchInfo : branchInfos) {
                 if (branchInfo != null) {
                     Map<String, String> branchInfoMap = (Map<String, String>) branchInfo;
-                    BranchTransactionDO branchTransactionDO =
-                            (BranchTransactionDO) BeanUtils.mapToObject(branchInfoMap, BranchTransactionDO.class);
-                    branchTransactionDOs.add(branchTransactionDO);
+                    //maybe async_commit task has delete the map in redis,so make sure the map not null
+                    Optional<BranchTransactionDO> branchTransactionDO =
+                            Optional.ofNullable((BranchTransactionDO) BeanUtils.mapToObject(branchInfoMap, BranchTransactionDO.class));
+                    branchTransactionDO.ifPresent(branchTransactionDOs::add);
                 }
             }
         }

--- a/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
@@ -15,7 +15,13 @@
  */
 package io.seata.server.storage.redis.store;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
fix the NEP of RedisTransactionStoreManager when get branch transactions

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3525

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
this NEP is not happening every time，it happens when submit a lot transaction，then sometime async_committer delete brach map in redis befor global transaction read it. 

### Ⅳ. Describe how to verify it
submit a lot transaction，break point at BranchTransactionDO.compareTo() with condition:(this.getGmtCreate() == null || branchTransactionDO == null || branchTransactionDO.getGmtCreate() == null) ,maybe u will get the NEP.

### Ⅴ. Special notes for reviews
the NEP happened many times in testing with more than 100W transaction，after fixed，never happend in 100W transaction .
