### PR TITLE
optimize: global session query in file mode

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -191,6 +191,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4409](https://github.com/seata/seata/pull/4409)] 测试类添加版权标题
   - [[#4282](https://github.com/seata/seata/pull/4282)] 优化回滚镜像构建逻辑
   - [[#4407](https://github.com/seata/seata/pull/4407)] file模式下无需延迟删除globasession
+  - [[#4436](https://github.com/seata/seata/pull/4436)] 优化file模式下的global session查询接口
 
 
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -196,7 +196,7 @@
   - [[#4409](https://github.com/seata/seata/pull/4409)] add copyright header to test classes
   - [[#4282](https://github.com/seata/seata/pull/4282)] optimize build UndoItem logic
   - [[#4407](https://github.com/seata/seata/pull/4407)] file mode does not require lazy processing of sessions
-
+  - [[#4436](https://github.com/seata/seata/pull/4436)] optimize global session query in file mode
   
   ### test:	
 

--- a/server/src/main/java/io/seata/server/console/impl/file/GlobalSessionFileServiceImpl.java
+++ b/server/src/main/java/io/seata/server/console/impl/file/GlobalSessionFileServiceImpl.java
@@ -28,12 +28,9 @@ import io.seata.server.console.service.GlobalSessionService;
 import io.seata.server.session.GlobalSession;
 import io.seata.server.session.SessionHolder;
 import io.seata.server.storage.SessionConverter;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
-import static io.seata.common.util.CollectionUtils.isEmpty;
-import static io.seata.common.util.CollectionUtils.isNotEmpty;
 import static io.seata.common.util.StringUtils.isBlank;
 import static java.util.Objects.isNull;
 
@@ -90,10 +87,6 @@ public class GlobalSessionFileServiceImpl implements GlobalSessionService {
                 &&
                 // transactionName
                 (isBlank(param.getTransactionName()) || session.getTransactionName().contains(param.getTransactionName()))
-
-                &&
-                // withBranch
-                (param.isWithBranch() ? isNotEmpty(session.getBranchSessions()) : isEmpty(session.getBranchSessions()))
 
                 &&
                 // timeStart

--- a/server/src/test/java/io/seata/server/session/FileSessionManagerTest.java
+++ b/server/src/test/java/io/seata/server/session/FileSessionManagerTest.java
@@ -279,9 +279,9 @@ public class FileSessionManagerTest {
             globalSessionParam.setPageNum(1);
             final PageResult<GlobalSessionVO> sizeAndNumTestResult = globalSessionService.query(globalSessionParam);
             Assertions.assertEquals(1, sizeAndNumTestResult.getCurrPage());
-            Assertions.assertEquals(2, sizeAndNumTestResult.getPages());
+            Assertions.assertEquals(3, sizeAndNumTestResult.getPages());
             Assertions.assertEquals(1, sizeAndNumTestResult.getData().size());
-            Assertions.assertEquals(2, sizeAndNumTestResult.getTotal());
+            Assertions.assertEquals(3, sizeAndNumTestResult.getTotal());
 
             // xid
             final GlobalSession firstGlobalSession = globalSessions.get(0);
@@ -323,8 +323,8 @@ public class FileSessionManagerTest {
             // with branch
             globalSessionParam.setStatus(null);
             final PageResult<GlobalSessionVO> withBranchTestResult = globalSessionService.query(globalSessionParam);
-            Assertions.assertEquals(1, withBranchTestResult.getData().size());
-            Assertions.assertEquals(1, withBranchTestResult.getData().size());
+            Assertions.assertEquals(3, withBranchTestResult.getData().size());
+            Assertions.assertEquals(3, withBranchTestResult.getData().size());
 
             // timeStart and timeEnd
             final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -334,15 +334,15 @@ public class FileSessionManagerTest {
             Assertions.assertEquals(0, globalSessionService.query(globalSessionParam).getData().size());
 
             globalSessionParam.setTimeStart(DateUtils.addHours(new Date(), -1));
-            Assertions.assertEquals(2, globalSessionService.query(globalSessionParam).getData().size());
+            Assertions.assertEquals(3, globalSessionService.query(globalSessionParam).getData().size());
 
 
             globalSessionParam.setTimeStart(null);
             globalSessionParam.setTimeEnd(DateUtils.addHours(new Date(), 1));
-            Assertions.assertEquals(2, globalSessionService.query(globalSessionParam).getData().size());
+            Assertions.assertEquals(3, globalSessionService.query(globalSessionParam).getData().size());
 
             globalSessionParam.setTimeStart(DateUtils.addHours(new Date(), -1));
-            Assertions.assertEquals(2, globalSessionService.query(globalSessionParam).getData().size());
+            Assertions.assertEquals(3, globalSessionService.query(globalSessionParam).getData().size());
         } finally {
             for (GlobalSession globalSession : globalSessions) {
                 globalSession.end();


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
file模式下的global session查询接口，当未选中“包含分支事务”时，会导致global session也无法查询。
由于file模式的分支事务信息本身就在内存中，故在file模式下忽略此条件。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

