### PR TITLE
feature: add config client undo data validation ignore column compare

### DIFF
--- a/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
+++ b/core/src/main/java/io/seata/core/constants/ConfigurationKeys.java
@@ -367,6 +367,10 @@ public interface ConfigurationKeys {
      */
     String TRANSACTION_UNDO_DATA_VALIDATION = CLIENT_UNDO_PREFIX + "dataValidation";
     /**
+     * The constant TRANSACTION_UNDO_DATA_VALIDATION_IGNORE_COLUMNS.
+     */
+    String TRANSACTION_UNDO_DATA_VALIDATION_IGNORE_COLUMNS =  CLIENT_UNDO_PREFIX + "dataValidationIgnoreColumns";
+    /**
      * The constant TRANSACTION_UNDO_LOG_SERIALIZATION.
      */
     String TRANSACTION_UNDO_LOG_SERIALIZATION = CLIENT_UNDO_PREFIX + "logSerialization";

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoExecutor.java
@@ -76,7 +76,11 @@ public abstract class AbstractUndoExecutor {
      */
     public static final boolean IS_UNDO_DATA_VALIDATION_ENABLE = ConfigurationFactory.getInstance()
             .getBoolean(ConfigurationKeys.TRANSACTION_UNDO_DATA_VALIDATION, DEFAULT_TRANSACTION_UNDO_DATA_VALIDATION);
-
+    /**
+     *  undo data validation ignore columns compare
+     */
+    public static final String DATA_VALIDATION_IGNORE_COLUMNS  = ConfigurationFactory.getInstance()
+            .getConfig(ConfigurationKeys.TRANSACTION_UNDO_DATA_VALIDATION_IGNORE_COLUMNS,"");
     /**
      * The Sql undo log.
      */
@@ -246,12 +250,12 @@ public abstract class AbstractUndoExecutor {
         // Validate if data is dirty.
         TableRecords currentRecords = queryCurrentRecords(conn);
         // compare with current data and after image.
-        Result<Boolean> afterEqualsCurrentResult = DataCompareUtils.isRecordsEquals(afterRecords, currentRecords);
+        Result<Boolean> afterEqualsCurrentResult = DataCompareUtils.isRecordsEquals(afterRecords, currentRecords,DATA_VALIDATION_IGNORE_COLUMNS);
         if (!afterEqualsCurrentResult.getResult()) {
 
             // If current data is not equivalent to the after data, then compare the current data with the before 
             // data, too. No need continue to undo if current data is equivalent to the before data snapshot
-            Result<Boolean> beforeEqualsCurrentResult = DataCompareUtils.isRecordsEquals(beforeRecords, currentRecords);
+            Result<Boolean> beforeEqualsCurrentResult = DataCompareUtils.isRecordsEquals(beforeRecords, currentRecords,DATA_VALIDATION_IGNORE_COLUMNS);
             if (beforeEqualsCurrentResult.getResult()) {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("Stop rollback because there is no data change " +

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/DataCompareUtilsTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/DataCompareUtilsTest.java
@@ -119,6 +119,76 @@ public class DataCompareUtilsTest {
         afterImage.setRows(new ArrayList<>());
         Assertions.assertTrue(DataCompareUtils.isRecordsEquals(beforeImage, afterImage).getResult());
     }
+    @Test
+    public void isRecordsEquals2() {
+        String ignoreColumn = "updated_time,inserted_time";
+        TableMeta tableMeta = Mockito.mock(TableMeta.class);
+        Mockito.when(tableMeta.getPrimaryKeyOnlyName()).thenReturn(Arrays.asList(new String[]{"pk"}));
+        Mockito.when(tableMeta.getTableName()).thenReturn("table_name");
+
+        TableRecords beforeImage = new TableRecords();
+        beforeImage.setTableName("table_name");
+        beforeImage.setTableMeta(tableMeta);
+
+        List<Row> rows = new ArrayList<>();
+        Row row = new Row();
+        Field field01 = addField(row,"pk", 1, "12345");
+        Field field02 = addField(row,"age", 1, "18");
+        Field field03 = addField(row,"updated_time", 1, "2022-01-18 14:26");
+        rows.add(row);
+        beforeImage.setRows(rows);
+
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, null,ignoreColumn).getResult());
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(null, beforeImage,ignoreColumn).getResult());
+
+        TableRecords afterImage = new TableRecords();
+        afterImage.setTableName("table_name1"); // wrong table name
+        afterImage.setTableMeta(tableMeta);
+
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+        afterImage.setTableName("table_name");
+
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+
+        List<Row> rows2 = new ArrayList<>();
+        Row row2 = new Row();
+        Field field11 = addField(row2,"pk", 1, "12345");
+        Field field12 = addField(row2,"age", 1, "18");
+        Field field13 = addField(row2,"updated_time", 1, "2022-01-18 14:26");
+        rows2.add(row2);
+        afterImage.setRows(rows2);
+        //set diff datetime ,return true
+        field13.setValue("2022-01-19 14:26");
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+
+        field11.setValue("23456");
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+        field11.setValue("12345");
+
+        field12.setName("sex");
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+        field12.setName("age");
+
+        field12.setValue("19");
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+        field12.setName("18");
+
+
+
+
+        Field field3 = new Field("pk", 1, "12346");
+        Row row3 = new Row();
+        row3.add(field3);
+        rows2.add(row3);
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+
+
+        beforeImage.setRows(new ArrayList<>());
+        afterImage.setRows(new ArrayList<>());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(beforeImage, afterImage,ignoreColumn).getResult());
+    }
     
     private Field addField(Row row, String name, int type, Object value){
         Field field = new Field(name, type, value);
@@ -158,6 +228,7 @@ public class DataCompareUtilsTest {
         rows2.add(row3);
         Assertions.assertFalse(DataCompareUtils.isRowsEquals(tableMeta, rows, rows2).getResult());
     }
+
 
     @Test
     public void testRowListToMapWithSinglePk(){

--- a/script/client/spring/application.properties
+++ b/script/client/spring/application.properties
@@ -43,6 +43,7 @@ seata.client.tm.degrade-check-allow-times=10
 seata.client.tm.degrade-check-period=2000
 seata.client.tm.interceptor-order=-2147482648 #Ordered.HIGHEST_PRECEDENCE + 1000
 seata.client.undo.data-validation=true
+seata.client.undo.data-validation-ignore-columns=updated_time,inserted_time
 seata.client.undo.log-serialization=jackson
 seata.client.undo.only-care-update-columns=true
 seata.client.undo.log-table=undo_log


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
add config client undo data validation ignore column compare
主要解决针对使用数据库触发器更新表的更新时间字段，导致全局事务锁超时的问题

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
unit test ok 

### Ⅴ. Special notes for reviews

