### PR TITLE
bugfix: fix `StringUtils.toString(obj)` throw `ClassCastException` when the obj is primitive data array

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -71,6 +71,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4107](https://github.com/seata/seata/pull/4107)] 修复项目构建时的死锁问题
   - [[#4158](https://github.com/seata/seata/pull/4158)] 修复logback无法加载到`RPC_PORT`的问题
   - [[#4162](https://github.com/seata/seata/pull/4162)] 修复Redis注册中心内置配置名导致启动报错问题
+  - [[#4165](https://github.com/seata/seata/pull/4165)] 修复 `StringUtils.toString(obj)` 当obj是基本数据数组时，抛出`ClassCastException`的问题
 
 
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -69,6 +69,7 @@
   - [[#4107](https://github.com/seata/seata/pull/4107)] fix deadlock problems during project construction
   - [[#4158](https://github.com/seata/seata/pull/4158)] fix the logback can't load the `RPC_PORT`
   - [[#4162](https://github.com/seata/seata/pull/4162)] fix correct built-in properties for redis registry
+  - [[#4165](https://github.com/seata/seata/pull/4165)] fix `StringUtils.toString(obj)` throw `ClassCastException` when the obj is primitive data array
   
 
    ### optimize：

--- a/common/src/main/java/io/seata/common/util/ArrayUtils.java
+++ b/common/src/main/java/io/seata/common/util/ArrayUtils.java
@@ -15,6 +15,8 @@
  */
 package io.seata.common.util;
 
+import java.lang.reflect.Array;
+
 /**
  * The type Array utils.
  *
@@ -23,6 +25,31 @@ package io.seata.common.util;
 public class ArrayUtils {
 
     private ArrayUtils() {
+    }
+
+    /**
+     * arrayObj cast to Object[]
+     *
+     * @param arrayObj the array obj
+     * @return array
+     */
+    public static Object[] toArray(Object arrayObj) {
+        if (arrayObj == null) {
+            return null;
+        }
+
+        if (!arrayObj.getClass().isArray()) {
+            throw new ClassCastException("'arrayObj' is not an array, can't cast to Object[]");
+        }
+
+        int length = Array.getLength(arrayObj);
+        Object[] array = new Object[length];
+        if (length > 0) {
+            for (int i = 0; i < length; ++i) {
+                array[i] = Array.get(arrayObj, i);
+            }
+        }
+        return array;
     }
 
     /**
@@ -55,5 +82,30 @@ public class ArrayUtils {
             sb.append("]");
             return sb.toString();
         });
+    }
+
+    /**
+     * Array To String.
+     *
+     * @param arrayObj the array obj
+     * @return str the string
+     */
+    public static String toString(final Object arrayObj) {
+        if (arrayObj == null) {
+            return "null";
+        }
+        if (!arrayObj.getClass().isArray()) {
+            return StringUtils.toString(arrayObj);
+        }
+
+        if (Array.getLength(arrayObj) == 0) {
+            return "[]";
+        }
+
+        if (arrayObj.getClass().getComponentType().isPrimitive()) {
+            return toString(toArray(arrayObj));
+        } else {
+            return toString((Object[])arrayObj);
+        }
     }
 }

--- a/common/src/main/java/io/seata/common/util/StringUtils.java
+++ b/common/src/main/java/io/seata/common/util/StringUtils.java
@@ -220,7 +220,7 @@ public class StringUtils {
             return CollectionUtils.toString((Collection<?>)obj);
         }
         if (obj.getClass().isArray()) {
-            return ArrayUtils.toString((Object[])obj);
+            return ArrayUtils.toString(obj);
         }
         if (obj instanceof Map) {
             return CollectionUtils.toString((Map<?, ?>)obj);

--- a/common/src/test/java/io/seata/common/util/StringUtilsTest.java
+++ b/common/src/test/java/io/seata/common/util/StringUtilsTest.java
@@ -157,11 +157,16 @@ public class StringUtilsTest {
         list.add(list);
         Assertions.assertEquals("[\"xxx\", 111, (this ArrayList)]", StringUtils.toString(list));
 
-        //case: Array
+        //case: String Array
         String[] strArr = new String[2];
         strArr[0] = "11";
         strArr[1] = "22";
         Assertions.assertEquals("[\"11\", \"22\"]", StringUtils.toString(strArr));
+        //case: int Array
+        int[] intArr = new int[2];
+        intArr[0] = 11;
+        intArr[1] = 22;
+        Assertions.assertEquals("[11, 22]", StringUtils.toString(intArr));
         //case: Array, and cycle dependency
         Object[] array = new Object[3];
         array[0] = 1;


### PR DESCRIPTION
bugfix: fix `StringUtils.toString(obj)` throw `ClassCastException` when the obj is primitive data array.
BUG修复：修复 `StringUtils.toString(obj)` 当obj是基本数据数组时，抛出`ClassCastException`的问题。