### PR TITLE
Update nacos-config.py

### DIFF
--- a/script/config-center/nacos/nacos-config.py
+++ b/script/config-center/nacos/nacos-config.py
@@ -4,7 +4,7 @@
 import http.client
 import sys
 
-if len(sys.argv) <= 2:
+if len(sys.argv) < 2:
     print ('python nacos-config.py nacosAddr')
     exit()
 


### PR DESCRIPTION
###  Describe what this PR did
官网链接过来的是这个版本。脚本参数数量判断错误，导致脚本跑不起来。dev分支已经修复该BUG。

