### PR TITLE
bugfix:Fix fetch PostgresqlTableMetaCache fail when the same table exists in different schemas

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -84,6 +84,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4233](https://github.com/seata/seata/pull/4233)] 修复 lock 和 branch 数据残留问题
   - [[#4276](https://github.com/seata/seata/pull/4276)] 修复 seata-test 单测不运行的问题
   - [[#4278](https://github.com/seata/seata/pull/4278)] 修复mysql的Blob/Clob/NClob数据类型无法反序列化的问题
+  - [[#4308](https://github.com/seata/seata/pull/4308)] 修复Postgresql多个schema下存在相同表的TableMetaCache解析问题
 
 
 ### optimize：

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -83,6 +83,7 @@
   - [[#4233](https://github.com/seata/seata/pull/4233)] fix data remanence problems in lock and branch under specific circumstances.
   - [[#4276](https://github.com/seata/seata/pull/4276)] fix seata-test module UT not work
   - [[#4278](https://github.com/seata/seata/pull/4278)] fix the problem that mysql's Blob/Clob/NClob data type cannot be deserialized
+  - [[#4308](https://github.com/seata/seata/pull/4308)] fix the TableMetaCache parsing problem with the same table under multiple Postgresql schemas
   
 
    ### optimize：

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
@@ -71,7 +71,6 @@ public class PostgresqlTableMetaCache extends AbstractTableMetaCache {
 
     private TableMeta resultSetMetaToSchema(Connection connection, String tableName) throws SQLException {
         DatabaseMetaData dbmd = connection.getMetaData();
-
         TableMeta tm = new TableMeta();
         tm.setTableName(tableName);
         String[] schemaTable = tableName.split("\\.");

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
@@ -61,8 +61,7 @@ public class PostgresqlTableMetaCache extends AbstractTableMetaCache {
     @Override
     protected TableMeta fetchSchema(Connection connection, String tableName) throws SQLException {
         try {
-            DatabaseMetaData dbmd = connection.getMetaData();
-            return resultSetMetaToSchema(dbmd, tableName);
+            return resultSetMetaToSchema(connection, tableName);
         } catch (SQLException sqlEx) {
             throw sqlEx;
         } catch (Exception e) {
@@ -70,7 +69,9 @@ public class PostgresqlTableMetaCache extends AbstractTableMetaCache {
         }
     }
 
-    private TableMeta resultSetMetaToSchema(DatabaseMetaData dbmd, String tableName) throws SQLException {
+    private TableMeta resultSetMetaToSchema(Connection connection, String tableName) throws SQLException {
+        DatabaseMetaData dbmd = connection.getMetaData();
+
         TableMeta tm = new TableMeta();
         tm.setTableName(tableName);
         String[] schemaTable = tableName.split("\\.");
@@ -99,7 +100,10 @@ public class PostgresqlTableMetaCache extends AbstractTableMetaCache {
             } else {
                 schemaName = schemaName.toLowerCase();
             }
+        } else {
+            schemaName = connection.getSchema();
         }
+
         if (tableName.startsWith("\"") && tableName.endsWith("\"")) {
             tableName = tableName.replaceAll("(^\")|(\"$)", "");
         } else {

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/mock/MockConnection.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/mock/MockConnection.java
@@ -63,4 +63,9 @@ public class MockConnection extends com.alibaba.druid.mock.MockConnection {
     public MockDriver getDriver() {
         return mockDriver;
     }
+
+    @Override
+    public String getSchema() {
+        return null;
+    }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
如果SQL表名没有写明schema，使用connection获取当前连接的schema，防止不同schema下存在相同表而导致错误识别多主键

If the SQL table name does not specify schema, use connection to obtain the schema of the current connection to prevent the existence of the same table under different schemas and cause misidentification of multiple primary keys

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3098

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

