### PR TITLE
bugfix: correct redis registry built-in properties

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -70,6 +70,8 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4074](https://github.com/seata/seata/pull/4074)] 修复XA模式资源悬挂问题
   - [[#4107](https://github.com/seata/seata/pull/4107)] 修复项目构建时的死锁问题
   - [[#4158](https://github.com/seata/seata/pull/4158)] 修复logback无法加载到`RPC_PORT`的问题
+  - [[#4162](https://github.com/seata/seata/pull/4162)] 修复Redis注册中心内置配置名导致启动报错问题
+
 
 
 ### optimize：

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -68,7 +68,7 @@
   - [[#4074](https://github.com/seata/seata/pull/4074)] fix prevents XA mode resource suspension
   - [[#4107](https://github.com/seata/seata/pull/4107)] fix deadlock problems during project construction
   - [[#4158](https://github.com/seata/seata/pull/4158)] fix the logback can't load the `RPC_PORT`
-
+  - [[#4162](https://github.com/seata/seata/pull/4162)] fix correct built-in properties for redis registry
   
 
    ### optimize：

--- a/discovery/seata-discovery-core/src/main/java/io/seata/discovery/registry/RegistryHeartBeats.java
+++ b/discovery/seata-discovery-core/src/main/java/io/seata/discovery/registry/RegistryHeartBeats.java
@@ -76,12 +76,16 @@ public class RegistryHeartBeats {
     }
 
     private static long getHeartbeatPeriod(String registryType) {
-        return FILE_CONFIG.getLong(String.join(FILE_CONFIG_SPLIT_CHAR, FILE_ROOT_REGISTRY, registryType, HEARTBEAT_KEY, HEARTBEAT_PERIOD_KEY),
+        String propertySuffix = String.join("-", HEARTBEAT_KEY, HEARTBEAT_PERIOD_KEY);
+        //  FILE_CONFIG.getLong("registry.${registryType}.heartbeat-period");
+        return FILE_CONFIG.getLong(String.join(FILE_CONFIG_SPLIT_CHAR, FILE_ROOT_REGISTRY, registryType, propertySuffix),
                 DEFAULT_HEARTBEAT_PERIOD);
     }
 
     private static boolean getHeartbeatEnabled(String registryType) {
-        return FILE_CONFIG.getBoolean(String.join(FILE_CONFIG_SPLIT_CHAR, FILE_ROOT_REGISTRY, registryType, HEARTBEAT_KEY, HEARTBEAT_ENABLED_KEY),
+        String propertySuffix = String.join("-", HEARTBEAT_KEY, HEARTBEAT_ENABLED_KEY);
+        //  FILE_CONFIG.getBoolean("registry.${registryType}.heartbeat-enabled");
+        return FILE_CONFIG.getBoolean(String.join(FILE_CONFIG_SPLIT_CHAR, FILE_ROOT_REGISTRY, registryType, propertySuffix),
                 DEFAULT_HEARTBEAT_ENABLED);
     }
 

--- a/discovery/seata-discovery-redis/src/main/java/io/seata/discovery/registry/redis/RedisRegistryServiceImpl.java
+++ b/discovery/seata-discovery-redis/src/main/java/io/seata/discovery/registry/redis/RedisRegistryServiceImpl.java
@@ -80,41 +80,41 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
         int port = Integer.parseInt(serverArr[1]);
         int db = seataConfig.getInt(getRedisDbFileKey());
         GenericObjectPoolConfig redisConfig = new GenericObjectPoolConfig();
-        redisConfig.setTestOnBorrow(seataConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test.on.borrow", true));
-        redisConfig.setTestOnReturn(seataConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test.on.return", false));
-        redisConfig.setTestWhileIdle(seataConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test.while.idle", false));
-        int maxIdle = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "max.idle", 0);
+        redisConfig.setTestOnBorrow(seataConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-borrow", true));
+        redisConfig.setTestOnReturn(seataConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-on-return", false));
+        redisConfig.setTestWhileIdle(seataConfig.getBoolean(REDIS_FILEKEY_PREFIX + "test-while-idle", false));
+        int maxIdle = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "max-idle", 0);
         if (maxIdle > 0) {
             redisConfig.setMaxIdle(maxIdle);
         }
-        int minIdle = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "min.idle", 0);
+        int minIdle = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "min-idle", 0);
         if (minIdle > 0) {
             redisConfig.setMinIdle(minIdle);
         }
-        int maxActive = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "max.active", 0);
+        int maxActive = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "max-active", 0);
         if (maxActive > 0) {
             redisConfig.setMaxTotal(maxActive);
         }
-        int maxTotal = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "max.total", 0);
+        int maxTotal = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "max-total", 0);
         if (maxTotal > 0) {
             redisConfig.setMaxTotal(maxTotal);
         }
-        int maxWait = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "max.wait",
-            seataConfig.getInt(REDIS_FILEKEY_PREFIX + "timeout", 0));
+        int maxWait = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "max-wait",
+                seataConfig.getInt(REDIS_FILEKEY_PREFIX + "timeout", 0));
         if (maxWait > 0) {
             redisConfig.setMaxWaitMillis(maxWait);
         }
-        int numTestsPerEvictionRun = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "num.tests.per.eviction.run", 0);
+        int numTestsPerEvictionRun = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "num-tests-per-eviction-run", 0);
         if (numTestsPerEvictionRun > 0) {
             redisConfig.setNumTestsPerEvictionRun(numTestsPerEvictionRun);
         }
         int timeBetweenEvictionRunsMillis = seataConfig.getInt(
-            REDIS_FILEKEY_PREFIX + "time.between.eviction.runs.millis", 0);
+                REDIS_FILEKEY_PREFIX + "time-between-eviction-runs-millis", 0);
         if (timeBetweenEvictionRunsMillis > 0) {
             redisConfig.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRunsMillis);
         }
-        int minEvictableIdleTimeMillis = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "min.evictable.idle.time.millis",
-            0);
+        int minEvictableIdleTimeMillis = seataConfig.getInt(REDIS_FILEKEY_PREFIX + "min-evictable-idle-time-millis",
+                0);
         if (minEvictableIdleTimeMillis > 0) {
             redisConfig.setMinEvictableIdleTimeMillis(minEvictableIdleTimeMillis);
         }
@@ -247,7 +247,7 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
                 try {
                     listener.onEvent(msg);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    LOGGER.error(e.getMessage(), e);
                 }
             }
         }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
correct  built-in properties for redis registry center

for example,
change `seata.registry.redis.test.on.borrow`  to `seata.registry.redis.test-on-borrow`

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3704

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
I don't know how to do it

### Ⅳ. Describe how to verify it
I change application.yml in server module , like this
```
seata:
  ......
  registry:
    # support: nacos 、 eureka 、 redis 、 zk  、 consul 、 etcd3 、 sofa
    type: redis
    redis:
      server-addr: localhost:6379
      db: 0
      password:
      cluster: default
      timeout: 0
```
then start ServerApplication. It works

### Ⅴ. Special notes for reviews

