### PR TITLE
optimize: add timer to deal with the global session when startup

### DIFF
--- a/common/src/main/java/io/seata/common/Constants.java
+++ b/common/src/main/java/io/seata/common/Constants.java
@@ -153,9 +153,9 @@ public interface Constants {
     String TX_TIMEOUT_CHECK = "TxTimeoutCheck";
 
     /**
-     * the constant FINISHED
+     * the constant ERROR_STATE
      */
-    String FINISHED = "Finished";
+    String ERROR_STATE = "ErrorState";
 
     /**
      * The constant UNDOLOG_DELETE

--- a/common/src/main/java/io/seata/common/Constants.java
+++ b/common/src/main/java/io/seata/common/Constants.java
@@ -153,6 +153,11 @@ public interface Constants {
     String TX_TIMEOUT_CHECK = "TxTimeoutCheck";
 
     /**
+     * the constant FINISHED
+     */
+    String FINISHED = "Finished";
+
+    /**
      * The constant UNDOLOG_DELETE
      */
     String UNDOLOG_DELETE = "UndologDelete";

--- a/server/src/main/java/io/seata/server/session/SessionCondition.java
+++ b/server/src/main/java/io/seata/server/session/SessionCondition.java
@@ -25,9 +25,8 @@ import io.seata.core.model.GlobalStatus;
 public class SessionCondition {
     private Long transactionId;
     private String xid;
-    private GlobalStatus status;
     private GlobalStatus[] statuses;
-    private long overTimeAliveMills;
+    private Long overTimeAliveMills;
 
     /**
      * Instantiates a new Session condition.
@@ -63,29 +62,11 @@ public class SessionCondition {
     }
 
     /**
-     * Gets status.
-     *
-     * @return the status
-     */
-    public GlobalStatus getStatus() {
-        return status;
-    }
-
-    /**
-     * Sets status.
-     *
-     * @param status the status
-     */
-    public void setStatus(GlobalStatus status) {
-        this.status = status;
-    }
-
-    /**
      * Gets over time alive mills.
      *
      * @return the over time alive mills
      */
-    public long getOverTimeAliveMills() {
+    public Long getOverTimeAliveMills() {
         return overTimeAliveMills;
     }
 
@@ -118,7 +99,7 @@ public class SessionCondition {
         return statuses;
     }
 
-    public void setStatuses(GlobalStatus[] statuses) {
+    public void setStatuses(GlobalStatus ...statuses) {
         this.statuses = statuses;
     }
 }

--- a/server/src/main/java/io/seata/server/session/SessionCondition.java
+++ b/server/src/main/java/io/seata/server/session/SessionCondition.java
@@ -47,19 +47,9 @@ public class SessionCondition {
     /**
      * Instantiates a new Session condition.
      *
-     * @param status the status
-     */
-    public SessionCondition(GlobalStatus status) {
-        this.status = status;
-        statuses = new GlobalStatus[] {status};
-    }
-
-    /**
-     * Instantiates a new Session condition.
-     *
      * @param statuses the statuses
      */
-    public SessionCondition(GlobalStatus[] statuses) {
+    public SessionCondition(GlobalStatus ...statuses) {
         this.statuses = statuses;
     }
 

--- a/server/src/main/java/io/seata/server/session/SessionHolder.java
+++ b/server/src/main/java/io/seata/server/session/SessionHolder.java
@@ -41,6 +41,7 @@ import static io.seata.common.Constants.RETRY_COMMITTING;
 import static io.seata.common.Constants.RETRY_ROLLBACKING;
 import static io.seata.common.Constants.TX_TIMEOUT_CHECK;
 import static io.seata.common.Constants.UNDOLOG_DELETE;
+import static io.seata.common.Constants.FINISHED;
 
 /**
  * The type Session holder.
@@ -195,7 +196,7 @@ public class SessionHolder {
         }
     }
 
-    private static void removeInErrorState(GlobalSession globalSession) {
+    public static void removeInErrorState(GlobalSession globalSession) {
         try {
             LOGGER.warn("The global session should NOT be {}, remove it. xid = {}", globalSession.getStatus(), globalSession.getXid());
             ROOT_SESSION_MANAGER.removeGlobalSession(globalSession);
@@ -359,12 +360,21 @@ public class SessionHolder {
     }
 
     /**
-     * tx timeout check lOck
+     * tx timeout check lock
      *
      * @return the boolean
      */
     public static boolean txTimeoutCheckLock() {
         return getRootSessionManager().scheduledLock(TX_TIMEOUT_CHECK);
+    }
+
+    /**
+     * finished lock
+     *
+     * @return the boolean
+     */
+    public static boolean finishedLock() {
+        return getRootSessionManager().scheduledLock(FINISHED);
     }
 
     /**
@@ -419,6 +429,15 @@ public class SessionHolder {
      */
     public static boolean unUndoLogDeleteLock() {
         return getRootSessionManager().unScheduledLock(UNDOLOG_DELETE);
+    }
+
+    /**
+     * un finished lock
+     *
+     * @return the boolean
+     */
+    public static boolean unFinishedLock() {
+        return getRootSessionManager().unScheduledLock(FINISHED);
     }
 
     public static void destroy() {

--- a/server/src/main/java/io/seata/server/storage/file/session/FileSessionManager.java
+++ b/server/src/main/java/io/seata/server/storage/file/session/FileSessionManager.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.seata.common.exception.ShouldNeverHappenException;
@@ -120,10 +122,38 @@ public class FileSessionManager extends AbstractSessionManager implements Reload
     @Override
     public List<GlobalSession> findGlobalSessions(SessionCondition condition) {
         List<GlobalSession> found = new ArrayList<>();
+
+        List<GlobalStatus> globalStatuses = null;
+        if (null != condition.getStatuses() && condition.getStatuses().length > 0) {
+            globalStatuses = Arrays.asList(condition.getStatuses());
+        }
         for (GlobalSession globalSession : sessionMap.values()) {
-            if (System.currentTimeMillis() - globalSession.getBeginTime() > condition.getOverTimeAliveMills()) {
-                found.add(globalSession);
+            if (null != condition.getOverTimeAliveMills() && condition.getOverTimeAliveMills() > 0) {
+                if (System.currentTimeMillis() - globalSession.getBeginTime() <= condition.getOverTimeAliveMills()) {
+                    continue;
+                }
             }
+
+            if (null != globalStatuses) {
+                if (!globalStatuses.contains(globalSession.getStatus())) {
+                    continue;
+                }
+            }
+
+            if (null != condition.getTransactionId() && condition.getTransactionId() > 0) {
+                if (!Objects.equals(condition.getTransactionId(), globalSession.getTransactionId())) {
+                    continue;
+                }
+            }
+
+            if (!StringUtils.isEmpty(condition.getXid())) {
+                if (!Objects.equals(condition.getXid(), globalSession.getXid())) {
+                    continue;
+                }
+            }
+
+            // All test pass, add to resp
+            found.add(globalSession);
         }
         return found;
     }

--- a/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/redis/store/RedisTransactionStoreManager.java
@@ -387,8 +387,6 @@ public class RedisTransactionStoreManager extends AbstractTransactionStoreManage
             return globalSessions;
         } else if (CollectionUtils.isNotEmpty(sessionCondition.getStatuses())) {
             return readSession(sessionCondition.getStatuses());
-        } else if (sessionCondition.getStatus() != null) {
-            return readSession(new GlobalStatus[]{sessionCondition.getStatus()});
         }
         return null;
     }

--- a/server/src/test/java/io/seata/server/session/FileSessionManagerTest.java
+++ b/server/src/test/java/io/seata/server/session/FileSessionManagerTest.java
@@ -208,7 +208,6 @@ public class FileSessionManagerTest {
     /**
      * Find global sessions test.
      *
-     * @param globalSessions the global sessions
      * @throws Exception the exception
      */
     @ParameterizedTest
@@ -222,9 +221,21 @@ public class FileSessionManagerTest {
             Collection<GlobalSession> expectedGlobalSessions = sessionManager.findGlobalSessions(sessionCondition);
             Assertions.assertNotNull(expectedGlobalSessions);
             Assertions.assertEquals(2, expectedGlobalSessions.size());
-            for (GlobalSession globalSession : globalSessions) {
-                sessionManager.removeGlobalSession(globalSession);
-            }
+
+            SessionCondition sessionCondition1 = new SessionCondition(globalSessions.get(0).getXid());
+            expectedGlobalSessions = sessionManager.findGlobalSessions(sessionCondition1);
+            Assertions.assertNotNull(expectedGlobalSessions);
+            Assertions.assertEquals(1, expectedGlobalSessions.size());
+
+            sessionCondition1.setTransactionId(globalSessions.get(0).getTransactionId());
+            expectedGlobalSessions = sessionManager.findGlobalSessions(sessionCondition1);
+            Assertions.assertNotNull(expectedGlobalSessions);
+            Assertions.assertEquals(1, expectedGlobalSessions.size());
+
+            sessionCondition1.setStatuses(globalSessions.get(0).getStatus());
+            expectedGlobalSessions = sessionManager.findGlobalSessions(sessionCondition1);
+            Assertions.assertNotNull(expectedGlobalSessions);
+            Assertions.assertEquals(1, expectedGlobalSessions.size());
         }
     }
 

--- a/server/src/test/java/io/seata/server/session/redis/RedisSessionManagerTest.java
+++ b/server/src/test/java/io/seata/server/session/redis/RedisSessionManagerTest.java
@@ -281,10 +281,6 @@ public class RedisSessionManagerTest {
         sessionManager.addBranchSession(session, branchSession);
 
         SessionCondition condition = new SessionCondition();
-        condition.setStatus(GlobalStatus.Begin);
-        sessionManager.findGlobalSessions(condition);
-
-        condition.setStatus(null);
         GlobalStatus[] statuses = {GlobalStatus.Begin};
         condition.setStatuses(statuses);
         sessionManager.findGlobalSessions(condition);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
1. redis和db模式下，服务启动的时候，会去扫描当前的所有globalsession，并且进行处理，堵塞启动进程，把其挪到定时任务中处理，加快启动速度。
2. file模式下，启动时，Committing和CommitRetrying不进行加锁

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3537

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

