### PR TITLE
optimize:[nacos-config.py]添加可选的用户名密码参数、解决bug

### DIFF
--- a/script/config-center/nacos/nacos-config.py
+++ b/script/config-center/nacos/nacos-config.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env python3
 #  -*- coding: UTF-8 -*-
 
 import http.client


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

 - 添加可选的用户名密码参数 使用（-n,-u,-p）选择性输入参数
 - 解决pair[1]出现空字符导致不跳过此轮循环的bug

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
暂未发现相关issue

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

已通过测试，测试范围仅包含上传config.txt到nacos中

### Ⅳ. Describe how to verify it

用该脚本提交一次config.txt即可验证

### Ⅴ. Special notes for reviews

上一次提交 [PULL REQUEST](https://github.com/seata/seata/pull/3937)