### PR TITLE
bugfix: fix the exception is lost caused by `StackTraceLogger` throw `RuntimeException`

### DIFF
--- a/core/src/main/java/io/seata/core/logger/StackTraceLogger.java
+++ b/core/src/main/java/io/seata/core/logger/StackTraceLogger.java
@@ -78,7 +78,7 @@ public final class StackTraceLogger {
         if (CollectionUtils.isEmpty(args)) {
             return new Object[]{cause};
         } else {
-            Object[] newArgs = Arrays.copyOf(args, args.length + 1);
+            Object[] newArgs = Arrays.copyOf(args, args.length + 1, Object[].class);
             newArgs[args.length] = cause;
             return newArgs;
         }


### PR DESCRIPTION
就一行代码，合并到 #3820 


bugfix: fix the exception is lost caused by `StackTraceLogger` throw `RuntimeException`.
BUG修复：由于`StackTraceLogger`抛出了`RuntimeException`导致异常信息丢失。

注意：此BUG会导致难以预估的结果。因为在catch中又抛出了`RuntimeException`。

### 此BUG产生的原因：
入参的`args`类型为`String[]`时，生成的newArgs也会是String[]，导致cause无法写入newArgs的末尾。