### PR TITLE
bugfix: RM did not clear XID after the local transaction threw an exception

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -63,7 +63,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3998](https://github.com/seata/seata/pull/3998)] 修复 jedis multi.exec 的 NPE 问题
   - [[#4011](https://github.com/seata/seata/pull/4011)] 修复 springboot下无法获取distributed-lock-table配置
   - [[#4023](https://github.com/seata/seata/pull/4023)] 修复 dubbo部分场景存在xid未清除的问题
-  - [[#4039](https://github.com/seata/seata/pull/4039)] 修复RM执行本地事务抛出异常之后，没有执行清除xid，导致线程一直绑定着错误请求的xid
+  - [[#4039](https://github.com/seata/seata/pull/4039)] 修复 本地事务抛出异常之后，RM没有清除xid
 
 
 ### optimize：

--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -63,6 +63,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3998](https://github.com/seata/seata/pull/3998)] 修复 jedis multi.exec 的 NPE 问题
   - [[#4011](https://github.com/seata/seata/pull/4011)] 修复 springboot下无法获取distributed-lock-table配置
   - [[#4023](https://github.com/seata/seata/pull/4023)] 修复 dubbo部分场景存在xid未清除的问题
+  - [[#4039](https://github.com/seata/seata/pull/4039)] 修复RM执行本地事务抛出异常之后，没有执行清除xid，导致线程一直绑定着错误请求的xid
 
 
 ### optimize：
@@ -118,7 +119,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4017](https://github.com/seata/seata/pull/4017)] 优化文件配置
   - [[#4018](https://github.com/seata/seata/pull/4018)] 优化 Apollo 配置
   - [[#4019](https://github.com/seata/seata/pull/4019)] 优化 Nacos、Consul、Zookeeper、Etcd3 配置
-  
+
 ### test：
 
 
@@ -151,7 +152,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [elrond-g](https://github.com/elrond-g)
   - [Rubbernecker](https://github.com/Rubbernecker)
   - [zhixing](https://github.com/chenlei3641)
-  
+
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -61,6 +61,7 @@
   - [[#3998](https://github.com/seata/seata/pull/3998)] fix the NPE of jedis multi.exec
   - [[#4011](https://github.com/seata/seata/pull/4011)] fix can not get properties of distributed-lock-table in springboot
   - [[#4023](https://github.com/seata/seata/pull/4023)] fix the problem that the xid is not cleared in some scenes of dubbo
+  - [[#4039](https://github.com/seata/seata/pull/4039)] fix RM fails to clear XID after throwing an exception after executing local transactions, resulting in the thread always binding the XID of the wrong request
 
 
    ### optimize：

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -61,7 +61,7 @@
   - [[#3998](https://github.com/seata/seata/pull/3998)] fix the NPE of jedis multi.exec
   - [[#4011](https://github.com/seata/seata/pull/4011)] fix can not get properties of distributed-lock-table in springboot
   - [[#4023](https://github.com/seata/seata/pull/4023)] fix the problem that the xid is not cleared in some scenes of dubbo
-  - [[#4039](https://github.com/seata/seata/pull/4039)] fix RM fails to clear XID after throwing an exception after executing local transactions, resulting in the thread always binding the XID of the wrong request
+  - [[#4039](https://github.com/seata/seata/pull/4039)] fix RM did not clear XID after the local transaction threw an exception
 
 
    ### optimize：

--- a/integration/http/src/main/java/io/seata/integration/http/TransactionPropagationInterceptor.java
+++ b/integration/http/src/main/java/io/seata/integration/http/TransactionPropagationInterceptor.java
@@ -17,10 +17,11 @@ package io.seata.integration.http;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import io.seata.common.util.StringUtils;
 import io.seata.core.context.RootContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 
@@ -31,9 +32,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  */
 public class TransactionPropagationInterceptor extends HandlerInterceptorAdapter {
 
-
     private static final Logger LOGGER = LoggerFactory.getLogger(TransactionPropagationInterceptor.class);
-
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -43,7 +42,7 @@ public class TransactionPropagationInterceptor extends HandlerInterceptorAdapter
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("xid in RootContext[{}] xid in HttpContext[{}]", xid, rpcXid);
         }
-        if (xid == null && rpcXid != null) {
+        if (StringUtils.isBlank(xid) && StringUtils.isNotBlank(rpcXid)) {
             RootContext.bind(rpcXid);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("bind[{}] to RootContext", rpcXid);
@@ -54,8 +53,7 @@ public class TransactionPropagationInterceptor extends HandlerInterceptorAdapter
     }
 
     @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
-        ModelAndView modelAndView) {
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
         if (RootContext.inGlobalTransaction()) {
             XidResource.cleanXid(request.getHeader(RootContext.KEY_XID));
         }

--- a/integration/http/src/main/java/io/seata/integration/http/XidResource.java
+++ b/integration/http/src/main/java/io/seata/integration/http/XidResource.java
@@ -32,14 +32,14 @@ public class XidResource {
 
     public static void cleanXid(String rpcXid) {
         String xid = RootContext.getXID();
-        if (xid != null) {
+        if (StringUtils.isNotBlank(xid)) {
             String unbindXid = RootContext.unbind();
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("unbind[{}] from RootContext", unbindXid);
             }
             if (!StringUtils.equalsIgnoreCase(rpcXid, unbindXid)) {
                 LOGGER.warn("xid in change during RPC from {} to {}", rpcXid, unbindXid);
-                if (unbindXid != null) {
+                if (StringUtils.isNotBlank(unbindXid)) {
                     RootContext.bind(unbindXid);
                     LOGGER.warn("bind [{}] back to RootContext", unbindXid);
                 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
bugfix:RM fails to clear XID after throwing an exception after executing local transactions, resulting in the thread always binding the XID of the wrong request

### Ⅱ. Does this pull request fix one issue?
fixes #4020.

