### PR TITLE
bugfix: fixed bugs in EventBus unit tests

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -85,11 +85,12 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3549](https://github.com/seata/seata/pull/3549)] 统一不同表中的xid字段的长度
   - [[#3551](https://github.com/seata/seata/pull/3551)] 调大RETRY_DEAD_THRESHOLD的值以及设置成可配置
   - [[#3589](https://github.com/seata/seata/pull/3589)] 使用JUnit API做异常检查
-  
-  
+
+
   ### test
 
   - [[#3381](https://github.com/seata/seata/pull/3381)] 添加 TmClient 的测试用例
+  - [[#3607](https://github.com/seata/seata/pull/3607)] 修正了EventBus单元测试中的bug
 
 
  非常感谢以下 contributors 的代码贡献。若有无意遗漏，请报告。

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -90,6 +90,7 @@
   ### test	
 
   - [[#3381](https://github.com/seata/seata/pull/3381)] test case for tmClient	
+  - [[#3607](https://github.com/seata/seata/pull/3607)] fixed bugs in EventBus unit tests
 
 
   Thanks to these contributors for their code commits. Please report an unintended omission.  	

--- a/server/src/test/java/io/seata/server/event/DefaultCoreForEventBusTest.java
+++ b/server/src/test/java/io/seata/server/event/DefaultCoreForEventBusTest.java
@@ -66,6 +66,8 @@ public class DefaultCoreForEventBusTest {
             DefaultCore core = new DefaultCore(remotingServer);
 
             GlobalTransactionEventSubscriber subscriber = new GlobalTransactionEventSubscriber();
+            // avoid transactional interference from other unit tests
+            Thread.sleep(1500);
             EventBusManager.get().register(subscriber);
 
             //start a transaction


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
单独测试DefaultCoreForEventBusTest#test时并不会出现,当与coordinator目录下的其它单元测试一并测试时,由于其中也存在需要异步提交的事务单测,导致GlobalTransactionEventSubscriber中的processGlobalTransactionEvent会进入多次相同的事务状态更改通知,导致单测无法通过
目前有2个修复方案:
1.如上面说的sleep,比较粗暴,但是能解决
2.Assertions.assertEquals强行要求了事务状态变更只能1次的通知,我觉得只要不是null就可以接受了
pr中采用方案1
理由:方案一虽然粗暴但是不会改变此单测的目的,而方案二的话就把结果改变了
![image](https://user-images.githubusercontent.com/19943636/113500495-ee211580-9550-11eb-9239-37a3f6e20fc5.png)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

