### PR TITLE
bugfix: Change the loadBalance config key to kebab-case style

### DIFF
--- a/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/StarterConstants.java
+++ b/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/StarterConstants.java
@@ -33,6 +33,7 @@ public interface StarterConstants {
     String CLIENT_TM_PREFIX = CLIENT_PREFIX + ".tm";
     String LOCK_PREFIX = CLIENT_RM_PREFIX + ".lock";
     String UNDO_PREFIX = CLIENT_PREFIX + ".undo";
+    String LOAD_BALANCE_PREFIX_KEBAB_STYLE = CLIENT_PREFIX + ".load-balance";
     String LOAD_BALANCE_PREFIX = CLIENT_PREFIX + ".loadBalance";
     String LOG_PREFIX = SEATA_PREFIX + ".log";
     String COMPRESS_PREFIX = UNDO_PREFIX + ".compress";

--- a/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/properties/registry/LoadBalanceProperties.java
+++ b/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/properties/registry/LoadBalanceProperties.java
@@ -20,13 +20,13 @@ import org.springframework.stereotype.Component;
 
 import static io.seata.common.DefaultValues.DEFAULT_LOAD_BALANCE;
 import static io.seata.common.DefaultValues.VIRTUAL_NODES_DEFAULT;
-import static io.seata.spring.boot.autoconfigure.StarterConstants.LOAD_BALANCE_PREFIX;
+import static io.seata.spring.boot.autoconfigure.StarterConstants.LOAD_BALANCE_PREFIX_KEBAB_STYLE;
 
 /**
  * @author ls9527
  */
 @Component
-@ConfigurationProperties(prefix = LOAD_BALANCE_PREFIX)
+@ConfigurationProperties(prefix = LOAD_BALANCE_PREFIX_KEBAB_STYLE)
 public class LoadBalanceProperties {
     /**
      * the load balance


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
最新的代码运行出现如下异常：
```java
Description:

Configuration property name 'seata.client.loadBalance' is not valid:

    Invalid characters: 'B'
    Bean: loadBalanceProperties
    Reason: Canonical names should be kebab-case ('-' separated), lowercase alpha-numeric characters and must start with a letter

Action:

Modify 'seata.client.loadBalance' so that it conforms to the canonical names requirements.
```
将`LoadBalanceProperties`类上`@ConfigurationProperties`注解的`prefix`属性值由`xx.loadBalance`改为`xx.load-balance`，使其符合 `kebab-case style`

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

