### PR TITLE
bugfix:fix can not deserialize blob/clob/nclob data type when use mysql

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
@@ -239,7 +239,7 @@ public class TableRecords implements java.io.Serializable {
                     }
                 } else {
                     // JDBCType.DISTINCT, JDBCType.STRUCT etc...
-                    field.setValue(resultSet.getObject(i));
+                    field.setValue(holdSerialDataType(resultSet.getObject(i)));
                 }
 
                 fields.add(field);
@@ -251,6 +251,36 @@ public class TableRecords implements java.io.Serializable {
             records.add(row);
         }
         return records;
+    }
+
+    /**
+     * since there is no parameterless constructor for Blob, Clob and NClob just like mysql,
+     * it needs to be converted to Serial_ type
+     *
+     * @param data the sql data
+     * @return Serializable Data
+     * @throws SQLException the sql exception
+     */
+    public static Object holdSerialDataType(Object data) throws SQLException {
+        if (null == data) {
+            return null;
+        }
+
+        if (data instanceof Blob) {
+            Blob blob = (Blob) data;
+            return new SerialBlob(blob);
+        }
+
+        if (data instanceof NClob) {
+            NClob nClob = (NClob) data;
+            return new SerialClob(nClob);
+        }
+
+        if (data instanceof Clob) {
+            Clob clob = (Clob) data;
+            return new SerialClob(clob);
+        }
+        return data;
     }
 
     public static class EmptyTableRecords extends TableRecords {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
Convert Blob, Clob, NClob types to Serial corresponding types to avoid deserialization failure due to the absence of a parameterless constructor

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #4249 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

