### PR TITLE
bugfix: fix the null pointer exception of calling the Seata interface when the Seata server is shut down（#3488）

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -43,6 +43,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3481](https://github.com/seata/seata/pull/3481)] 修复当 consul client 获取集群信息报错时会导致刷新任务中断
   - [[#3491](https://github.com/seata/seata/pull/3491)] 修复README.md文件中的拼写错误
   - [[#3531](https://github.com/seata/seata/pull/3531)] 修复RedisTransactionStoreManager读取brachTransaction中的NPE
+  - [[#3488](https://github.com/seata/seata/pull/3488)] 修复seata服务器关闭时，调用seata接口空指针异常
 
   ### optimize： 
 
@@ -103,6 +104,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [github-ganyu](https://github.com/github-ganyu)
   - [xuande](https://github.com/xuande)
   - [tanggen](https://github.com/tanggen)
+  - [xuxiaowei](https://github.com/xuxiaowei-com-cn)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -44,6 +44,7 @@
   - [[#3481](https://github.com/seata/seata/pull/3481)] fix seata node refresh failure because consul crash
   - [[#3491](https://github.com/seata/seata/pull/3491)] fix typo in README.md
   - [[#3531](https://github.com/seata/seata/pull/3531)] fix the NPE of RedisTransactionStoreManager when get branch transactions
+  - [[#3488](https://github.com/seata/seata/pull/3488)] fix the null pointer exception of calling the Seata interface when the Seata server is shut down
 
 
   ### optimize： 	
@@ -108,6 +109,7 @@
   - [github-ganyu](https://github.com/github-ganyu)
   - [xuande](https://github.com/xuande)
   - [tanggen](https://github.com/tanggen)
+  - [xuxiaowei](https://github.com/xuxiaowei-com-cn)
 
 
   Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.	

--- a/core/src/main/java/io/seata/core/protocol/MessageFuture.java
+++ b/core/src/main/java/io/seata/core/protocol/MessageFuture.java
@@ -66,6 +66,8 @@ public class MessageFuture {
             throw (RuntimeException)result;
         } else if (result instanceof Throwable) {
             throw new RuntimeException((Throwable)result);
+        } else if (result == null) {
+            throw new InterruptedException("Can not connect to services-server");
         }
 
         return result;


### PR DESCRIPTION
bugfix: fix the null pointer exception of calling the Seata interface when the Seata server is shut down（#3488）

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
bugfix: fix the null pointer exception of calling the Seata interface when the Seata server is shut down

### Ⅱ. Does this pull request fix one issue?
fixes #3488

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it
Repeat step: after stopping the Seata server, call the Seata interface

### Ⅴ. Special notes for reviews

