### PR TITLE
optimize: optimize the get pks by auto when auto generated keys is false

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -73,6 +73,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3236](https://github.com/seata/seata/pull/3236)] 优化执行解锁操作的条件，减少不必要的store操作。
   - [[#3485](https://github.com/seata/seata/pull/3485)] 优化 ConfigurationFactory 中无用的try/catch
   - [[#3505](https://github.com/seata/seata/pull/3505)] 优化GlobalTransactionScanner类中无用的if判断
+  - [[#3544](https://github.com/seata/seata/pull/3544)] 优化无法通过Statement#getGeneratedKeys时，只能获取到批量插入的第一个主键的问题
 
   ### test
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -75,7 +75,8 @@
   - [[#3236](https://github.com/seata/seata/pull/3236)] optimize the conditions for executing unlocking
   - [[#3485](https://github.com/seata/seata/pull/3485)] optimize useless codes in ConfigurationFactory
   - [[#3505](https://github.com/seata/seata/pull/3505)] optimize useless if judgments in the GlobalTransactionScanner class
-                                                        
+  - [[#3544](https://github.com/seata/seata/pull/3544)] optimize the get pks by auto when auto generated keys is false
+                                       
 
   
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author jsbxyyx
@@ -60,7 +61,7 @@ public class MySQLInsertExecutor extends BaseInsertExecutor implements Defaultab
      * the key is the db's resource id
      * the value is the step
      */
-    public static final Map<String, Integer> RESOURCE_ID_STEP_CACHE = new HashMap<>(8);
+    public static final Map<String, Integer> RESOURCE_ID_STEP_CACHE = new ConcurrentHashMap<>(8);
 
     /**
      * Instantiates a new Abstract dml base executor.

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
@@ -199,7 +199,7 @@ public class MySQLInsertExecutor extends BaseInsertExecutor implements Defaultab
             ResultSet increment = statementProxy.getTargetStatement().executeQuery("SHOW VARIABLES LIKE 'auto_increment_increment'");
 
             increment.next();
-            step = increment.getBigDecimal(2);
+            step = new BigDecimal(increment.getObject(2).toString());
             RESOURCE_ID_STEP_CACHE.put(resourceId, step);
         }
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
@@ -145,7 +145,7 @@ public class MySQLInsertExecutor extends BaseInsertExecutor implements Defaultab
                 // do auto increment base LAST_INSERT_ID and variable `auto_increment_increment`
                 if (updateCount > 1 && canAutoIncrement(pkMetaMap)) {
                     firstId.next();
-                    return autoGeneratePks(firstId.getBigDecimal(1), autoColumnName, updateCount);
+                    return autoGeneratePks(new BigDecimal(firstId.getString(1)), autoColumnName, updateCount);
                 }
             } else {
                 throw e;
@@ -199,7 +199,7 @@ public class MySQLInsertExecutor extends BaseInsertExecutor implements Defaultab
             ResultSet increment = statementProxy.getTargetStatement().executeQuery("SHOW VARIABLES LIKE 'auto_increment_increment'");
 
             increment.next();
-            step = new BigDecimal(increment.getObject(2).toString());
+            step = new BigDecimal(increment.getString(2));
             RESOURCE_ID_STEP_CACHE.put(resourceId, step);
         }
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
@@ -56,6 +56,13 @@ public class MySQLInsertExecutor extends BaseInsertExecutor implements Defaultab
     public static final String ERR_SQL_STATE = "S1009";
 
     /**
+     * The cache of auto increment step of database
+     * the key is the db's resource id
+     * the value is the step
+     */
+    public static final Map<String, Integer> RESOURCE_ID_STEP_CACHE = new HashMap<>(8);
+
+    /**
      * Instantiates a new Abstract dml base executor.
      *
      * @param statementProxy    the statement proxy
@@ -127,8 +134,17 @@ public class MySQLInsertExecutor extends BaseInsertExecutor implements Defaultab
             // specify Statement.RETURN_GENERATED_KEYS to
             // Statement.executeUpdate() or Connection.prepareStatement().
             if (ERR_SQL_STATE.equalsIgnoreCase(e.getSQLState())) {
-                LOGGER.warn("Fail to get auto-generated keys, use 'SELECT LAST_INSERT_ID()' instead. Be cautious, statement could be polluted. Recommend you set the statement to return generated keys.");
-                genKeys = statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
+                LOGGER.error("Fail to get auto-generated keys, use 'SELECT LAST_INSERT_ID()' instead. Be cautious, " +
+                        "statement could be polluted. Recommend you set the statement to return generated keys.");
+                int updateCount = statementProxy.getUpdateCount();
+                ResultSet firstId = genKeys = statementProxy.getTargetStatement().executeQuery("SELECT LAST_INSERT_ID()");
+
+                // If there is batch insert
+                // do auto increment base LAST_INSERT_ID and variable `auto_increment_increment`
+                if (updateCount > 1 && canAutoIncrement(pkMetaMap)) {
+                    firstId.next();
+                    return autoGeneratePks(firstId.getLong(1), autoColumnName, updateCount);
+                }
             } else {
                 throw e;
             }
@@ -170,5 +186,39 @@ public class MySQLInsertExecutor extends BaseInsertExecutor implements Defaultab
     public List<Object> getPkValuesByDefault() throws SQLException {
         // mysql default keyword the logic not support. (sample: insert into test(id, name) values(default, 'xx'))
         throw new NotSupportYetException();
+    }
+
+    protected Map<String, List<Object>> autoGeneratePks(Long first, String autoColumnName, Integer updateCount) throws SQLException {
+        int step = 1;
+        String resourceId = statementProxy.getConnectionProxy().getDataSourceProxy().getResourceId();
+        if (RESOURCE_ID_STEP_CACHE.containsKey(resourceId)) {
+            step = RESOURCE_ID_STEP_CACHE.get(resourceId);
+        } else {
+            ResultSet increment = statementProxy.getTargetStatement().executeQuery("SHOW VARIABLES LIKE 'auto_increment_increment'");
+
+            increment.next();
+            step = increment.getInt(2);
+            RESOURCE_ID_STEP_CACHE.put(resourceId, step);
+        }
+
+        List<Object> pkValues = new ArrayList<>();
+        for (int i = 0; i < updateCount; i++) {
+            pkValues.add(first + i * step);
+        }
+
+        Map<String, List<Object>> pkValuesMap = new HashMap<>(1, 1.001f);
+        pkValuesMap.put(autoColumnName,pkValues);
+        return pkValuesMap;
+    }
+
+    protected boolean canAutoIncrement(Map<String, ColumnMeta> primaryKeyMap) {
+        if (primaryKeyMap.size() != 1) {
+            return false;
+        }
+
+        for (ColumnMeta pk : primaryKeyMap.values()) {
+            return pk.isAutoincrement();
+        }
+        return false;
     }
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertExecutor.java
@@ -205,7 +205,8 @@ public class MySQLInsertExecutor extends BaseInsertExecutor implements Defaultab
 
         List<Object> pkValues = new ArrayList<>();
         for (int i = 0; i < updateCount; i++) {
-            pkValues.add(cursor.add(step));
+            pkValues.add(cursor);
+            cursor = cursor.add(step);
         }
 
         Map<String, List<Object>> pkValuesMap = new HashMap<>(1, 1.001f);

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
@@ -92,7 +92,7 @@ public class MySQLInsertExecutorTest {
         when(statementProxy.getTargetStatement()).thenReturn(statementProxy);
 
         MockResultSet resultSet = new MockResultSet(statementProxy);
-        resultSet.mockResultSet(Arrays.asList("Variable_name", "Value"), new Object[][]{{"auto_increment_increment", BigDecimal.ONE}});
+        resultSet.mockResultSet(Arrays.asList("Variable_name", "Value"), new Object[][]{{"auto_increment_increment", "1"}});
         when(statementProxy.getTargetStatement().executeQuery("SHOW VARIABLES LIKE 'auto_increment_increment'")).thenReturn(resultSet);
 
         StatementCallback statementCallback = mock(StatementCallback.class);

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
@@ -92,7 +92,7 @@ public class MySQLInsertExecutorTest {
         when(statementProxy.getTargetStatement()).thenReturn(statementProxy);
 
         MockResultSet resultSet = new MockResultSet(statementProxy);
-        resultSet.mockResultSet(Arrays.asList("Variable_name", "Value"), new Object[][]{{"auto_increment_increment", 1L}});
+        resultSet.mockResultSet(Arrays.asList("Variable_name", "Value"), new Object[][]{{"auto_increment_increment", BigDecimal.ONE}});
         when(statementProxy.getTargetStatement().executeQuery("SHOW VARIABLES LIKE 'auto_increment_increment'")).thenReturn(resultSet);
 
         StatementCallback statementCallback = mock(StatementCallback.class);

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
@@ -91,7 +91,7 @@ public class MySQLInsertExecutorTest {
         when(statementProxy.getTargetStatement()).thenReturn(statementProxy);
 
         MockResultSet resultSet = new MockResultSet(statementProxy);
-        resultSet.mockResultSet(Arrays.asList("LAST_INSERT_ID"), new Object[][]{{1L}});
+        resultSet.mockResultSet(Arrays.asList("Variable_name", "Value"), new Object[][]{{"auto_increment_increment", 1L}});
         when(statementProxy.getTargetStatement().executeQuery("SHOW VARIABLES LIKE 'auto_increment_increment'")).thenReturn(resultSet);
 
         StatementCallback statementCallback = mock(StatementCallback.class);

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertExecutorTest.java
@@ -43,6 +43,7 @@ import org.mockito.Mockito;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -581,9 +582,9 @@ public class MySQLInsertExecutorTest {
 
     @Test
     public void test_autoGeneratePks() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method method = MySQLInsertExecutor.class.getDeclaredMethod("autoGeneratePks", new Class[]{Long.class, String.class, Integer.class});
+        Method method = MySQLInsertExecutor.class.getDeclaredMethod("autoGeneratePks", new Class[]{BigDecimal.class, String.class, Integer.class});
         method.setAccessible(true);
-        Object resp = method.invoke(insertExecutor, 1L, "ID", 3);
+        Object resp = method.invoke(insertExecutor, BigDecimal.ONE, "ID", 3);
 
         Assertions.assertNotNull(resp);
         Assertions.assertTrue(resp instanceof Map);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
MySQL插入的时候，如果getGeneratedKeys无法获取到主键，并且是批量插入的时候，原本的逻辑只能回滚第一条插入的数据，参考MySQL的jdbc驱动的StatementImpl的实现，在业务层进行自增长，保证回滚的时候可以回滚全部的数据。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

