### PR TITLE
bugfix: set time threshold for transactions in committing state

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -43,6 +43,8 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3481](https://github.com/seata/seata/pull/3481)] 修复当 consul client 获取集群信息报错时会导致刷新任务中断
   - [[#3491](https://github.com/seata/seata/pull/3491)] 修复README.md文件中的拼写错误
   - [[#3531](https://github.com/seata/seata/pull/3531)] 修复RedisTransactionStoreManager读取brachTransaction中的NPE
+  - [[#3500](https://github.com/seata/seata/pull/3500)] 修复 oracle 和 postgreSql 不能查询出 column info 的问题
+  - [[#3560](https://github.com/seata/seata/pull/3560)] 修复 Committing 状态的事务没有时间阈值问题
 
   ### optimize： 
 
@@ -103,6 +105,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [github-ganyu](https://github.com/github-ganyu)
   - [xuande](https://github.com/xuande)
   - [tanggen](https://github.com/tanggen)
+  - [dmego](https://github.com/dmego)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -44,6 +44,8 @@
   - [[#3481](https://github.com/seata/seata/pull/3481)] fix seata node refresh failure because consul crash
   - [[#3491](https://github.com/seata/seata/pull/3491)] fix typo in README.md
   - [[#3531](https://github.com/seata/seata/pull/3531)] fix the NPE of RedisTransactionStoreManager when get branch transactions
+  - [[#3500](https://github.com/seata/seata/pull/3500)] fix oracle and postgreSQL can't query column info
+  - [[#3560](https://github.com/seata/seata/pull/3560)] set time threshold for transactions in committing state
 
 
   ### optimize： 	
@@ -108,6 +110,7 @@
   - [github-ganyu](https://github.com/github-ganyu)
   - [xuande](https://github.com/xuande)
   - [tanggen](https://github.com/tanggen)
+  - [dmego](https://github.com/dmego)
 
 
   Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.	

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
@@ -281,7 +281,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
         SessionHelper.forEach(rollbackingSessions, rollbackingSession -> {
             try {
                 // prevent repeated rollback
-                if (rollbackingSession.getStatus().equals(GlobalStatus.Rollbacking) && !rollbackingSession.isRollbackingDead()) {
+                if (rollbackingSession.getStatus().equals(GlobalStatus.Rollbacking) && !rollbackingSession.isDeadSession()) {
                     //The function of this 'return' is 'continue'.
                     return;
                 }
@@ -316,6 +316,11 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
         long now = System.currentTimeMillis();
         SessionHelper.forEach(committingSessions, committingSession -> {
             try {
+                // prevent repeated commit
+                if (committingSession.getStatus().equals(GlobalStatus.Committing) && !committingSession.isDeadSession()) {
+                    //The function of this 'return' is 'continue'.
+                    return;
+                }
                 if (isRetryTimeout(now, MAX_COMMIT_RETRY_TIMEOUT.toMillis(), committingSession.getBeginTime())) {
                     /**
                      * Prevent thread safety issues

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
@@ -347,7 +347,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
      */
     protected void handleAsyncCommitting() {
         Collection<GlobalSession> asyncCommittingSessions = SessionHolder.getAsyncCommittingSessionManager()
-                .allSessions();
+            .allSessions();
         if (CollectionUtils.isEmpty(asyncCommittingSessions)) {
             return;
         }

--- a/server/src/main/java/io/seata/server/session/GlobalSession.java
+++ b/server/src/main/java/io/seata/server/session/GlobalSession.java
@@ -157,10 +157,10 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
     }
 
     /**
-     * prevent could not handle rollbacking transaction
-     * @return if true force roll back
+     * prevent could not handle committing and rollbacking transaction
+     * @return if true retry commit or roll back
      */
-    public boolean isRollbackingDead() {
+    public boolean isDeadSession() {
         return (System.currentTimeMillis() - beginTime) > (2 * 6000);
     }
 
@@ -687,5 +687,4 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
             this.changeStatus(GlobalStatus.RollbackRetrying);
         }
     }
-
 }

--- a/server/src/main/java/io/seata/server/session/GlobalSession.java
+++ b/server/src/main/java/io/seata/server/session/GlobalSession.java
@@ -19,7 +19,9 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -82,6 +84,10 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
 
     private GlobalSessionLock globalSessionLock = new GlobalSessionLock();
 
+    /**
+     * The high reliable session map.
+     */
+    public static Map<GlobalStatus, Set<GlobalSession>> reliableSessionMap = new ConcurrentHashMap<>();
 
     /**
      * Add boolean.
@@ -666,18 +672,24 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
     }
 
     public void asyncCommit() throws TransactionException {
+        // first save global session in reliable map
+        saveInReliableMap(GlobalStatus.AsyncCommitting);
         this.addSessionLifecycleListener(SessionHolder.getAsyncCommittingSessionManager());
         SessionHolder.getAsyncCommittingSessionManager().addGlobalSession(this);
         this.changeStatus(GlobalStatus.AsyncCommitting);
     }
 
     public void queueToRetryCommit() throws TransactionException {
+        // first save global session in reliable map
+        saveInReliableMap(GlobalStatus.CommitRetrying);
         this.addSessionLifecycleListener(SessionHolder.getRetryCommittingSessionManager());
         SessionHolder.getRetryCommittingSessionManager().addGlobalSession(this);
         this.changeStatus(GlobalStatus.CommitRetrying);
     }
 
     public void queueToRetryRollback() throws TransactionException {
+        // first save global session in reliable map
+        saveInReliableMap(GlobalStatus.RollbackRetrying);
         this.addSessionLifecycleListener(SessionHolder.getRetryRollbackingSessionManager());
         SessionHolder.getRetryRollbackingSessionManager().addGlobalSession(this);
         GlobalStatus currentStatus = this.getStatus();
@@ -686,5 +698,18 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
         } else {
             this.changeStatus(GlobalStatus.RollbackRetrying);
         }
+    }
+
+    /**
+     * Save global session in reliable map
+     * @param status global status
+     */
+    private void saveInReliableMap(GlobalStatus status) {
+        Set<GlobalSession> sessions = reliableSessionMap.get(status);
+        if (sessions == null) {
+            sessions = new HashSet<>();
+        }
+        sessions.add(this);
+        reliableSessionMap.put(status, sessions);
     }
 }

--- a/server/src/main/java/io/seata/server/storage/db/session/DataBaseSessionManager.java
+++ b/server/src/main/java/io/seata/server/storage/db/session/DataBaseSessionManager.java
@@ -168,7 +168,7 @@ public class DataBaseSessionManager extends AbstractSessionManager
         if (SessionHolder.ASYNC_COMMITTING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
             return findGlobalSessions(new SessionCondition(GlobalStatus.AsyncCommitting));
         } else if (SessionHolder.RETRY_COMMITTING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
-            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.CommitRetrying}));
+            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.CommitRetrying, GlobalStatus.Committing}));
         } else if (SessionHolder.RETRY_ROLLBACKING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
             return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.RollbackRetrying,
                 GlobalStatus.Rollbacking, GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying}));

--- a/server/src/main/java/io/seata/server/storage/redis/session/RedisSessionManager.java
+++ b/server/src/main/java/io/seata/server/storage/redis/session/RedisSessionManager.java
@@ -166,7 +166,7 @@ public class RedisSessionManager extends AbstractSessionManager
         if (SessionHolder.ASYNC_COMMITTING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
             return findGlobalSessions(new SessionCondition(GlobalStatus.AsyncCommitting));
         } else if (SessionHolder.RETRY_COMMITTING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
-            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.CommitRetrying}));
+            return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.CommitRetrying, GlobalStatus.Committing}));
         } else if (SessionHolder.RETRY_ROLLBACKING_SESSION_MANAGER_NAME.equalsIgnoreCase(taskName)) {
             return findGlobalSessions(new SessionCondition(new GlobalStatus[] {GlobalStatus.RollbackRetrying,
                 GlobalStatus.Rollbacking, GlobalStatus.TimeoutRollbacking, GlobalStatus.TimeoutRollbackRetrying}));


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
当 TC 驱动 RM 提交事务时，如果在 doGlobalCommit  时数据库宕机，异常被捕获，此时会将事务添加到retry 的 sessionMenager 中，等待 retry 定时任务来处理，但是由于数据库宕机，数据库中事务的状态无法被修改，一直保持 Commiting 状态。retry 定时任务将不会处理该状态的事务。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3558

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
参考了 `DefaultCoordinator#handleRetryRollbacking` 中的实现。
在`DefaultCoordinator#handleRetryCommitting` 中把 committing 状态的全局事务也查出来，然后判断是否是 isDeadSession 。判断依据是 `(System.currentTimeMillis() - beginTime) > (2 * 6000);`




