### PR TITLE
optimize: file mode does not require lazy processing of sessions

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -186,6 +186,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4353](https://github.com/seata/seata/pull/4353)] 为 `seata-all.jar` 瘦身
   - [[#4400](https://github.com/seata/seata/pull/4400)] 异步二阶段任务支持并行处理提升效率 
   - [[#4391](https://github.com/seata/seata/pull/4391)] commit/rollback 重试超时事件
+  - [[#4407](https://github.com/seata/seata/pull/4407)] file模式下无需延迟删除globasession
 
 
 ### test：

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -190,6 +190,8 @@
   - [[#4353](https://github.com/seata/seata/pull/4353)] Slimming down for the `seata-all.jar`
   - [[#4400](https://github.com/seata/seata/pull/4400)] asynchronous tasks handle global transactions in parallel
   - [[#4391](https://github.com/seata/seata/pull/4391)] commit/rollback retry timeout event
+  - [[#4407](https://github.com/seata/seata/pull/4407)] file mode does not require lazy processing of sessions
+
 
   ### test:	
 

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
@@ -22,11 +22,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -34,10 +34,10 @@ import io.netty.channel.Channel;
 import io.seata.common.thread.NamedThreadFactory;
 import io.seata.common.util.CollectionUtils;
 import io.seata.common.util.DurationUtil;
+import io.seata.common.util.StringUtils;
 import io.seata.config.ConfigurationFactory;
 import io.seata.core.constants.ConfigurationKeys;
 import io.seata.core.context.RootContext;
-import io.seata.core.event.EventBus;
 import io.seata.core.exception.TransactionException;
 import io.seata.core.model.GlobalStatus;
 import io.seata.core.protocol.AbstractMessage;
@@ -67,8 +67,8 @@ import io.seata.core.rpc.RpcContext;
 import io.seata.core.rpc.TransactionMessageHandler;
 import io.seata.core.rpc.netty.ChannelManager;
 import io.seata.core.rpc.netty.NettyRemotingServer;
+import io.seata.core.store.StoreMode;
 import io.seata.server.AbstractTCInboundHandler;
-import io.seata.server.event.EventBusManager;
 import io.seata.server.session.BranchSession;
 import io.seata.server.session.GlobalSession;
 import io.seata.server.session.SessionCondition;
@@ -165,9 +165,9 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
 
     private final DefaultCore core;
 
-    private final EventBus eventBus = EventBusManager.get();
-
     private static volatile DefaultCoordinator instance;
+
+    private final boolean delayHandleSession;
 
     /**
      * Instantiates a new Default coordinator.
@@ -175,6 +175,9 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
      * @param remotingServer the remoting server
      */
     private DefaultCoordinator(RemotingServer remotingServer) {
+        String mode = CONFIG.getConfig(ConfigurationKeys.STORE_MODE);
+        // file mode requires no delay in processing
+        this.delayHandleSession = !StringUtils.equalsIgnoreCase(mode, StoreMode.FILE.getName());
         if (remotingServer == null) {
             throw new IllegalArgumentException("RemotingServer not allowed be null.");
         }
@@ -422,8 +425,9 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
         SessionHelper.forEach(rollbackingSessions, rollbackingSession -> {
             try {
                 // prevent repeated rollback
-                if (rollbackingSession.getStatus().equals(GlobalStatus.Rollbacking) && !rollbackingSession.isDeadSession()) {
-                    //The function of this 'return' is 'continue'.
+                if (delayHandleSession && rollbackingSession.getStatus().equals(GlobalStatus.Rollbacking)
+                    && !rollbackingSession.isDeadSession()) {
+                    // The function of this 'return' is 'continue'.
                     return;
                 }
                 if (isRetryTimeout(now, MAX_ROLLBACK_RETRY_TIMEOUT.toMillis(), rollbackingSession.getBeginTime())) {
@@ -461,8 +465,9 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
         SessionHelper.forEach(committingSessions, committingSession -> {
             try {
                 // prevent repeated commit
-                if (committingSession.getStatus().equals(GlobalStatus.Committing) && !committingSession.isDeadSession()) {
-                    //The function of this 'return' is 'continue'.
+                if (delayHandleSession && committingSession.getStatus().equals(GlobalStatus.Committing)
+                    && !committingSession.isDeadSession()) {
+                    // The function of this 'return' is 'continue'.
                     return;
                 }
                 if (isRetryTimeout(now, MAX_COMMIT_RETRY_TIMEOUT.toMillis(), committingSession.getBeginTime())) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
目前的实现中,在同步二阶段时不会进行删除全局事务为了避免db和redis下残留branchsession和lock所以进行了默认2分10秒延迟删除,但是file下globalsession是有锁的,不会出现这种残留情况,也就无需延迟,仅需异步删除即可,file的内存是寸土寸金应尽快删除,所以需要通过storemode判断处理

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #4399 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

