### PR TITLE
[WIP] optimize(rm-datasource): Check beforeImage and afterImage can be undo…

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/MultiExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/MultiExecutor.java
@@ -16,18 +16,16 @@
 package io.seata.rm.datasource.exec;
 
 
-import io.seata.common.exception.ShouldNeverHappenException;
-import io.seata.rm.datasource.StatementProxy;
-import io.seata.rm.datasource.sql.struct.TableRecords;
-import io.seata.sqlparser.SQLRecognizer;
-import io.seata.sqlparser.SQLType;
-
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import io.seata.rm.datasource.StatementProxy;
+import io.seata.rm.datasource.sql.struct.TableRecords;
+import io.seata.sqlparser.SQLRecognizer;
 
 /**
  * The type MultiSql executor. now just support same type
@@ -118,11 +116,7 @@ public class MultiExecutor<T, S extends Statement> extends AbstractDMLBaseExecut
             sqlRecognizer = recognizer = entry.getKey();
             beforeImage = entry.getValue();
             afterImage = afterImagesMap.get(recognizer);
-            if (SQLType.UPDATE == sqlRecognizer.getSQLType()) {
-                if (beforeImage.getRows().size() != afterImage.getRows().size()) {
-                    throw new ShouldNeverHappenException("Before image size is not equaled to after image size, probably because you updated the primary keys.");
-                }
-            }
+            checkBeforeAfterImages(beforeImage, afterImage);
             super.prepareUndoLog(beforeImage, afterImage);
         }
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/Field.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/Field.java
@@ -15,6 +15,8 @@
  */
 package io.seata.rm.datasource.sql.struct;
 
+import com.google.common.base.Objects;
+
 /**
  * Field
  *
@@ -145,5 +147,23 @@ public class Field implements java.io.Serializable {
     @Override
     public String toString() {
         return String.format("[%s,%s]", name, value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Field field = (Field) o;
+        return type == field.type && Objects.equal(name, field.name) && keyType == field.keyType
+                && Objects.equal(value, field.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name, keyType, type, value);
     }
 }


### PR DESCRIPTION
… precisely and safely (issue #3611)

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Check beforeImage and afterImage can be undo precisely and safely

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3611 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

