### PR TITLE
optimize: acquire lock return fail-fast code in redis-pipeline mode.

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -153,6 +153,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4251](https://github.com/seata/seata/pull/4251)] 优化部分代码处理
   - [[#4262](https://github.com/seata/seata/pull/4262)] 优化 tcc 模块代码处理
   - [[#4235](https://github.com/seata/seata/pull/4235)] 优化eureka注册中心保存实例信息
+  - [[#4277](https://github.com/seata/seata/pull/4277)] 优化Redis-pipeline模式本地事务下的锁竞争机制
   
 
 ### test：

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -153,6 +153,7 @@
   - [[#4251](https://github.com/seata/seata/pull/4251)] optimize partial code handling
   - [[#4262](https://github.com/seata/seata/pull/4262)] optimize tcc module code handling
   - [[#4235](https://github.com/seata/seata/pull/4235)] optimize instance saved in eureka
+  - [[#4277](https://github.com/seata/seata/pull/4277)] optimize acquire lock return fail-fast code in redis-pipeline mode.
   
 
   ### test:	

--- a/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
+++ b/server/src/main/java/io/seata/server/storage/redis/lock/RedisLocker.java
@@ -21,13 +21,11 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -170,14 +168,14 @@ public class RedisLocker extends AbstractLocker {
             List<List<String>> existedLockInfos =
                     Lists.partition((List<String>)(List)pipeline1.syncAndReturnAll(), autoCommit ? 1 : 2);
             if (!autoCommit) {
-                Collections.sort(existedLockInfos, (list1, list2) -> {
-                    String status1 = Optional.ofNullable(list1.get(1)).orElse("0");
-                    String status2 = Optional.ofNullable(list2.get(1)).orElse("0");
-                    return Long.valueOf(status2).compareTo(Long.valueOf(status1));
-                });
+                boolean hasRollBackingLock = existedLockInfos.parallelStream().anyMatch(
+                    result -> StringUtils.equals(result.get(1), String.valueOf(LockStatus.Rollbacking.getCode())));
+                if (hasRollBackingLock) {
+                    throw new StoreException(new BranchTransactionException(LockKeyConflictFailFast));
+                }
             }
 
-            boolean failFast = false;
+            // The logic is executed here, there must be a lock without Rollbacking status when autoCommit equals false
             for (int i = 0; i < needLockKeys.size(); i++) {
                 List<String> results = existedLockInfos.get(i);
                 String existedLockXid = CollectionUtils.isEmpty(results) ? null : existedLockInfos.get(i).get(0);
@@ -186,20 +184,10 @@ public class RedisLocker extends AbstractLocker {
                     needAddLock.put(needLockKeys.get(i), needLockDOS.get(i));
                 } else {
                     if (!StringUtils.equals(existedLockXid, needLockXid)) {
-                        if (!autoCommit) {
-                            String status = existedLockInfos.get(i).get(1);
-                            if (StringUtils.equals(status, String.valueOf(LockStatus.Rollbacking.getCode()))) {
-                                failFast = true;
-                                break;
-                            }
-                        }
                         // If not equals,means the rowkey is holding by another global transaction
                         return false;
                     }
                 }
-            }
-            if (failFast) {
-                throw new StoreException(new BranchTransactionException(LockKeyConflictFailFast));
             }
             if (needAddLock.isEmpty()) {
                 return true;
@@ -212,14 +200,13 @@ public class RedisLocker extends AbstractLocker {
             pipeline.hsetnx(key, XID, value.getXid());
             pipeline.hsetnx(key, TRANSACTION_ID, value.getTransactionId().toString());
             pipeline.hsetnx(key, BRANCH_ID, value.getBranchId().toString());
-            pipeline.hsetnx(key, STATUS, String.valueOf(LockStatus.Locked.getCode()));
             pipeline.hset(key, ROW_KEY, value.getRowKey());
             pipeline.hset(key, RESOURCE_ID, value.getResourceId());
             pipeline.hset(key, TABLE_NAME, value.getTableName());
             pipeline.hset(key, PK, value.getPk());
         });
         List<Integer> results = (List<Integer>) (List) pipeline.syncAndReturnAll();
-        List<List<Integer>> partitions = Lists.partition(results, 8);
+        List<List<Integer>> partitions = Lists.partition(results, 7);
 
         ArrayList<String> success = new ArrayList<>(partitions.size());
         Integer status = SUCCEED;


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
When the local transaction and the global transaction are enabled, the branch registration fails to acquire the global lock, the lock holder is in the second-stage rollback, and the branch registration fails to be retried quickly, because the retry with the local transaction does not release the database lock , resulting in a two-phase rollback wait. Therefore, if a global lock is found in the Rollbacking state, the fail-fast code is returned directly.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
#4267 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

