### PR TITLE
optimize：Data sources can be excluded by beanname or className(#4287)

### DIFF
--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/io/seata/spring/boot/autoconfigure/properties/SeataProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/io/seata/spring/boot/autoconfigure/properties/SeataProperties.java
@@ -71,7 +71,7 @@ public class SeataProperties {
     /**
      * Specifies which datasource class are not eligible for auto-proxying
      */
-    private Class<?>[] excludeClassesForAutoProxying = {};
+    private String[] excludeClassesForAutoProxying = {};
 
     @Autowired
     private SpringCloudAlibabaConfiguration springCloudAlibabaConfiguration;
@@ -172,11 +172,11 @@ public class SeataProperties {
 
     }
 
-    public Class<?>[] getExcludeClassesForAutoProxying() {
+    public String[] getExcludeClassesForAutoProxying() {
         return excludeClassesForAutoProxying;
     }
 
-    public SeataProperties setExcludeClassesForAutoProxying(Class<?>[] excludeClassesForAutoProxying) {
+    public SeataProperties setExcludeClassesForAutoProxying(String[] excludeClassesForAutoProxying) {
         this.excludeClassesForAutoProxying = excludeClassesForAutoProxying;
         return this;
 

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/io/seata/spring/boot/autoconfigure/properties/SeataProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/io/seata/spring/boot/autoconfigure/properties/SeataProperties.java
@@ -57,17 +57,9 @@ public class SeataProperties {
      */
     private String[] scanPackages = {};
     /**
-     * Specifies classnames that won't be scanned in the GlobalTransactionScanner
-     */
-    private String[] excludesForScanning = {};
-    /**
      * Specifies beans that won't be scanned in the GlobalTransactionScanner
      */
-    private String[] excludeNamesForScanning = {};
-    /**
-     * Specifies classes that won't be scanned in the GlobalTransactionScanner
-     */
-    private Class<?>[] excludeClassesForScanning = {};
+    private String[] excludesForScanning = {};
     /**
      * Specifies which datasource classname are not eligible for auto-proxying
      */
@@ -168,25 +160,6 @@ public class SeataProperties {
     public SeataProperties setExcludesForScanning(String[] excludesForScanning) {
         this.excludesForScanning = excludesForScanning;
         return this;
-    }
-
-    public String[] getExcludeNamesForScanning() {
-        return excludeNamesForScanning;
-    }
-
-    public SeataProperties setExcludeNamesForScanning(String[] excludeNamesForScanning) {
-        this.excludeNamesForScanning = excludeNamesForScanning;
-        return this;
-    }
-
-    public Class<?>[] getExcludeClassesForScanning() {
-        return excludeClassesForScanning;
-    }
-
-    public SeataProperties setExcludeClassesForScanning(Class<?>[] excludeClassesForScanning) {
-        this.excludeClassesForScanning = excludeClassesForScanning;
-        return this;
-
     }
 
     public String[] getExcludeNamesForAutoProxying() {

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/io/seata/spring/boot/autoconfigure/properties/SeataProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-client/src/main/java/io/seata/spring/boot/autoconfigure/properties/SeataProperties.java
@@ -57,13 +57,29 @@ public class SeataProperties {
      */
     private String[] scanPackages = {};
     /**
-     * Specifies beans that won't be scanned in the GlobalTransactionScanner
+     * Specifies classnames that won't be scanned in the GlobalTransactionScanner
      */
     private String[] excludesForScanning = {};
     /**
-     * Specifies which datasource bean are not eligible for auto-proxying
+     * Specifies beans that won't be scanned in the GlobalTransactionScanner
+     */
+    private String[] excludeNamesForScanning = {};
+    /**
+     * Specifies classes that won't be scanned in the GlobalTransactionScanner
+     */
+    private Class<?>[] excludeClassesForScanning = {};
+    /**
+     * Specifies which datasource classname are not eligible for auto-proxying
      */
     private String[] excludesForAutoProxying = {};
+    /**
+     * Specifies which datasource bean are not eligible for auto-proxying
+     */
+    private String[] excludeNamesForAutoProxying = {};
+    /**
+     * Specifies which datasource class are not eligible for auto-proxying
+     */
+    private Class<?>[] excludeClassesForAutoProxying = {};
 
     @Autowired
     private SpringCloudAlibabaConfiguration springCloudAlibabaConfiguration;
@@ -152,5 +168,44 @@ public class SeataProperties {
     public SeataProperties setExcludesForScanning(String[] excludesForScanning) {
         this.excludesForScanning = excludesForScanning;
         return this;
+    }
+
+    public String[] getExcludeNamesForScanning() {
+        return excludeNamesForScanning;
+    }
+
+    public SeataProperties setExcludeNamesForScanning(String[] excludeNamesForScanning) {
+        this.excludeNamesForScanning = excludeNamesForScanning;
+        return this;
+    }
+
+    public Class<?>[] getExcludeClassesForScanning() {
+        return excludeClassesForScanning;
+    }
+
+    public SeataProperties setExcludeClassesForScanning(Class<?>[] excludeClassesForScanning) {
+        this.excludeClassesForScanning = excludeClassesForScanning;
+        return this;
+
+    }
+
+    public String[] getExcludeNamesForAutoProxying() {
+        return excludeNamesForAutoProxying;
+    }
+
+    public SeataProperties setExcludeNamesForAutoProxying(String[] excludeNamesForAutoProxying) {
+        this.excludeNamesForAutoProxying = excludeNamesForAutoProxying;
+        return this;
+
+    }
+
+    public Class<?>[] getExcludeClassesForAutoProxying() {
+        return excludeClassesForAutoProxying;
+    }
+
+    public SeataProperties setExcludeClassesForAutoProxying(Class<?>[] excludeClassesForAutoProxying) {
+        this.excludeClassesForAutoProxying = excludeClassesForAutoProxying;
+        return this;
+
     }
 }

--- a/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/SeataDataSourceAutoConfiguration.java
+++ b/seata-spring-boot-starter/src/main/java/io/seata/spring/boot/autoconfigure/SeataDataSourceAutoConfiguration.java
@@ -43,7 +43,8 @@ public class SeataDataSourceAutoConfiguration {
     @Bean(BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR)
     @ConditionalOnMissingBean(SeataAutoDataSourceProxyCreator.class)
     public SeataAutoDataSourceProxyCreator seataAutoDataSourceProxyCreator(SeataProperties seataProperties) {
-        return new SeataAutoDataSourceProxyCreator(seataProperties.isUseJdkProxy(),
-            seataProperties.getExcludesForAutoProxying(), seataProperties.getDataSourceProxyMode());
+        return new SeataAutoDataSourceProxyCreator(seataProperties.isUseJdkProxy(),seataProperties.getExcludesForAutoProxying(),
+                seataProperties.getExcludeNamesForAutoProxying(),seataProperties.getExcludeClassesForAutoProxying(),
+                seataProperties.getDataSourceProxyMode());
     }
 }

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/AutoDataSourceProxyRegistrar.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/AutoDataSourceProxyRegistrar.java
@@ -43,7 +43,7 @@ public class AutoDataSourceProxyRegistrar implements ImportBeanDefinitionRegistr
         boolean useJdkProxy = Boolean.parseBoolean(annotationAttributes.get(ATTRIBUTE_KEY_USE_JDK_PROXY).toString());
         String[] excludes = (String[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDES);
         String[] excludeNames = (String[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDE_NAMES);
-        Class<?>[] excludeClasses = (Class<?>[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDE_CLASSES);
+        String[] excludeClasses = (String[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDE_CLASSES);
         String dataSourceProxyMode = (String) annotationAttributes.get(ATTRIBUTE_KEY_DATA_SOURCE_PROXY_MODE);
 
         //register seataAutoDataSourceProxyCreator bean def

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/AutoDataSourceProxyRegistrar.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/AutoDataSourceProxyRegistrar.java
@@ -30,6 +30,8 @@ import org.springframework.core.type.AnnotationMetadata;
 public class AutoDataSourceProxyRegistrar implements ImportBeanDefinitionRegistrar {
     private static final String ATTRIBUTE_KEY_USE_JDK_PROXY = "useJdkProxy";
     private static final String ATTRIBUTE_KEY_EXCLUDES = "excludes";
+    private static final String ATTRIBUTE_KEY_EXCLUDE_NAMES = "excludeNames";
+    private static final String ATTRIBUTE_KEY_EXCLUDE_CLASSES = "excludeClasses";
     private static final String ATTRIBUTE_KEY_DATA_SOURCE_PROXY_MODE = "dataSourceProxyMode";
 
     public static final String BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR = "seataAutoDataSourceProxyCreator";
@@ -40,6 +42,8 @@ public class AutoDataSourceProxyRegistrar implements ImportBeanDefinitionRegistr
 
         boolean useJdkProxy = Boolean.parseBoolean(annotationAttributes.get(ATTRIBUTE_KEY_USE_JDK_PROXY).toString());
         String[] excludes = (String[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDES);
+        String[] excludeNames = (String[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDE_NAMES);
+        Class<?>[] excludeClasses = (Class<?>[]) annotationAttributes.get(ATTRIBUTE_KEY_EXCLUDE_CLASSES);
         String dataSourceProxyMode = (String) annotationAttributes.get(ATTRIBUTE_KEY_DATA_SOURCE_PROXY_MODE);
 
         //register seataAutoDataSourceProxyCreator bean def
@@ -48,6 +52,8 @@ public class AutoDataSourceProxyRegistrar implements ImportBeanDefinitionRegistr
                 .genericBeanDefinition(SeataAutoDataSourceProxyCreator.class)
                 .addConstructorArgValue(useJdkProxy)
                 .addConstructorArgValue(excludes)
+                .addConstructorArgValue(excludeNames)
+                .addConstructorArgValue(excludeClasses)
                 .addConstructorArgValue(dataSourceProxyMode)
                 .getBeanDefinition();
             registry.registerBeanDefinition(BEAN_NAME_SEATA_AUTO_DATA_SOURCE_PROXY_CREATOR, beanDefinition);

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/EnableAutoDataSourceProxy.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/EnableAutoDataSourceProxy.java
@@ -60,7 +60,7 @@ public @interface EnableAutoDataSourceProxy {
      * @return excludeClasses
      */
 
-    Class<?>[] excludeClasses() default {};
+    String[] excludeClasses() default {};
 
     /**
      * Data source proxy mode, AT or XA

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/EnableAutoDataSourceProxy.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/EnableAutoDataSourceProxy.java
@@ -41,10 +41,26 @@ public @interface EnableAutoDataSourceProxy {
 
     /**
      * Specifies which datasource bean are not eligible for auto-proxying
+     * You can use excludeClasses instead
      *
      * @return excludes
      */
+    @Deprecated
     String[] excludes() default {};
+    /**
+     * Specifies which datasource bean are not eligible for auto-proxying
+     *
+     * @return excludeNames
+     */
+    String[] excludeNames() default {};
+
+    /**
+     * Specifies which datasource class are not eligible for auto-proxying
+     *
+     * @return excludeClasses
+     */
+
+    Class<?>[] excludeClasses() default {};
 
     /**
      * Data source proxy mode, AT or XA

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyCreator.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyCreator.java
@@ -43,14 +43,14 @@ public class SeataAutoDataSourceProxyCreator extends AbstractAutoProxyCreator {
 
     private final Set<String> excludeNames;
 
-    private final Set<Class<?>> excludeClasses;
+    private final Set<String> excludeClasses;
 
     private final String dataSourceProxyMode;
 
     private final Object[] advisors;
 
     public SeataAutoDataSourceProxyCreator(boolean useJdkProxy, String[] excludes, String[] excludeNames,
-                                           Class<?>[] excludeClasses, String dataSourceProxyMode) {
+                                           String[] excludeClasses, String dataSourceProxyMode) {
         setProxyTargetClass(!useJdkProxy);
         this.excludes = new HashSet<>(Arrays.asList(excludes));
         this.excludeNames = new HashSet<>(Arrays.asList(excludeNames));
@@ -71,7 +71,7 @@ public class SeataAutoDataSourceProxyCreator extends AbstractAutoProxyCreator {
 
     @Override
     protected boolean shouldSkip(Class<?> beanClass, String beanName) {
-        if (excludeClasses.contains(beanClass)) {
+        if (excludeClasses.contains(beanClass.getName())) {
             return true;
         }
         if (excludeNames.contains(beanName)) {

--- a/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyCreator.java
+++ b/spring/src/main/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyCreator.java
@@ -41,13 +41,20 @@ public class SeataAutoDataSourceProxyCreator extends AbstractAutoProxyCreator {
 
     private final Set<String> excludes;
 
+    private final Set<String> excludeNames;
+
+    private final Set<Class<?>> excludeClasses;
+
     private final String dataSourceProxyMode;
 
     private final Object[] advisors;
 
-    public SeataAutoDataSourceProxyCreator(boolean useJdkProxy, String[] excludes, String dataSourceProxyMode) {
+    public SeataAutoDataSourceProxyCreator(boolean useJdkProxy, String[] excludes, String[] excludeNames,
+                                           Class<?>[] excludeClasses, String dataSourceProxyMode) {
         setProxyTargetClass(!useJdkProxy);
         this.excludes = new HashSet<>(Arrays.asList(excludes));
+        this.excludeNames = new HashSet<>(Arrays.asList(excludeNames));
+        this.excludeClasses = new HashSet<>(Arrays.asList(excludeClasses));
         this.dataSourceProxyMode = dataSourceProxyMode;
         this.advisors = buildAdvisors(dataSourceProxyMode);
     }
@@ -64,6 +71,12 @@ public class SeataAutoDataSourceProxyCreator extends AbstractAutoProxyCreator {
 
     @Override
     protected boolean shouldSkip(Class<?> beanClass, String beanName) {
+        if (excludeClasses.contains(beanClass)) {
+            return true;
+        }
+        if (excludeNames.contains(beanName)) {
+            return true;
+        }
         if (excludes.contains(beanClass.getName())) {
             return true;
         }

--- a/spring/src/test/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyTest.java
+++ b/spring/src/test/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyTest.java
@@ -58,12 +58,15 @@ class SeataAutoDataSourceProxyTest {
     static void beforeAll() {
         boolean useJdkProxy = true;
         String[] excludes = new String[0];
+        String[] excludeNames = new String[0];
+        Class<?>[] excludeClasses = new Class[0];
         String dataSourceProxyMode = BranchType.AT.name();
 
         advice= spy(new SeataAutoDataSourceProxyAdvice(dataSourceProxyMode));
         Object[] advices = new Object[]{new DefaultIntroductionAdvisor(advice)};
 
-        creator = spy(new SeataAutoDataSourceProxyCreator(useJdkProxy, excludes, dataSourceProxyMode));
+        creator = spy(new SeataAutoDataSourceProxyCreator(useJdkProxy, excludes,excludeNames,excludeClasses,
+                dataSourceProxyMode));
         doReturn(advices).when(creator).getAdvicesAndAdvisorsForBean(any(), anyString(), any());
     }
 

--- a/spring/src/test/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyTest.java
+++ b/spring/src/test/java/io/seata/spring/annotation/datasource/SeataAutoDataSourceProxyTest.java
@@ -59,7 +59,7 @@ class SeataAutoDataSourceProxyTest {
         boolean useJdkProxy = true;
         String[] excludes = new String[0];
         String[] excludeNames = new String[0];
-        Class<?>[] excludeClasses = new Class[0];
+        String[] excludeClasses = new String[0];
         String dataSourceProxyMode = BranchType.AT.name();
 
         advice= spy(new SeataAutoDataSourceProxyAdvice(dataSourceProxyMode));


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
优化@EnableAutoDataSourceProxy(excludes="xxx") ，添加两个参数支持className和beanName两种排除方式,将excludes注解标记为Deprecated

### Ⅱ. Does this pull request fix one issue?
fixes #4287

### Ⅲ. Why don't you add test cases (unit test/integration test)?
无
### Ⅳ. Describe how to verify it
在用注解EnableAutoDataSourceProxy时添加excludeNames和excludeClasses测试即可。

### Ⅴ. Special notes for reviews