### PR TITLE
feature: support manual way to rollback without exception

### DIFF
--- a/core/src/main/java/io/seata/core/context/RootContext.java
+++ b/core/src/main/java/io/seata/core/context/RootContext.java
@@ -73,6 +73,11 @@ public class RootContext {
 
     private static BranchType DEFAULT_BRANCH_TYPE;
 
+    /**
+     * the flag to support manual way to rollback without exception
+     */
+    private static boolean BRANCH_ROLLBACK_MANUAL = false;
+
     public static void setDefaultBranchType(BranchType defaultBranchType) {
         if (defaultBranchType != AT && defaultBranchType != XA) {
             throw new IllegalArgumentException("The default branch type must be " + AT + " or " + XA + "." +
@@ -83,6 +88,14 @@ public class RootContext {
                 RootContext.class.getSimpleName(), DEFAULT_BRANCH_TYPE, defaultBranchType);
         }
         DEFAULT_BRANCH_TYPE = defaultBranchType;
+    }
+
+    public static void setBranchRollbackManual(boolean branchRollbackManual) {
+        BRANCH_ROLLBACK_MANUAL = branchRollbackManual;
+    }
+
+    public static boolean isBranchRollbackManual() {
+        return BRANCH_ROLLBACK_MANUAL;
     }
 
     /**


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

support manual way to rollback without exception. 

In current version, we can only rollback by throwing exception in transaction, but it is not flexible. For some special reason , we want to rollback the transaction but exceptions is not expected like degrade framework such as Feign, alibaba-sentinel.
So, this PR is to enhance a manual way to rollback.

In your GlobalTransaction function where you want to rollback transaction without exception, change the variable BRANCH_ROLLBACK_MANUAL in RootContext by the public function setBranchRollbackManual(boolean) in RootContext.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #2737

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


1. In Feign fallback function, we can change the variable BRANCH_ROLLBACK_MANUAL in RootContext to rollback the GlobalTransaction so that wo need not to throw any exception after invoking the feignclient.
2. invoke the function
3. to see the data result.


### Ⅴ. Special notes for reviews

we can integration other framework such as alibaba-sentinel, feign, dubbo and so on to make seata more flexible.

