### PR TITLE
optimize: support instance `BusinessActionContext` before `try` method, and `@BusinessActionContextParameter(paramName)` can not be set 

### DIFF
--- a/spring/src/main/java/io/seata/spring/tcc/TccActionInterceptor.java
+++ b/spring/src/main/java/io/seata/spring/tcc/TccActionInterceptor.java
@@ -99,12 +99,11 @@ public class TccActionInterceptor implements MethodInterceptor, ConfigurationCha
             try {
                 Object[] methodArgs = invocation.getArguments();
                 //Handler the TCC Aspect
-                Map<String, Object> ret = actionInterceptorHandler.proceed(method, methodArgs, xid, businessAction,
+                Object result = actionInterceptorHandler.proceed(method, methodArgs, xid, businessAction,
                         invocation::proceed);
                 //return the final result
-                return ret.get(Constants.TCC_METHOD_RESULT);
-            }
-            finally {
+                return result;
+            } finally {
                 //if not TCC, unbind branchType
                 if (BranchType.TCC != previousBranchType) {
                     RootContext.unbindBranchType();

--- a/tcc/src/main/java/io/seata/rm/tcc/api/BusinessActionContext.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/api/BusinessActionContext.java
@@ -17,6 +17,10 @@ package io.seata.rm.tcc.api;
 
 import java.io.Serializable;
 import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.alibaba.fastjson.JSON;
 
 /**
  * The type Business action context.
@@ -46,6 +50,9 @@ public class BusinessActionContext implements Serializable {
      */
     private Boolean isUpdated;
 
+    /**
+     * action context
+     */
     private Map<String, Object> actionContext;
 
     /**
@@ -64,18 +71,48 @@ public class BusinessActionContext implements Serializable {
     public BusinessActionContext(String xid, String branchId, Map<String, Object> actionContext) {
         this.xid = xid;
         this.branchId = branchId;
-        this.setActionContext(actionContext);
+        this.actionContext = actionContext;
     }
 
     /**
      * Gets action context.
-     * if you get actionContext in tcc phase-2 , it would be a map object.
      *
      * @param key the key
      * @return the action context
      */
+    @Nullable
     public Object getActionContext(String key) {
         return actionContext.get(key);
+    }
+
+    /**
+     * Gets action context.
+     *
+     * @param key        the key
+     * @param valueClazz the action context class
+     * @param <T>        the action context type
+     * @return the action context
+     */
+    @Nullable
+    public <T> T getActionContext(String key, @Nonnull Class<T> valueClazz) {
+        Object value = actionContext.get(key);
+        if (value == null) {
+            return null;
+        }
+
+        if (valueClazz.isAssignableFrom(value.getClass())) {
+            return (T)value;
+        }
+
+        if (String.class.equals(valueClazz)) {
+            return (T)value.toString();
+        }
+
+        try {
+            return (T)value;
+        } catch (ClassCastException e) {
+            return JSON.parseObject(value.toString(), valueClazz);
+        }
     }
 
     /**
@@ -94,6 +131,15 @@ public class BusinessActionContext implements Serializable {
      */
     public void setBranchId(long branchId) {
         this.branchId = String.valueOf(branchId);
+    }
+
+    /**
+     * Sets branch id.
+     *
+     * @param branchId the branch id
+     */
+    public void setBranchId(String branchId) {
+        this.branchId = branchId;
     }
 
     /**
@@ -130,15 +176,6 @@ public class BusinessActionContext implements Serializable {
      */
     public void setXid(String xid) {
         this.xid = xid;
-    }
-
-    /**
-     * Sets branch id.
-     *
-     * @param branchId the branch id
-     */
-    public void setBranchId(String branchId) {
-        this.branchId = branchId;
     }
 
     /**

--- a/tcc/src/main/java/io/seata/rm/tcc/api/BusinessActionContextUtil.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/api/BusinessActionContextUtil.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 
 /**
  * the api of sharing business action context to tcc phase 2
@@ -35,7 +36,7 @@ import java.util.Objects;
  * @author tanzj
  * @date 2021/4/16
  */
-public class BusinessActionContextUtil {
+public final class BusinessActionContextUtil {
 
     private BusinessActionContextUtil() {
     }
@@ -45,7 +46,7 @@ public class BusinessActionContextUtil {
     /**
      * add business action context and share it to tcc phase2
      *
-     * @param key the key of new context
+     * @param key   the key of new context
      * @param value new context
      */
     public static void addContext(String key, Object value) {
@@ -65,7 +66,7 @@ public class BusinessActionContextUtil {
             context.forEach((key, value) -> {
                 if (!Objects.isNull(value)) {
                     actionContext.setUpdated(true);
-                    actionContext.addActionContext(key, value);
+                    actionContext.addActionContext(key, handleValue(value));
                 }
             });
             //if delay report, params will be finally reported after phase 1 execution
@@ -76,6 +77,21 @@ public class BusinessActionContextUtil {
         }
     }
 
+    /**
+     * Handle the value.
+     * It is convenient to convert type in phase 2.
+     *
+     * @param value the value
+     * @return the value or json string
+     * @see BusinessActionContext#getActionContext(String, Class)
+     */
+    private static Object handleValue(@Nonnull Object value) {
+        if (value instanceof CharSequence || value instanceof Number || value instanceof Boolean) {
+            return value;
+        } else {
+            return JSON.toJSONString(value);
+        }
+    }
 
     /**
      * to do branch report sharing actionContext

--- a/tcc/src/main/java/io/seata/rm/tcc/api/TwoPhaseBusinessAction.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/api/TwoPhaseBusinessAction.java
@@ -30,6 +30,9 @@ import java.lang.annotation.Target;
  * @see io.seata.rm.tcc.api.LocalTCC // TCC annotation, which added on the TCC interface. It can't be left out.
  * @see io.seata.spring.annotation.GlobalTransactionScanner#wrapIfNecessary(Object, String, Object) // the scanner for TM, GlobalLock, and TCC mode
  * @see io.seata.spring.tcc.TccActionInterceptor // the interceptor of TCC mode
+ * @see BusinessActionContext
+ * @see BusinessActionContextUtil
+ * @see BusinessActionContextParameter
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})

--- a/tcc/src/main/java/io/seata/rm/tcc/interceptor/ActionContextUtil.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/interceptor/ActionContextUtil.java
@@ -66,11 +66,11 @@ public class ActionContextUtil {
                             context.putAll(fetchContextFromObject(paramObject));
                         }
                     } else {
-                        if (StringUtils.isBlank(annotation.paramName())) {
-                            context.put(fieldName, paramObject);
-                        } else {
-                            context.put(annotation.paramName(), paramObject);
+                        String paramName = annotation.paramName();
+                        if (StringUtils.isBlank(paramName)) {
+                            paramName = fieldName;
                         }
+                        context.put(paramName, paramObject);
                     }
                 }
             }

--- a/tcc/src/main/java/io/seata/rm/tcc/interceptor/ActionInterceptorHandler.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/interceptor/ActionInterceptorHandler.java
@@ -20,6 +20,7 @@ import io.seata.common.Constants;
 import io.seata.common.exception.FrameworkException;
 import io.seata.common.executor.Callback;
 import io.seata.common.util.NetUtil;
+import io.seata.common.util.StringUtils;
 import io.seata.core.context.RootContext;
 import io.seata.core.model.BranchType;
 import io.seata.rm.DefaultResourceManager;
@@ -33,6 +34,7 @@ import org.slf4j.MDC;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -186,6 +188,7 @@ public class ActionInterceptorHandler {
     protected Map<String, Object> fetchActionRequestContext(Method method, Object[] arguments) {
         Map<String, Object> context = new HashMap<>(8);
 
+        Parameter[] parameters = method.getParameters();
         Annotation[][] parameterAnnotations = method.getParameterAnnotations();
         for (int i = 0; i < parameterAnnotations.length; i++) {
             for (int j = 0; j < parameterAnnotations[i].length; j++) {
@@ -203,13 +206,21 @@ public class ActionInterceptorHandler {
                         if (param.isParamInProperty()) {
                             context.putAll(ActionContextUtil.fetchContextFromObject(targetParam));
                         } else {
-                            context.put(param.paramName(), targetParam);
+                            String paramName = param.paramName();
+                            if (StringUtils.isBlank(paramName)) {
+                                paramName = parameters[i].getName();
+                            }
+                            context.put(paramName, targetParam);
                         }
                     } else {
                         if (param.isParamInProperty()) {
                             context.putAll(ActionContextUtil.fetchContextFromObject(paramObject));
                         } else {
-                            context.put(param.paramName(), paramObject);
+                            String paramName = param.paramName();
+                            if (StringUtils.isBlank(paramName)) {
+                                paramName = parameters[i].getName();
+                            }
+                            context.put(paramName, paramObject);
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
optimize:
1. support instance `BusinessActionContext` before `try` method.
2. `@BusinessActionContextParameter(paramName)` can not be set 

优化：
1. 支持在`try` 方法外，由用户自己实例化`BusinessActionContext`.
2. `@BusinessActionContextParameter(paramName)`可以不用设置了，会自动读取方法参数名。
3. 一阶段生成的自定义类型的数据，将转为JSON后再上报。同时添加方便转换为自定义类型的重载方法。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

