### PR TITLE
optimize: Improve the performance of global commit and global rollback

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -160,6 +160,8 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4277](https://github.com/seata/seata/pull/4277)] 优化Redis-pipeline模式本地事务下的锁竞争机制
   - [[#4284](https://github.com/seata/seata/pull/4284)] 支持MSE-Nacos 的 ak/sk 鉴权方式
   - [[#4300](https://github.com/seata/seata/pull/4300)] 优化NettyRemotingServer的close()由DefaultCoordinator来调用，不再额外注册到ServerRunner
+  - [[#4270](https://github.com/seata/seata/pull/4270)] 提高全局提交和全局回滚的性能，分支事务清理异步化
+
   
 
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -160,6 +160,9 @@
   - [[#4277](https://github.com/seata/seata/pull/4277)] optimize acquire lock return fail-fast code in redis-pipeline mode.
   - [[#4284](https://github.com/seata/seata/pull/4284)] support authentication of MSE-Nacos with ak/sk
   - [[#4300](https://github.com/seata/seata/pull/4300)] optimize let DefaultCoordinator invoke NettyRemotingServer's close method,no longer closed by ServerRunner
+  - [[#4270](https://github.com/seata/seata/pull/4270)] improve the performance of global commit and global rollback, asynchronous branch transaction cleanup
+
+
   
 
   ### test:	

--- a/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
+++ b/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
@@ -38,6 +38,16 @@ public interface ConfigurationKeys {
     String STORE_PREFIX = "store.";
 
     /**
+     * The constant SESSION_PREFIX.
+     */
+    String SESSION_PREFIX = "session.";
+
+    /**
+     * The constant STORE_SESSION_PREFIX.
+     */
+    String STORE_SESSION_PREFIX = STORE_PREFIX + SESSION_PREFIX;
+
+    /**
      * The constant MODE.
      */
     String MODE = "mode";
@@ -65,12 +75,12 @@ public interface ConfigurationKeys {
     /**
      * The constant STORE_SESSION_MODE.
      */
-    String STORE_SESSION_MODE = STORE_PREFIX + "session." + MODE;
+    String STORE_SESSION_MODE = STORE_SESSION_PREFIX + MODE;
 
     /**
      * The constant SERVER_STORE_SESSION_MODE.
      */
-    String SERVER_STORE_SESSION_MODE = SEATA_PREFIX + STORE_PREFIX + "session." + MODE;
+    String SERVER_STORE_SESSION_MODE = SEATA_PREFIX + STORE_SESSION_PREFIX + MODE;
 
     /**
      * The constant STORE_PUBLIC_KEY.
@@ -772,4 +782,14 @@ public interface ConfigurationKeys {
      * The constant RPC_TM_REQUEST_TIMEOUT
      */
     String RPC_TC_REQUEST_TIMEOUT = TRANSPORT_PREFIX + "rpcTcRequestTimeout";
+
+    /**
+     * The constant SESSION_BRANCH_ASYNC_QUEUE_SIZE
+     */
+    String SESSION_BRANCH_ASYNC_QUEUE_SIZE = SERVER_PREFIX + SESSION_PREFIX + "branchAsyncQueueSize";
+
+    /**
+     * The constant ENABLE_BRANCH_ASYNC_REMOVE
+     */
+    String ENABLE_BRANCH_ASYNC_REMOVE = SERVER_PREFIX + SESSION_PREFIX + "enableBranchAsyncRemove";
 }

--- a/script/config-center/config.txt
+++ b/script/config-center/config.txt
@@ -100,3 +100,5 @@ metrics.exporterList=prometheus
 metrics.exporterPrometheusPort=9898
 tcc.fence.logTableName=tcc_fence_log
 tcc.fence.cleanPeriod=1h
+server.session.branchAsyncQueueSize=5000
+server.session.enableBranchAsyncRemove=true

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/io/seata/spring/boot/autoconfigure/StarterConstants.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/io/seata/spring/boot/autoconfigure/StarterConstants.java
@@ -81,6 +81,8 @@ public interface StarterConstants {
     String STORE_REDIS_SINGLE_PREFIX = STORE_REDIS_PREFIX + ".single";
     String STORE_REDIS_SENTINEL_PREFIX = STORE_REDIS_PREFIX + ".sentinel";
 
+    String SESSION_PREFIX = SERVER_PREFIX + ".session";
+
     String REGEX_SPLIT_CHAR = ";";
 
 

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/io/seata/spring/boot/autoconfigure/SeataServerEnvironmentPostProcessor.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/io/seata/spring/boot/autoconfigure/SeataServerEnvironmentPostProcessor.java
@@ -19,6 +19,7 @@ import io.seata.spring.boot.autoconfigure.properties.server.MetricsProperties;
 import io.seata.spring.boot.autoconfigure.properties.server.ServerProperties;
 import io.seata.spring.boot.autoconfigure.properties.server.ServerRecoveryProperties;
 import io.seata.spring.boot.autoconfigure.properties.server.ServerUndoProperties;
+import io.seata.spring.boot.autoconfigure.properties.server.session.SessionProperties;
 import io.seata.spring.boot.autoconfigure.properties.server.store.StoreDBProperties;
 import io.seata.spring.boot.autoconfigure.properties.server.store.StoreFileProperties;
 import io.seata.spring.boot.autoconfigure.properties.server.store.StoreProperties;
@@ -33,6 +34,7 @@ import static io.seata.spring.boot.autoconfigure.StarterConstants.PROPERTY_BEAN_
 import static io.seata.spring.boot.autoconfigure.StarterConstants.SERVER_PREFIX;
 import static io.seata.spring.boot.autoconfigure.StarterConstants.SERVER_RECOVERY_PREFIX;
 import static io.seata.spring.boot.autoconfigure.StarterConstants.SERVER_UNDO_PREFIX;
+import static io.seata.spring.boot.autoconfigure.StarterConstants.SESSION_PREFIX;
 import static io.seata.spring.boot.autoconfigure.StarterConstants.STORE_DB_PREFIX;
 import static io.seata.spring.boot.autoconfigure.StarterConstants.STORE_FILE_PREFIX;
 import static io.seata.spring.boot.autoconfigure.StarterConstants.STORE_LOCK_PREFIX;
@@ -62,6 +64,7 @@ public class SeataServerEnvironmentPostProcessor implements EnvironmentPostProce
         PROPERTY_BEAN_MAP.put(STORE_REDIS_PREFIX, StoreRedisProperties.class);
         PROPERTY_BEAN_MAP.put(STORE_REDIS_SINGLE_PREFIX, StoreRedisProperties.Single.class);
         PROPERTY_BEAN_MAP.put(STORE_REDIS_SENTINEL_PREFIX, StoreRedisProperties.Sentinel.class);
+        PROPERTY_BEAN_MAP.put(SESSION_PREFIX, SessionProperties.class);
     }
 
     @Override

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/io/seata/spring/boot/autoconfigure/properties/server/session/SessionProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-server/src/main/java/io/seata/spring/boot/autoconfigure/properties/server/session/SessionProperties.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.spring.boot.autoconfigure.properties.server.session;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import static io.seata.spring.boot.autoconfigure.StarterConstants.SESSION_PREFIX;
+
+/**
+ * session properties
+ *
+ * @author yangwenpeng
+ * @since 2022-01-07 17:39
+ */
+@Component
+@ConfigurationProperties(prefix = SESSION_PREFIX)
+public class SessionProperties {
+
+    /**
+     * branch async remove queue size
+     */
+    private Integer branchAsyncQueueSize;
+
+    /**
+     * enable to asynchronous remove branchSession
+     */
+    private Boolean enableBranchAsyncRemove = true;
+
+    public Integer getBranchAsyncQueueSize() {
+        return branchAsyncQueueSize;
+    }
+
+    public SessionProperties setBranchAsyncQueueSize(Integer branchAsyncQueueSize) {
+        this.branchAsyncQueueSize = branchAsyncQueueSize;
+        return this;
+    }
+
+    public Boolean getEnableBranchAsync() {
+        return enableBranchAsyncRemove;
+    }
+
+    public SessionProperties setEnableBranchAsync(Boolean enableBranchAsyncRemove) {
+        this.enableBranchAsyncRemove = enableBranchAsyncRemove;
+        return this;
+    }
+}

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
@@ -210,7 +210,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
      * @param branchSession the branchSession
      */
     public void doBranchRemoveAsync(GlobalSession globalSession, BranchSession branchSession) {
-        branchRemoveExecutor.submit(new BranchRemoveTask(globalSession, branchSession));
+        branchRemoveExecutor.execute(new BranchRemoveTask(globalSession, branchSession));
     }
 
     /**
@@ -219,7 +219,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
      * @param globalSession the globalSession
      */
     public void doBranchRemoveAllAsync(GlobalSession globalSession) {
-        branchRemoveExecutor.submit(new BranchRemoveTask(globalSession));
+        branchRemoveExecutor.execute(new BranchRemoveTask(globalSession));
     }
 
     @Override

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCore.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCore.java
@@ -197,7 +197,7 @@ public class DefaultCore implements Core {
 
                 BranchStatus currentStatus = branchSession.getStatus();
                 if (currentStatus == BranchStatus.PhaseOne_Failed) {
-                    globalSession.removeBranch(branchSession);
+                    SessionHelper.removeBranch(globalSession, branchSession, !retrying);
                     return CONTINUE;
                 }
                 try {
@@ -205,7 +205,7 @@ public class DefaultCore implements Core {
 
                     switch (branchStatus) {
                         case PhaseTwo_Committed:
-                            globalSession.removeBranch(branchSession);
+                            SessionHelper.removeBranch(globalSession, branchSession, !retrying);
                             return CONTINUE;
                         case PhaseTwo_CommitFailed_Unretryable:
                             if (globalSession.canBeCommittedAsync()) {
@@ -307,14 +307,14 @@ public class DefaultCore implements Core {
             Boolean result = SessionHelper.forEach(globalSession.getReverseSortedBranches(), branchSession -> {
                 BranchStatus currentBranchStatus = branchSession.getStatus();
                 if (currentBranchStatus == BranchStatus.PhaseOne_Failed) {
-                    globalSession.removeBranch(branchSession);
+                    SessionHelper.removeBranch(globalSession, branchSession, !retrying);
                     return CONTINUE;
                 }
                 try {
                     BranchStatus branchStatus = branchRollback(globalSession, branchSession);
                     switch (branchStatus) {
                         case PhaseTwo_Rollbacked:
-                            globalSession.removeBranch(branchSession);
+                            SessionHelper.removeBranch(globalSession, branchSession, !retrying);
                             LOGGER.info("Rollback branch transaction successfully, xid = {} branchId = {}", globalSession.getXid(), branchSession.getBranchId());
                             return CONTINUE;
                         case PhaseTwo_RollbackFailed_Unretryable:

--- a/server/src/main/java/io/seata/server/transaction/saga/SagaCore.java
+++ b/server/src/main/java/io/seata/server/transaction/saga/SagaCore.java
@@ -16,7 +16,6 @@
 package io.seata.server.transaction.saga;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
@@ -106,12 +105,12 @@ public class SagaCore extends AbstractCore {
 
             switch (branchStatus) {
                 case PhaseTwo_Committed:
-                    removeAllBranches(globalSession);
+                    SessionHelper.removeAllBranch(globalSession, !retrying);
                     LOGGER.info("Successfully committed SAGA global[" + globalSession.getXid() + "]");
                     break;
                 case PhaseTwo_Rollbacked:
                     LOGGER.info("Successfully rollbacked SAGA global[" + globalSession.getXid() + "]");
-                    removeAllBranches(globalSession);
+                    SessionHelper.removeAllBranch(globalSession, !retrying);
                     SessionHelper.endRollbacked(globalSession);
                     return false;
                 case PhaseTwo_RollbackFailed_Retryable:
@@ -122,7 +121,7 @@ public class SagaCore extends AbstractCore {
                     return false;
                 case PhaseOne_Failed:
                     LOGGER.error("By [{}], finish SAGA global [{}]", branchStatus, globalSession.getXid());
-                    removeAllBranches(globalSession);
+                    SessionHelper.removeAllBranch(globalSession, !retrying);
                     globalSession.changeStatus(GlobalStatus.Finished);
                     globalSession.end();
                     return false;
@@ -164,7 +163,7 @@ public class SagaCore extends AbstractCore {
 
             switch (branchStatus) {
                 case PhaseTwo_Rollbacked:
-                    removeAllBranches(globalSession);
+                    SessionHelper.removeAllBranch(globalSession, !retrying);
                     LOGGER.info("Successfully rollbacked SAGA global[{}]",globalSession.getXid());
                     break;
                 case PhaseTwo_RollbackFailed_Unretryable:
@@ -196,12 +195,12 @@ public class SagaCore extends AbstractCore {
     @Override
     public void doGlobalReport(GlobalSession globalSession, String xid, GlobalStatus globalStatus) throws TransactionException {
         if (GlobalStatus.Committed.equals(globalStatus)) {
-            removeAllBranches(globalSession);
+            SessionHelper.removeAllBranch(globalSession, false);
             SessionHelper.endCommitted(globalSession);
             LOGGER.info("Global[{}] committed", globalSession.getXid());
         } else if (GlobalStatus.Rollbacked.equals(globalStatus)
                 || GlobalStatus.Finished.equals(globalStatus)) {
-            removeAllBranches(globalSession);
+            SessionHelper.removeAllBranch(globalSession, false);
             SessionHelper.endRollbacked(globalSession);
             LOGGER.info("Global[{}] rollbacked", globalSession.getXid());
         } else {
@@ -217,19 +216,6 @@ public class SagaCore extends AbstractCore {
                 globalSession.queueToRetryCommit();
                 LOGGER.info("Global[{}] will retry commit", globalSession.getXid());
             }
-        }
-    }
-
-    /**
-     * remove all branches
-     *
-     * @param globalSession the globalSession
-     * @throws TransactionException the TransactionException
-     */
-    private void removeAllBranches(GlobalSession globalSession) throws TransactionException {
-        ArrayList<BranchSession> branchSessions = globalSession.getSortedBranches();
-        for (BranchSession branchSession : branchSessions) {
-            globalSession.removeBranch(branchSession);
         }
     }
 

--- a/server/src/main/resources/application.example.yml
+++ b/server/src/main/resources/application.example.yml
@@ -114,6 +114,9 @@ seata:
     undo:
       log-save-days: 7
       log-delete-period: 86400000
+    session:
+      branch-async-queue-size: 5000
+      enable-branch-async-remove: true
   store:
     # support: file 、 db 、 redis
     mode: file

--- a/server/src/main/resources/application.example.yml
+++ b/server/src/main/resources/application.example.yml
@@ -115,8 +115,8 @@ seata:
       log-save-days: 7
       log-delete-period: 86400000
     session:
-      branch-async-queue-size: 5000
-      enable-branch-async-remove: true
+      branch-async-queue-size: 5000 #branch async remove queue size
+      enable-branch-async-remove: true #enable to asynchronous remove branchSession
   store:
     # support: file 、 db 、 redis
     mode: file


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
When the global commit or rollback is performed, the branch transaction enters the thread pool for asynchronous deletion after the second-phase delivery is successful.

全局提交或回滚时，分支事务二阶段下发成功后进入线程池中异步删除。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3750 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
先review方案

### Ⅳ. Describe how to verify it
The transaction is committed and rolled back normally, the TM receives the response before the branch transaction is deleted, and the branch transaction is deleted after the asynchronous thread is executed.

正常提交和回滚事务，TM在分支事务删除前收到响应，异步线程执行后分支事务被删除。

### Ⅴ. Special notes for reviews

