### PR TITLE
optimize: suspend undolog conflict

### DIFF
--- a/rm-datasource/src/main/java/io/seata/rm/datasource/DataSourceManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/DataSourceManager.java
@@ -47,7 +47,7 @@ public class DataSourceManager extends AbstractResourceManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DataSourceManager.class);
 
-    private final AsyncWorker asyncWorker = new AsyncWorker(this);
+    private final AsyncWorker asyncWorker = AsyncWorker.getInstance(this);
 
     private final Map<String, Resource> dataSourceCache = new ConcurrentHashMap<>();
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoLogManager.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoLogManager.java
@@ -36,9 +36,14 @@ import io.seata.core.constants.ClientTableColumnsName;
 import io.seata.core.constants.ConfigurationKeys;
 import io.seata.core.exception.BranchTransactionException;
 import io.seata.core.exception.TransactionException;
-import io.seata.rm.datasource.ConnectionContext;
+import io.seata.core.model.BranchType;
+import io.seata.core.model.ResourceManager;
+import io.seata.rm.DefaultResourceManager;
+import io.seata.rm.datasource.DataSourceManager;
 import io.seata.rm.datasource.ConnectionProxy;
 import io.seata.rm.datasource.DataSourceProxy;
+import io.seata.rm.datasource.AsyncWorker;
+import io.seata.rm.datasource.ConnectionContext;
 import io.seata.rm.datasource.sql.struct.TableMeta;
 import io.seata.rm.datasource.sql.struct.TableMetaCacheFactory;
 import org.slf4j.Logger;
@@ -80,27 +85,29 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
     }
 
     protected static final String UNDO_LOG_TABLE_NAME = ConfigurationFactory.getInstance().getConfig(
-        ConfigurationKeys.TRANSACTION_UNDO_LOG_TABLE, DEFAULT_TRANSACTION_UNDO_LOG_TABLE);
+            ConfigurationKeys.TRANSACTION_UNDO_LOG_TABLE, DEFAULT_TRANSACTION_UNDO_LOG_TABLE);
 
     private static final String CHECK_UNDO_LOG_TABLE_EXIST_SQL = "SELECT 1 FROM " + UNDO_LOG_TABLE_NAME + " LIMIT 1";
 
     protected static final String SELECT_UNDO_LOG_SQL = "SELECT * FROM " + UNDO_LOG_TABLE_NAME + " WHERE "
-        + ClientTableColumnsName.UNDO_LOG_BRANCH_XID + " = ? AND " + ClientTableColumnsName.UNDO_LOG_XID
-        + " = ? FOR UPDATE";
+            + ClientTableColumnsName.UNDO_LOG_BRANCH_XID + " = ? AND " + ClientTableColumnsName.UNDO_LOG_XID
+            + " = ? FOR UPDATE";
 
     protected static final String DELETE_UNDO_LOG_SQL = "DELETE FROM " + UNDO_LOG_TABLE_NAME + " WHERE "
-        + ClientTableColumnsName.UNDO_LOG_BRANCH_XID + " = ? AND " + ClientTableColumnsName.UNDO_LOG_XID + " = ?";
+            + ClientTableColumnsName.UNDO_LOG_BRANCH_XID + " = ? AND " + ClientTableColumnsName.UNDO_LOG_XID + " = ?";
 
     protected static final boolean ROLLBACK_INFO_COMPRESS_ENABLE = ConfigurationFactory.getInstance().getBoolean(
-        ConfigurationKeys.CLIENT_UNDO_COMPRESS_ENABLE, DEFAULT_CLIENT_UNDO_COMPRESS_ENABLE);
+            ConfigurationKeys.CLIENT_UNDO_COMPRESS_ENABLE, DEFAULT_CLIENT_UNDO_COMPRESS_ENABLE);
 
     protected static final CompressorType ROLLBACK_INFO_COMPRESS_TYPE = CompressorType.getByName(ConfigurationFactory.getInstance().getConfig(
-        ConfigurationKeys.CLIENT_UNDO_COMPRESS_TYPE, DEFAULT_CLIENT_UNDO_COMPRESS_TYPE));
+            ConfigurationKeys.CLIENT_UNDO_COMPRESS_TYPE, DEFAULT_CLIENT_UNDO_COMPRESS_TYPE));
 
     protected static final long ROLLBACK_INFO_COMPRESS_THRESHOLD = SizeUtil.size2Long(ConfigurationFactory.getInstance().getConfig(
             ConfigurationKeys.CLIENT_UNDO_COMPRESS_THRESHOLD, DEFAULT_CLIENT_UNDO_COMPRESS_THRESHOLD));
 
     private static final ThreadLocal<String> SERIALIZER_LOCAL = new ThreadLocal<>();
+
+    private final AsyncWorker asyncWorker = AsyncWorker.getInstance((DataSourceManager) getResourceManager());
 
     public static String getCurrentSerializer() {
         return SERIALIZER_LOCAL.get();
@@ -139,9 +146,9 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
     /**
      * batch Delete undo log.
      *
-     * @param xids xid
+     * @param xids      xid
      * @param branchIds branch Id
-     * @param conn connection
+     * @param conn      connection
      */
     @Override
     public void batchDeleteUndoLog(Set<String> xids, Set<Long> branchIds, Connection conn) throws SQLException {
@@ -174,7 +181,7 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
     protected static String toBatchDeleteUndoLogSql(int xidSize, int branchIdSize) {
         StringBuilder sqlBuilder = new StringBuilder(64);
         sqlBuilder.append("DELETE FROM ").append(UNDO_LOG_TABLE_NAME).append(" WHERE  ").append(
-            ClientTableColumnsName.UNDO_LOG_BRANCH_XID).append(" IN ");
+                ClientTableColumnsName.UNDO_LOG_BRANCH_XID).append(" IN ");
         appendInParam(branchIdSize, sqlBuilder);
         sqlBuilder.append(" AND ").append(ClientTableColumnsName.UNDO_LOG_XID).append(" IN ");
         appendInParam(xidSize, sqlBuilder);
@@ -240,8 +247,12 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
             compressorType = ROLLBACK_INFO_COMPRESS_TYPE;
             undoLogContent = CompressorFactory.getCompressor(compressorType.getCode()).compress(undoLogContent);
         }
-
-        insertUndoLogWithNormal(xid, branchId, buildContext(parser.getName(), compressorType), undoLogContent, cp.getTargetConnection());
+        try {
+            insertUndoLogWithNormal(xid, branchId, buildContext(parser.getName(), compressorType), undoLogContent, cp.getTargetConnection());
+        }catch (SQLIntegrityConstraintViolationException e){
+            LOGGER.error("Insert undo log duplicate key exception,maybe has been rollbacked by phase2",e);
+            asyncWorker.cleanSuspendUndoLog(xid,branchId,cp.getDataSourceProxy().getResourceId());
+        }
     }
 
     /**
@@ -295,7 +306,7 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
 
                     String serializer = context == null ? null : context.get(UndoLogConstants.SERIALIZER_KEY);
                     UndoLogParser parser = serializer == null ? UndoLogParserFactory.getInstance()
-                        : UndoLogParserFactory.getInstance(serializer);
+                            : UndoLogParserFactory.getInstance(serializer);
                     BranchUndoLog branchUndoLog = parser.decode(rollbackInfo);
 
                     try {
@@ -307,10 +318,10 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
                         }
                         for (SQLUndoLog sqlUndoLog : sqlUndoLogs) {
                             TableMeta tableMeta = TableMetaCacheFactory.getTableMetaCache(dataSourceProxy.getDbType()).getTableMeta(
-                                conn, sqlUndoLog.getTableName(), dataSourceProxy.getResourceId());
+                                    conn, sqlUndoLog.getTableName(), dataSourceProxy.getResourceId());
                             sqlUndoLog.setTableMeta(tableMeta);
                             AbstractUndoExecutor undoExecutor = UndoExecutorFactory.getUndoExecutor(
-                                dataSourceProxy.getDbType(), sqlUndoLog);
+                                    dataSourceProxy.getDbType(), sqlUndoLog);
                             undoExecutor.executeOn(conn);
                         }
                     } finally {
@@ -333,14 +344,14 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
                     conn.commit();
                     if (LOGGER.isInfoEnabled()) {
                         LOGGER.info("xid {} branch {}, undo_log deleted with {}", xid, branchId,
-                            State.GlobalFinished.name());
+                                State.GlobalFinished.name());
                     }
                 } else {
                     insertUndoLogWithGlobalFinished(xid, branchId, UndoLogParserFactory.getInstance(), conn);
                     conn.commit();
                     if (LOGGER.isInfoEnabled()) {
                         LOGGER.info("xid {} branch {}, undo_log added with {}", xid, branchId,
-                            State.GlobalFinished.name());
+                                State.GlobalFinished.name());
                     }
                 }
 
@@ -359,8 +370,8 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
                     }
                 }
                 throw new BranchTransactionException(BranchRollbackFailed_Retriable, String
-                    .format("Branch session rollback failed and try again later xid = %s branchId = %s %s", xid,
-                        branchId, e.getMessage()), e);
+                        .format("Branch session rollback failed and try again later xid = %s branchId = %s %s", xid,
+                                branchId, e.getMessage()), e);
 
             } finally {
                 try {
@@ -415,7 +426,7 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
      * @return
      * @throws SQLException SQLException
      */
-    protected byte[] getRollbackInfo(ResultSet rs) throws SQLException  {
+    protected byte[] getRollbackInfo(ResultSet rs) throws SQLException {
         byte[] rollbackInfo = rs.getBytes(ClientTableColumnsName.UNDO_LOG_ROLLBACK_INFO);
 
         String rollbackInfoContext = rs.getString(ClientTableColumnsName.UNDO_LOG_CONTEXT);
@@ -427,6 +438,7 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
 
     /**
      * if the undoLogContent is big enough to be compress
+     *
      * @param undoLogContent undoLogContent
      * @return boolean
      */
@@ -447,5 +459,9 @@ public abstract class AbstractUndoLogManager implements UndoLogManager {
 
     protected String getCheckUndoLogTableExistSql() {
         return CHECK_UNDO_LOG_TABLE_EXIST_SQL;
+    }
+
+    private static ResourceManager getResourceManager() {
+        return DefaultResourceManager.get().getResourceManager(BranchType.AT);
     }
 }

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/AsyncWorkerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/AsyncWorkerTest.java
@@ -42,7 +42,7 @@ class AsyncWorkerTest {
 
     @Test
     void doBranchCommitSafely() {
-        assertDoesNotThrow(worker::doBranchCommitSafely, "this method should never throw anything");
+        assertDoesNotThrow(worker::doUndoLogCleanSafely, "this method should never throw anything");
     }
 
     @Test

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/AsyncWorkerTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/AsyncWorkerTest.java
@@ -47,27 +47,27 @@ class AsyncWorkerTest {
 
     @Test
     void groupedByResourceId() {
-        List<AsyncWorker.Phase2Context> contexts = getRandomContexts();
-        Map<String, List<AsyncWorker.Phase2Context>> groupedContexts = worker.groupedByResourceId(contexts);
+        List<AsyncWorker.BranchPhaseContext> contexts = getRandomContexts();
+        Map<String, List<AsyncWorker.BranchPhaseContext>> groupedContexts = worker.groupedByResourceId(contexts);
         groupedContexts.forEach((resourceId, group) -> group.forEach(context -> {
             String message = "each context in the group should has the same resourceId";
             assertEquals(resourceId, context.resourceId, message);
         }));
     }
 
-    private List<AsyncWorker.Phase2Context> getRandomContexts() {
+    private List<AsyncWorker.BranchPhaseContext> getRandomContexts() {
         return random.ints().limit(16)
                 .mapToObj(String::valueOf)
                 .flatMap(this::generateContextStream)
                 .collect(Collectors.toList());
     }
 
-    private Stream<AsyncWorker.Phase2Context> generateContextStream(String resourceId) {
+    private Stream<AsyncWorker.BranchPhaseContext> generateContextStream(String resourceId) {
         int size = random.nextInt(10);
         return IntStream.range(0, size).mapToObj(i -> buildContext(resourceId));
     }
 
-    private AsyncWorker.Phase2Context buildContext(String resourceId) {
-        return new AsyncWorker.Phase2Context("test", 0, resourceId);
+    private AsyncWorker.BranchPhaseContext buildContext(String resourceId) {
+        return new AsyncWorker.BranchPhaseContext("test", 0, resourceId);
     }
 }

--- a/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
@@ -18,11 +18,16 @@ package io.seata.rm.tcc;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 
 import io.seata.common.exception.FrameworkErrorCode;
 import io.seata.common.exception.SkipCallbackWrapperException;
 import io.seata.common.executor.Callback;
+import io.seata.common.thread.NamedThreadFactory;
 import io.seata.rm.tcc.constant.TCCFenceConstant;
 import io.seata.rm.tcc.exception.TCCFenceException;
 import io.seata.rm.tcc.store.TCCFenceDO;
@@ -53,6 +58,25 @@ public class TCCFenceHandler {
 
     private static TransactionTemplate transactionTemplate;
 
+    private static final int MAX_THREAD_CLEAN = 1;
+
+    private static final int MAX_QUEUE_SIZE = 500;
+
+    private static final LinkedBlockingQueue<FenceLogIdentity> LOG_QUEUE = new LinkedBlockingQueue<>(MAX_QUEUE_SIZE);
+
+    private static FenceLogCleanRunnable fenceLogCleanRunnable;
+
+    private static ExecutorService logCleanExecutor;
+
+    static {
+        try {
+            initLogCleanExecutor();
+        } catch (Exception e) {
+            LOGGER.error("init fence log clean executor error", e);
+        }
+    }
+
+
     public static void setDataSource(DataSource dataSource) {
         TCCFenceHandler.dataSource = dataSource;
     }
@@ -82,6 +106,13 @@ public class TCCFenceHandler {
                     throw new TCCFenceException(String.format("Insert tcc fence record error, prepare fence failed. xid= %s, branchId= %s", xid, branchId),
                             FrameworkErrorCode.InsertRecordError);
                 }
+            } catch (TCCFenceException e) {
+                if (e.getErrcode() == FrameworkErrorCode.DuplicateKeyException) {
+                    LOGGER.error("Branch transaction has already rollbacked before,prepare fence failed. xid= {},branchId = {}", xid, branchId);
+                    addToLogCleanQueue(xid, branchId);
+                }
+                status.setRollbackOnly();
+                throw new SkipCallbackWrapperException(e);
             } catch (Throwable t) {
                 status.setRollbackOnly();
                 throw new SkipCallbackWrapperException(t);
@@ -92,11 +123,11 @@ public class TCCFenceHandler {
     /**
      * tcc commit method enhanced
      *
-     * @param commitMethod          commit method
-     * @param targetTCCBean         target tcc bean
-     * @param xid                   the global transaction id
-     * @param branchId              the branch transaction id
-     * @param args                  commit method's parameters
+     * @param commitMethod  commit method
+     * @param targetTCCBean target tcc bean
+     * @param xid           the global transaction id
+     * @param branchId      the branch transaction id
+     * @param args          commit method's parameters
      * @return the boolean
      */
     public static boolean commitFence(Method commitMethod, Object targetTCCBean,
@@ -130,12 +161,12 @@ public class TCCFenceHandler {
     /**
      * tcc rollback method enhanced
      *
-     * @param rollbackMethod        rollback method
-     * @param targetTCCBean         target tcc bean
-     * @param xid                   the global transaction id
-     * @param branchId              the branch transaction id
-     * @param args                  rollback method's parameters
-     * @param actionName            the action name
+     * @param rollbackMethod rollback method
+     * @param targetTCCBean  target tcc bean
+     * @param xid            the global transaction id
+     * @param branchId       the branch transaction id
+     * @param args           rollback method's parameters
+     * @param actionName     the action name
      * @return the boolean
      */
     public static boolean rollbackFence(Method rollbackMethod, Object targetTCCBean,
@@ -194,11 +225,11 @@ public class TCCFenceHandler {
     /**
      * Update TCC Fence status and invoke target method
      *
-     * @param method                target method
-     * @param targetTCCBean         target bean
-     * @param xid                   the global transaction id
-     * @param branchId              the branch transaction id
-     * @param status                the tcc fence status
+     * @param method        target method
+     * @param targetTCCBean target bean
+     * @param xid           the global transaction id
+     * @param branchId      the branch transaction id
+     * @param status        the tcc fence status
      * @return the boolean
      */
     private static boolean updateStatusAndInvokeTargetMethod(Connection conn, Method method, Object targetTCCBean,
@@ -261,5 +292,78 @@ public class TCCFenceHandler {
                 throw e;
             }
         });
+    }
+
+    private static void initLogCleanExecutor() {
+        logCleanExecutor = new ThreadPoolExecutor(MAX_THREAD_CLEAN, MAX_THREAD_CLEAN, Integer.MAX_VALUE,
+                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(),
+                new NamedThreadFactory("fenceLogCleanThread", MAX_THREAD_CLEAN, true)
+        );
+        fenceLogCleanRunnable = new FenceLogCleanRunnable();
+        logCleanExecutor.submit(fenceLogCleanRunnable);
+    }
+
+    private static void addToLogCleanQueue(final String xid, final long branchId) {
+        FenceLogIdentity logIdentity = new FenceLogIdentity();
+        logIdentity.setXid(xid);
+        logIdentity.setBranchId(branchId);
+        try {
+            LOG_QUEUE.add(logIdentity);
+        } catch (Exception e) {
+            LOGGER.warn("Insert tcc fence record into queue for async delete error,xid:{},branchId:{}", xid, branchId, e);
+        }
+    }
+
+    /**
+     * clean fence log that has the final status runnable.
+     *
+     * @see TCCFenceConstant
+     */
+    private static class FenceLogCleanRunnable implements Runnable {
+        @Override
+        public void run() {
+            while (true) {
+
+                try {
+                    FenceLogIdentity logIdentity = LOG_QUEUE.take();
+                    boolean ret = TCCFenceHandler.deleteFence(logIdentity.getXid(), logIdentity.getBranchId());
+                    if (!ret) {
+                        LOGGER.error("delete fence log failed, xid: {}, branchId: {}", logIdentity.getXid(), logIdentity.getBranchId());
+                    }
+                } catch (InterruptedException e) {
+                    LOGGER.error("take fence log from queue for clean be interrupted", e);
+                } catch (Exception e) {
+                    LOGGER.error("exception occur when clean fence log", e);
+                }
+            }
+        }
+    }
+
+    private static class FenceLogIdentity {
+        /**
+         * the global transaction id
+         */
+        private String xid;
+
+        /**
+         * the branch transaction id
+         */
+        private Long branchId;
+
+        public String getXid() {
+            return xid;
+        }
+
+        public Long getBranchId() {
+            return branchId;
+        }
+
+        public void setXid(String xid) {
+            this.xid = xid;
+        }
+
+        public void setBranchId(Long branchId) {
+            this.branchId = branchId;
+        }
     }
 }

--- a/tcc/src/main/java/io/seata/rm/tcc/store/db/TCCFenceStoreDataBaseDAO.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/store/db/TCCFenceStoreDataBaseDAO.java
@@ -24,13 +24,8 @@ import io.seata.rm.tcc.exception.TCCFenceException;
 import io.seata.rm.tcc.store.TCCFenceDO;
 import io.seata.rm.tcc.store.TCCFenceStore;
 import io.seata.rm.tcc.store.db.sql.TCCFenceStoreSqls;
-import org.yaml.snakeyaml.constructor.DuplicateKeyException;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.Date;
 
 /**
@@ -101,7 +96,7 @@ public class TCCFenceStoreDataBaseDAO implements TCCFenceStore {
             ps.setTimestamp(5, now);
             ps.setTimestamp(6, now);
             return ps.executeUpdate() > 0;
-        } catch (DuplicateKeyException e) {
+        } catch (SQLIntegrityConstraintViolationException e) {
             throw new TCCFenceException(String.format("Insert tcc fence record duplicate key exception. xid= %s, branchId= %s", tccFenceDO.getXid(), tccFenceDO.getBranchId()),
                     FrameworkErrorCode.DuplicateKeyException);
         } catch (SQLException e) {

--- a/tcc/src/main/java/io/seata/rm/tcc/store/db/sql/TCCFenceStoreSqls.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/store/db/sql/TCCFenceStoreSqls.java
@@ -63,7 +63,7 @@ public class TCCFenceStoreSqls {
      */
     protected static final String DELETE_BY_DATE_AND_STATUS = "delete from " + LOCAL_TCC_LOG_PLACEHOLD
             + " where gmt_modified < ? "
-            + " and status in (" + TCCFenceConstant.STATUS_COMMITTED + " , " + TCCFenceConstant.STATUS_ROLLBACKED + ")";
+            + " and status in (" + TCCFenceConstant.STATUS_COMMITTED + " , " + TCCFenceConstant.STATUS_ROLLBACKED + " , " + TCCFenceConstant.STATUS_SUSPENDED + ")";
 
     public static String getInsertLocalTCCLogSQL(String localTccTable) {
         return INSERT_LOCAL_TCC_LOG.replace(LOCAL_TCC_LOG_PLACEHOLD, localTccTable);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
optimization after a unique index conflict occurs in undolog #3160


### Ⅱ. Does this pull request fix one issue?
#3160 


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
先帮忙看看代码对不对呢
### Ⅳ. Describe how to verify it
对tcc和at模式发生资源悬挂场景造成tcc_fence_log或undo_log发生唯一键冲突时，将对应的日志记录放入队列，异步删除。
1、tcc通过开辟单独的线程配合日清理线程来做
2、AT模式复用了二阶段提交异步删除任务AsyncWorker，同时复用了同一个队列实例


### Ⅴ. Special notes for reviews

