### PR TITLE
optimize: client check whether undolog table exist before cleaning undolog

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -145,7 +145,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4144](https://github.com/seata/seata/pull/4144)] 支持默认的事务分组配置 
   - [[#4157](https://github.com/seata/seata/pull/4157)] 优化客户端批量发送请求
   - [[#4191](https://github.com/seata/seata/pull/4191)] RPC请求超时时间支持配置化
-  - [[#4216](https://github.com/seata/seata/pull/4216)] TCC用户无须清理undolog表
+  - [[#4216](https://github.com/seata/seata/pull/4216)] 非AT用户无须清理undolog表
   
 ### test：
 

--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -145,6 +145,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4144](https://github.com/seata/seata/pull/4144)] 支持默认的事务分组配置 
   - [[#4157](https://github.com/seata/seata/pull/4157)] 优化客户端批量发送请求
   - [[#4191](https://github.com/seata/seata/pull/4191)] RPC请求超时时间支持配置化
+  - [[#4216](https://github.com/seata/seata/pull/4216)] TCC用户无须清理undolog表
   
 ### test：
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -144,6 +144,7 @@
   - [[#4144](https://github.com/seata/seata/pull/4144)] support default configuration of tx-service-group    
   - [[#4157](https://github.com/seata/seata/pull/4157)] optimize client batch sending.   
   - [[#4191](https://github.com/seata/seata/pull/4191)] support rpc timeout can be customized.
+  - [[#4216](https://github.com/seata/seata/pull/4216)] no more cleaning undolog attempt for TCC-only user
   
   ### test:	
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -144,7 +144,7 @@
   - [[#4144](https://github.com/seata/seata/pull/4144)] support default configuration of tx-service-group    
   - [[#4157](https://github.com/seata/seata/pull/4157)] optimize client batch sending.   
   - [[#4191](https://github.com/seata/seata/pull/4191)] support rpc timeout can be customized.
-  - [[#4216](https://github.com/seata/seata/pull/4216)] no more cleaning undolog attempt for TCC-only user
+  - [[#4216](https://github.com/seata/seata/pull/4216)] no more attempt to clean undolog for none AT user
   
   ### test:	
 

--- a/rm-datasource/src/main/java/io/seata/rm/RMHandlerAT.java
+++ b/rm-datasource/src/main/java/io/seata/rm/RMHandlerAT.java
@@ -19,12 +19,15 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.seata.core.model.BranchType;
 import io.seata.core.model.ResourceManager;
 import io.seata.core.protocol.transaction.UndoLogDeleteRequest;
 import io.seata.rm.datasource.DataSourceManager;
 import io.seata.rm.datasource.DataSourceProxy;
+import io.seata.rm.datasource.undo.UndoLogManager;
 import io.seata.rm.datasource.undo.UndoLogManagerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,43 +43,93 @@ public class RMHandlerAT extends AbstractRMHandler {
 
     private static final int LIMIT_ROWS = 3000;
 
+    private final Map<String, Boolean> undoLogTableExistRecord = new ConcurrentHashMap<>();
+
     @Override
     public void handle(UndoLogDeleteRequest request) {
+        String resourceId = request.getResourceId();
         DataSourceManager dataSourceManager = (DataSourceManager)getResourceManager();
-        DataSourceProxy dataSourceProxy = dataSourceManager.get(request.getResourceId());
+        DataSourceProxy dataSourceProxy = dataSourceManager.get(resourceId);
         if (dataSourceProxy == null) {
-            LOGGER.warn("Failed to get dataSourceProxy for delete undolog on {}", request.getResourceId());
+            LOGGER.warn("Failed to get dataSourceProxy for delete undolog on {}", resourceId);
             return;
         }
-        Date logCreatedSave = getLogCreated(request.getSaveDays());
-        Connection conn = null;
+
+        boolean hasUndoLogTable = undoLogTableExistRecord.computeIfAbsent(resourceId, id -> checkUndoLogTableExist(dataSourceProxy));
+        if (!hasUndoLogTable) {
+            LOGGER.debug("resource({}) has no undo_log table, UndoLogDeleteRequest will be ignored", resourceId);
+            return;
+        }
+
+        Connection conn = getConnection(dataSourceProxy);
+        if (conn == null) {
+            LOGGER.warn("Failed to get connection to delete expired undo_log for {}", resourceId);
+            return;
+        }
+
+        Date division = getLogCreated(request.getSaveDays());
+
+        UndoLogManager manager = getUndoLogManager(dataSourceProxy);
+
+        int deleteRows;
+        do {
+            deleteRows = deleteUndoLog(manager, conn, division);
+        } while (deleteRows == LIMIT_ROWS);
+
         try {
-            conn = dataSourceProxy.getPlainConnection();
-            int deleteRows = 0;
-            do {
-                try {
-                    deleteRows = UndoLogManagerFactory.getUndoLogManager(dataSourceProxy.getDbType())
-                            .deleteUndoLogByLogCreated(logCreatedSave, LIMIT_ROWS, conn);
-                    if (deleteRows > 0 && !conn.getAutoCommit()) {
-                        conn.commit();
-                    }
-                } catch (SQLException exx) {
-                    if (deleteRows > 0 && !conn.getAutoCommit()) {
-                        conn.rollback();
-                    }
-                    throw exx;
-                }
-            } while (deleteRows == LIMIT_ROWS);
-        } catch (Exception e) {
-            LOGGER.error("Failed to delete expired undo_log, error:{}", e.getMessage(), e);
-        } finally {
-            if (conn != null) {
-                try {
-                    conn.close();
-                } catch (SQLException closeEx) {
-                    LOGGER.warn("Failed to close JDBC resource while deleting undo_log ", closeEx);
-                }
+            conn.close();
+        } catch (SQLException closeEx) {
+            LOGGER.warn("Failed to close JDBC resource after deleting undo_log ", closeEx);
+        }
+    }
+
+    boolean checkUndoLogTableExist(DataSourceProxy dataSourceProxy) {
+        Connection connection = getConnection(dataSourceProxy);
+        if (connection == null) {
+            return false;
+        }
+        UndoLogManager manager = getUndoLogManager(dataSourceProxy);
+        boolean isExisted = manager.hasUndoLogTable(connection);
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            String resourceId = dataSourceProxy.getResourceId();
+            LOGGER.warn("Failed to close JDBC resource for {}", resourceId);
+        }
+        return isExisted;
+    }
+
+    Connection getConnection(DataSourceProxy dataSourceProxy) {
+        try {
+            return dataSourceProxy.getPlainConnection();
+        } catch (SQLException e) {
+            String resourceId = dataSourceProxy.getResourceId();
+            LOGGER.error("Failed to get connection for {}", resourceId, e);
+            return null;
+        }
+    }
+
+    UndoLogManager getUndoLogManager(DataSourceProxy dataSourceProxy) {
+        return UndoLogManagerFactory.getUndoLogManager(dataSourceProxy.getDbType());
+    }
+
+    int deleteUndoLog(UndoLogManager manager, Connection conn, Date division) {
+        try {
+            int deleteRows = manager.deleteUndoLogByLogCreated(division, LIMIT_ROWS, conn);
+            if (!conn.getAutoCommit()) {
+                conn.commit();
             }
+            return deleteRows;
+        } catch (SQLException e) {
+            LOGGER.error("Failed to delete expired undo_log", e);
+            try {
+                if (!conn.getAutoCommit()) {
+                    conn.rollback();
+                }
+            } catch (SQLException re) {
+                LOGGER.error("Failed to rollback undolog", re);
+            }
+            return 0;
         }
     }
 
@@ -90,9 +143,7 @@ public class RMHandlerAT extends AbstractRMHandler {
     }
 
     /**
-     * get AT resource managerDataSourceManager.java
-     *
-     * @return
+     * get AT resource manager
      */
     @Override
     protected ResourceManager getResourceManager() {
@@ -103,5 +154,4 @@ public class RMHandlerAT extends AbstractRMHandler {
     public BranchType getBranchType() {
         return BranchType.AT;
     }
-
 }

--- a/rm-datasource/src/main/java/io/seata/rm/RMHandlerAT.java
+++ b/rm-datasource/src/main/java/io/seata/rm/RMHandlerAT.java
@@ -79,7 +79,7 @@ public class RMHandlerAT extends AbstractRMHandler {
         try {
             conn.close();
         } catch (SQLException closeEx) {
-            LOGGER.warn("Failed to close JDBC resource after deleting undo_log ", closeEx);
+            LOGGER.warn("Failed to close JDBC resource after deleting undo_log", closeEx);
         }
     }
 
@@ -94,7 +94,7 @@ public class RMHandlerAT extends AbstractRMHandler {
             connection.close();
         } catch (SQLException e) {
             String resourceId = dataSourceProxy.getResourceId();
-            LOGGER.warn("Failed to close JDBC resource for {}", resourceId);
+            LOGGER.warn("Failed to close JDBC resource for {}", resourceId, e);
         }
         return isExisted;
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoLogManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoLogManager.java
@@ -82,6 +82,8 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
     protected static final String UNDO_LOG_TABLE_NAME = ConfigurationFactory.getInstance().getConfig(
         ConfigurationKeys.TRANSACTION_UNDO_LOG_TABLE, DEFAULT_TRANSACTION_UNDO_LOG_TABLE);
 
+    private static final String CHECK_UNDO_LOG_TABLE_EXIST_SQL = "SELECT 1 FROM " + UNDO_LOG_TABLE_NAME + " LIMIT 1";
+
     protected static final String SELECT_UNDO_LOG_SQL = "SELECT * FROM " + UNDO_LOG_TABLE_NAME + " WHERE "
         + ClientTableColumnsName.UNDO_LOG_BRANCH_XID + " = ? AND " + ClientTableColumnsName.UNDO_LOG_XID
         + " = ? FOR UPDATE";
@@ -430,5 +432,20 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
      */
     protected boolean needCompress(byte[] undoLogContent) {
         return ROLLBACK_INFO_COMPRESS_ENABLE && undoLogContent.length > ROLLBACK_INFO_COMPRESS_THRESHOLD;
+    }
+
+    @Override
+    public boolean hasUndoLogTable(Connection conn) {
+        String checkExistSql = getCheckUndoLogTableExistSql();
+        try (PreparedStatement checkPst = conn.prepareStatement(checkExistSql)) {
+            checkPst.executeQuery();
+            return true;
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    protected String getCheckUndoLogTableExistSql() {
+        return CHECK_UNDO_LOG_TABLE_EXIST_SQL;
     }
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/UndoLogManager.java
@@ -79,4 +79,10 @@ public interface UndoLogManager {
      */
     int deleteUndoLogByLogCreated(Date logCreated, int limitRows, Connection conn) throws SQLException;
 
+    /**
+     * does this resource have undolog table?(some may not have, if they don't use AT mode at all)
+     * @param conn connection of the resource
+     * @return whether undolog table exist or not
+     */
+    boolean hasUndoLogTable(Connection conn);
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/oracle/OracleUndoLogManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/oracle/OracleUndoLogManager.java
@@ -38,6 +38,7 @@ public class OracleUndoLogManager extends AbstractUndoLogManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleUndoLogManager.class);
 
+    private static final String CHECK_UNDO_LOG_TABLE_EXIST_SQL = "SELECT 1 FROM " + UNDO_LOG_TABLE_NAME + " WHERE ROWNUM = 1";
 
     private static final String INSERT_UNDO_LOG_SQL = "INSERT INTO " + UNDO_LOG_TABLE_NAME +
             " (" + ClientTableColumnsName.UNDO_LOG_ID + "," + ClientTableColumnsName.UNDO_LOG_BRANCH_XID + ", "
@@ -97,4 +98,8 @@ public class OracleUndoLogManager extends AbstractUndoLogManager {
         }
     }
 
+    @Override
+    protected String getCheckUndoLogTableExistSql() {
+        return CHECK_UNDO_LOG_TABLE_EXIST_SQL;
+    }
 }

--- a/rm-datasource/src/test/java/io/seata/rm/RMHandlerATTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/RMHandlerATTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.rm;
+
+import io.seata.core.protocol.transaction.UndoLogDeleteRequest;
+import io.seata.rm.datasource.DataSourceManager;
+import io.seata.rm.datasource.DataSourceProxy;
+import io.seata.rm.datasource.undo.UndoLogManager;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+
+import static org.mockito.Mockito.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RMHandlerATTest {
+
+    @Test
+    void hasUndoLogTableTest() {
+        RMHandlerAT handler = buildHandler(true);
+        UndoLogDeleteRequest request = buildRequest();
+        int testTimes = 5;
+        for (int i = 0; i < testTimes; i++) {
+            handler.handle(request);
+        }
+        verify(handler, times(1)).checkUndoLogTableExist(any());
+        verify(handler, times(testTimes)).deleteUndoLog(any(), any(), any());
+    }
+
+    @Test
+    void noUndoLogTableTest() {
+        RMHandlerAT handler = buildHandler(false);
+        UndoLogDeleteRequest request = buildRequest();
+        int testTimes = 5;
+        for (int i = 0; i < testTimes; i++) {
+            handler.handle(request);
+        }
+        verify(handler, times(1)).checkUndoLogTableExist(any());
+        verify(handler, never()).deleteUndoLog(any(), any(), any());
+    }
+
+    private RMHandlerAT buildHandler(boolean hasUndoLogTable) {
+        RMHandlerAT handler = spy(new RMHandlerAT());
+        DataSourceManager dataSourceManager = mock(DataSourceManager.class);
+        doReturn(dataSourceManager).when(handler).getResourceManager();
+
+        DataSourceProxy dataSourceProxy = mock(DataSourceProxy.class);
+        when(dataSourceManager.get(anyString())).thenReturn(dataSourceProxy);
+
+        Connection connection = mock(Connection.class);
+        assertDoesNotThrow(() -> {
+            when(dataSourceProxy.getPlainConnection()).thenReturn(connection);
+        });
+
+        UndoLogManager manager = mock(UndoLogManager.class);
+        when(manager.hasUndoLogTable(any())).thenReturn(hasUndoLogTable);
+        doReturn(manager).when(handler).getUndoLogManager(any());
+
+        return handler;
+    }
+
+    private UndoLogDeleteRequest buildRequest() {
+        UndoLogDeleteRequest request = new UndoLogDeleteRequest();
+        request.setResourceId("test");
+        request.setSaveDays((short) 1);
+        return request;
+    }
+}

--- a/rm-datasource/src/test/java/io/seata/rm/RMHandlerATTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/RMHandlerATTest.java
@@ -23,10 +23,21 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyString;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+/**
+ * @author selfishlover
+ */
 class RMHandlerATTest {
 
     @Test


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
when RM receive UndoLogDeleteRequest(send by TC), if user does not use AT mode at all(which mean their database does not have undo_log table), exception would occur(such as undo_log table doesn't existed~) and logger will print error info(which scares user~). Here, we check whether undo_log table exist before trying to delete undolog.
