### PR TITLE
optimize: make `LoadBalanceProperties` compatible with `spring-boot:2.x` and above

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -85,7 +85,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3549](https://github.com/seata/seata/pull/3549)] 统一不同表中的xid字段的长度
   - [[#3551](https://github.com/seata/seata/pull/3551)] 调大RETRY_DEAD_THRESHOLD的值以及设置成可配置
   - [[#3589](https://github.com/seata/seata/pull/3589)] 使用JUnit API做异常检查
-  
+  - [[#3601](https://github.com/seata/seata/pull/3601)] 使`LoadBalanceProperties`与`spring-boot:2.3.x`兼容
   
   ### test
 

--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -85,7 +85,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3549](https://github.com/seata/seata/pull/3549)] 统一不同表中的xid字段的长度
   - [[#3551](https://github.com/seata/seata/pull/3551)] 调大RETRY_DEAD_THRESHOLD的值以及设置成可配置
   - [[#3589](https://github.com/seata/seata/pull/3589)] 使用JUnit API做异常检查
-  - [[#3601](https://github.com/seata/seata/pull/3601)] 使`LoadBalanceProperties`与`spring-boot:2.3.x`兼容
+  - [[#3601](https://github.com/seata/seata/pull/3601)] 使`LoadBalanceProperties`与`spring-boot:2.3.x`及以上版本兼容
   
   ### test
 

--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -85,7 +85,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3549](https://github.com/seata/seata/pull/3549)] 统一不同表中的xid字段的长度
   - [[#3551](https://github.com/seata/seata/pull/3551)] 调大RETRY_DEAD_THRESHOLD的值以及设置成可配置
   - [[#3589](https://github.com/seata/seata/pull/3589)] 使用JUnit API做异常检查
-  - [[#3601](https://github.com/seata/seata/pull/3601)] 使`LoadBalanceProperties`与`spring-boot:2.3.x`及以上版本兼容
+  - [[#3601](https://github.com/seata/seata/pull/3601)] 使`LoadBalanceProperties`与`spring-boot:2.x`及以上版本兼容
   
   ### test
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -86,7 +86,7 @@
   - [[#3549](https://github.com/seata/seata/pull/3549)] unified the length of xid in scripts
   - [[#3551](https://github.com/seata/seata/pull/3551)] make RETRY_DEAD_THRESHOLD bigger and configurable
   - [[#3589](https://github.com/seata/seata/pull/3589)] Changed exception check by JUnit API usage
-  - [[#3601](https://github.com/seata/seata/pull/3601)] make `LoadBalanceProperties` compatible with `spring-boot:2.3.x`
+  - [[#3601](https://github.com/seata/seata/pull/3601)] make `LoadBalanceProperties` compatible with `spring-boot:2.3.x` and above
 
   ### test	
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -86,7 +86,7 @@
   - [[#3549](https://github.com/seata/seata/pull/3549)] unified the length of xid in scripts
   - [[#3551](https://github.com/seata/seata/pull/3551)] make RETRY_DEAD_THRESHOLD bigger and configurable
   - [[#3589](https://github.com/seata/seata/pull/3589)] Changed exception check by JUnit API usage
-  - [[#3601](https://github.com/seata/seata/pull/3601)] make `LoadBalanceProperties` compatible with `spring-boot:2.3.x` and above
+  - [[#3601](https://github.com/seata/seata/pull/3601)] make `LoadBalanceProperties` compatible with `spring-boot:2.x` and above
 
   ### test	
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -86,6 +86,7 @@
   - [[#3549](https://github.com/seata/seata/pull/3549)] unified the length of xid in scripts
   - [[#3551](https://github.com/seata/seata/pull/3551)] make RETRY_DEAD_THRESHOLD bigger and configurable
   - [[#3589](https://github.com/seata/seata/pull/3589)] Changed exception check by JUnit API usage
+  - [[#3601](https://github.com/seata/seata/pull/3601)] make `LoadBalanceProperties` compatible with `spring-boot:2.3.x`
 
   ### test	
 

--- a/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/StarterConstants.java
+++ b/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/StarterConstants.java
@@ -33,7 +33,8 @@ public interface StarterConstants {
     String CLIENT_TM_PREFIX = CLIENT_PREFIX + ".tm";
     String LOCK_PREFIX = CLIENT_RM_PREFIX + ".lock";
     String UNDO_PREFIX = CLIENT_PREFIX + ".undo";
-    String LOAD_BALANCE_PREFIX = CLIENT_PREFIX + ".load-balance";
+    String LOAD_BALANCE_PREFIX_KEBAB_STYLE = CLIENT_PREFIX + ".load-balance";
+    String LOAD_BALANCE_PREFIX = CLIENT_PREFIX + ".loadBalance";
     String LOG_PREFIX = SEATA_PREFIX + ".log";
     String COMPRESS_PREFIX = UNDO_PREFIX + ".compress";
 

--- a/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/StarterConstants.java
+++ b/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/StarterConstants.java
@@ -33,7 +33,7 @@ public interface StarterConstants {
     String CLIENT_TM_PREFIX = CLIENT_PREFIX + ".tm";
     String LOCK_PREFIX = CLIENT_RM_PREFIX + ".lock";
     String UNDO_PREFIX = CLIENT_PREFIX + ".undo";
-    String LOAD_BALANCE_PREFIX = CLIENT_PREFIX + ".loadBalance";
+    String LOAD_BALANCE_PREFIX = CLIENT_PREFIX + ".load-balance";
     String LOG_PREFIX = SEATA_PREFIX + ".log";
     String COMPRESS_PREFIX = UNDO_PREFIX + ".compress";
 

--- a/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/properties/registry/LoadBalanceProperties.java
+++ b/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/properties/registry/LoadBalanceProperties.java
@@ -20,13 +20,13 @@ import org.springframework.stereotype.Component;
 
 import static io.seata.common.DefaultValues.DEFAULT_LOAD_BALANCE;
 import static io.seata.common.DefaultValues.VIRTUAL_NODES_DEFAULT;
-import static io.seata.spring.boot.autoconfigure.StarterConstants.LOAD_BALANCE_PREFIX;
+import static io.seata.spring.boot.autoconfigure.StarterConstants.LOAD_BALANCE_PREFIX_KEBAB_STYLE;
 
 /**
  * @author ls9527
  */
 @Component
-@ConfigurationProperties(prefix = LOAD_BALANCE_PREFIX)
+@ConfigurationProperties(prefix = LOAD_BALANCE_PREFIX_KEBAB_STYLE)
 public class LoadBalanceProperties {
     /**
      * the load balance

--- a/seata-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/seata-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -187,7 +187,7 @@
       "deprecation": {
         "level": "error",
         "replacement": "seata.log.exception-rate",
-        "reason": "The location of this configuration has been changed to 'seata.log.exception-rate'."
+        "reason": "Please configure to 'seata.log.exception-rate'."
       }
     },
     {
@@ -269,6 +269,28 @@
       "defaultValue": 1
     },
     {
+      "name": "seata.registry.load-balance",
+      "type": "java.lang.String",
+      "sourceType": "io.seata.spring.boot.autoconfigure.properties.registry.RegistryProperties",
+      "defaultValue": "RandomLoadBalance",
+      "deprecation": {
+        "level": "error",
+        "replacement": "seata.client.load-balance.type",
+        "reason": "Please configure to 'seata.client.load-balance.type'."
+      }
+    },
+    {
+      "name": "seata.registry.load-balance-virtual-nodes",
+      "type": "java.lang.Integer",
+      "sourceType": "io.seata.spring.boot.autoconfigure.properties.registry.RegistryProperties",
+      "defaultValue": 10,
+      "deprecation": {
+        "level": "error",
+        "replacement": "seata.client.load-balance.virtual-nodes",
+        "reason": "Please configure to 'seata.client.load-balance.virtual-nodes'."
+      }
+    },
+    {
       "name": "seata.client.load-balance.type",
       "type": "java.lang.String",
       "sourceType": "io.seata.spring.boot.autoconfigure.properties.registry.LoadBalanceProperties",
@@ -305,7 +327,7 @@
       ]
     },
     {
-      "name": "seata.registry.load-balance",
+      "name": "seata.client.load-balance.type",
       "values": [
         {
           "value": "RandomLoadBalance",


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
optimize: make `LoadBalanceProperties` compatible with `spring-boot:2.x` and above.
优化：使`LoadBalanceProperties`与`spring-boot:2.x`及以上版本兼容。

原因：springboot从2.x开始，强制要求`@ConfigurationProperties`的prefix属性必须使用kebab-case格式。不能使用驼峰格式。

错误信息如下：
```
***************************
APPLICATION FAILED TO START
***************************

Description:

Configuration property name 'seata.client.loadBalance' is not valid:

    Invalid characters: 'B'
    Bean: loadBalanceProperties
    Reason: Canonical names should be kebab-case ('-' separated), lowercase alpha-numeric characters and must start with a letter

Action:

Modify 'seata.client.loadBalance' so that it conforms to the canonical names requirements.
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

