### PR TITLE
optimize:[nacos-config.py]添加可选的用户名密码参数、解决pair[1]出现空字符的bug

### DIFF
--- a/script/config-center/nacos/nacos-config.py
+++ b/script/config-center/nacos/nacos-config.py
@@ -6,7 +6,7 @@ import sys
 import urllib.parse
 
 if len(sys.argv) < 2:
-    print ('python nacos-config.py nacosAddr')
+    print ('python nacos-config.py nacosHost')
     exit()
 
 headers = {
@@ -16,7 +16,7 @@ headers = {
 hasError = False
 for line in open('../config.txt'):
     pair = line.rstrip("\n").split('=')
-    if len(pair) < 2:
+    if len(pair) < 2 or pair[1] == '':
         continue
     print (line),
     url_prefix = sys.argv[1]
@@ -24,6 +24,11 @@ for line in open('../config.txt'):
     if len(sys.argv) == 3:
         namespace=sys.argv[2]
         url_postfix = '/nacos/v1/cs/configs?dataId={0}&group=SEATA_GROUP&content={1}&tenant={2}'.format(urllib.parse.quote(str(pair[0])),urllib.parse.quote(str(pair[1])).strip(),namespace)
+    elif len(sys.argv) == 5:
+        namespace=sys.argv[2]
+        username=sys.argv[3]
+        password=sys.argv[4]
+        url_postfix = '/nacos/v1/cs/configs?dataId={0}&group=SEATA_GROUP&content={1}&tenant={2}&username={3}&password{4}'.format(urllib.parse.quote(str(pair[0])),urllib.parse.quote(str(pair[1])).strip(),namespace,username,password)
     else:
         url_postfix = '/nacos/v1/cs/configs?dataId={}&group=SEATA_GROUP&content={}'.format(urllib.parse.quote(str(pair[0])),urllib.parse.quote(str(pair[1]))).strip()
     conn.request("POST", url_postfix, headers=headers)


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

 - 添加可选的用户名密码参数
 - 解决pair[1]出现空字符导致不跳过此轮循环的bug

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
暂未发现相关issue

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

已通过测试，测试范围仅包含上传config.txt到nacos中

### Ⅳ. Describe how to verify it

用该脚本提交一次config.txt即可验证

### Ⅴ. Special notes for reviews

无
