### PR TITLE
fix: retry when failed to renewal the etcdlease

### DIFF
--- a/discovery/seata-discovery-etcd3/src/main/java/io/seata/discovery/registry/etcd3/EtcdRegistryServiceImpl.java
+++ b/discovery/seata-discovery-etcd3/src/main/java/io/seata/discovery/registry/etcd3/EtcdRegistryServiceImpl.java
@@ -348,7 +348,6 @@ public class EtcdRegistryServiceImpl implements RegistryService<Watch.Listener> 
                     TimeUnit.SECONDS.sleep(LIFE_KEEP_INTERVAL);
                 } catch (Exception e) {
                     LOGGER.error("EtcdLifeKeeper", e);
-                    throw new ShouldNeverHappenException("failed to renewal the lease.");
                 }
             }
         }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
seata-server当etcd保活失败时重试 而不是直接放弃保活

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
https://github.com/seata/seata/issues/3692

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
涉及返回网络异常 略复杂

### Ⅳ. Describe how to verify it
使用etcd3作为服务发现启动seata-server
触发网络问题使得seata-server无法正常访问etcd
一段时间之后恢复网络 此时seata-server按期望应当进行保活

### Ⅴ. Special notes for reviews

