### PR TITLE
bugfix: fix code for "sessionMode" not execute problem

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -38,6 +38,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#3906](https://github.com/seata/seata/pull/3906)] 支持 SPI 卸载
   - [[#3668](https://github.com/seata/seata/pull/3668)] 支持kotlin协程
   - [[#4134](https://github.com/seata/seata/pull/4134)] 初始化控制台基础代码
+  - [[#4213](https://github.com/seata/seata/pull/4213)] 修复部分"sessionMode"代码没执行导致启动失败问题
 
 
 ### bugfix：

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -76,6 +76,7 @@
   - [[#4177](https://github.com/seata/seata/pull/4177)] fix the problem of accidentally releasing the global lock
   - [[#4174](https://github.com/seata/seata/pull/4174)] fix delete undo log connection already closed
   - [[#4189](https://github.com/seata/seata/pull/4189)] fix the `kafka-appender.xml` and `logstash-appender.xml`
+  - [[#4213](https://github.com/seata/seata/pull/4213)] fix code for "sessionMode" not execute problem
   
 
    ### optimize：

--- a/server/src/main/java/io/seata/server/ServerApplicationListener.java
+++ b/server/src/main/java/io/seata/server/ServerApplicationListener.java
@@ -54,6 +54,13 @@ public class ServerApplicationListener implements GenericApplicationListener {
 
         ApplicationEnvironmentPreparedEvent environmentPreparedEvent = (ApplicationEnvironmentPreparedEvent)event;
         ConfigurableEnvironment environment = environmentPreparedEvent.getEnvironment();
+
+        // Load by priority
+        System.setProperty("sessionMode",
+                environment.getProperty(SERVER_STORE_SESSION_MODE, environmentPreparedEvent.getEnvironment().getProperty(SERVER_STORE_MODE, "file")));
+        System.setProperty("lockMode",
+                environment.getProperty(SERVER_STORE_LOCK_MODE, environmentPreparedEvent.getEnvironment().getProperty(SERVER_STORE_MODE, "file")));
+
         String[] args = environmentPreparedEvent.getArgs();
 
         // port: -h > -D > env > yml > default
@@ -96,12 +103,6 @@ public class ServerApplicationListener implements GenericApplicationListener {
         }
         String servicePort = String.valueOf(Integer.parseInt(serverPort) + SERVICE_OFFSET_SPRING_BOOT);
         setTargetPort(environment, servicePort, true);
-
-        // Load by priority
-        System.setProperty("sessionMode",
-                environment.getProperty(SERVER_STORE_SESSION_MODE, environmentPreparedEvent.getEnvironment().getProperty(SERVER_STORE_MODE, "file")));
-        System.setProperty("lockMode",
-                environment.getProperty(SERVER_STORE_LOCK_MODE, environmentPreparedEvent.getEnvironment().getProperty(SERVER_STORE_MODE, "file")));
     }
 
     private void setTargetPort(ConfigurableEnvironment environment, String port, boolean needAddPropertySource) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
fix some code for "sessionMode" not execute problem.

if I config service-port , 
```
 server:
    service-port: 8091
```
the following code will not execute
```java
        // Load by priority
        System.setProperty("sessionMode",
                environment.getProperty(SERVER_STORE_SESSION_MODE, environmentPreparedEvent.getEnvironment().getProperty(SERVER_STORE_MODE, "file")));
        System.setProperty("lockMode",
                environment.getProperty(SERVER_STORE_LOCK_MODE, environmentPreparedEvent.getEnvironment().getProperty(SERVER_STORE_MODE, "file")));

```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
no

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
I don't know how to do it

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

