### PR TITLE
bugfix: fix GlobalSession cannot be cleared normally when delayed deletion is enabled

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -97,7 +97,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4310](https://github.com/seata/seata/pull/4310)] 修复通过"SELECT LAST_INSERT_ID"获取mysql数据库自增id失败的问题
   - [[#4331](https://github.com/seata/seata/pull/4331)] 修复使用ONLY_CARE_UPDATE_COLUMNS配置可能出现的脏写校验异常
   - [[#4408](https://github.com/seata/seata/pull/4408)] 修复容器环境中设置环境变量无效的问题
-  - [[#4438](https://github.com/seata/seata/pull/4438)] 修复GlobalSession在延迟删除的情况下无法被正常删除的问题
+  - [[#4438](https://github.com/seata/seata/pull/4438)] 修复develop版本file模式下GlobalSession在延迟删除的情况下无法被正常删除的问题
 
 
 

--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -97,6 +97,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4310](https://github.com/seata/seata/pull/4310)] 修复通过"SELECT LAST_INSERT_ID"获取mysql数据库自增id失败的问题
   - [[#4331](https://github.com/seata/seata/pull/4331)] 修复使用ONLY_CARE_UPDATE_COLUMNS配置可能出现的脏写校验异常
   - [[#4408](https://github.com/seata/seata/pull/4408)] 修复容器环境中设置环境变量无效的问题
+  - [[#4438](https://github.com/seata/seata/pull/4438)] 修复GlobalSession在延迟删除的情况下无法被正常删除的问题
 
 
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -100,6 +100,7 @@
   - [[#4310](https://github.com/seata/seata/pull/4310)] fix the problem that failed to obtain the self increment ID of MySQL database through "select last_insert_id"
   - [[#4331](https://github.com/seata/seata/pull/4331)] fix dirty write check exception that may occur when using ONLY_CARE_UPDATE_COLUMNS configuration
   - [[#4408](https://github.com/seata/seata/pull/4408)] fix the invalid environment variable in container env
+  - [[#4438](https://github.com/seata/seata/pull/4438)] fix the problem that GlobalSession could not be deleted normally in the case of delayed deletion
   
 
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -100,7 +100,7 @@
   - [[#4310](https://github.com/seata/seata/pull/4310)] fix the problem that failed to obtain the self increment ID of MySQL database through "select last_insert_id"
   - [[#4331](https://github.com/seata/seata/pull/4331)] fix dirty write check exception that may occur when using ONLY_CARE_UPDATE_COLUMNS configuration
   - [[#4408](https://github.com/seata/seata/pull/4408)] fix the invalid environment variable in container env
-  - [[#4438](https://github.com/seata/seata/pull/4438)] fix the problem that GlobalSession could not be deleted normally in the case of delayed deletion
+  - [[#4438](https://github.com/seata/seata/pull/4438)] fix the problem that GlobalSession could not be deleted normally in the case of delayed deletion in the file mode of the develop branch
   
 
 

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCore.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCore.java
@@ -282,8 +282,8 @@ public class DefaultCore implements Core {
             return globalSession.getStatus();
         }
 
-        doGlobalRollback(globalSession, false);
-        return globalSession.getStatus();
+        boolean rollbackSuccess = doGlobalRollback(globalSession, false);
+        return rollbackSuccess ? GlobalStatus.Rollbacked : globalSession.getStatus();
     }
 
     @Override
@@ -332,9 +332,6 @@ public class DefaultCore implements Core {
             // Return if the result is not null
             if (result != null) {
                 return result;
-            }
-            if (!retrying) {
-                globalSession.setStatus(GlobalStatus.Rollbacked);
             }
         }
         // In db mode, lock and branch data residual problems may occur.

--- a/server/src/test/java/io/seata/server/coordinator/DefaultCoreTest.java
+++ b/server/src/test/java/io/seata/server/coordinator/DefaultCoreTest.java
@@ -262,7 +262,7 @@ public class DefaultCoreTest {
         core.mockCore(BranchType.AT,
                 new MockCore(BranchStatus.PhaseTwo_Committed, BranchStatus.PhaseTwo_Rollbacked));
         core.doGlobalRollback(globalSession, false);
-        Assertions.assertEquals(globalSession.getStatus(), GlobalStatus.Rollbacked);
+        Assertions.assertEquals(globalSession.getStatus(), GlobalStatus.Begin);
     }
 
     /**

--- a/server/src/test/java/io/seata/server/event/DefaultCoreForEventBusTest.java
+++ b/server/src/test/java/io/seata/server/event/DefaultCoreForEventBusTest.java
@@ -121,14 +121,15 @@ public class DefaultCoreForEventBusTest {
             subscriber.setDownLatch(new CountDownLatch(3));
             xid = core.begin("test_app_id", "default_group", "test_tran_name2", 30000);
             core.rollback(xid);
-
+            //sleep for retryRollback
+            Thread.sleep(1500);
             //check
             subscriber.getDownLatch().await(1500, TimeUnit.MILLISECONDS);
             Assertions.assertEquals(2, subscriber.getEventCounters().get(GlobalStatus.Begin).get());
             //Because of the delayed deletion of GlobalSession, and without changing the status of the Session,
             //the 'doGlobalRollback' method will actually be triggered twice.
             Assertions.assertEquals(2, subscriber.getEventCounters().get(GlobalStatus.Rollbacking).get());
-            Assertions.assertNull(subscriber.getEventCounters().get(GlobalStatus.Rollbacked));
+            Assertions.assertNotNull(subscriber.getEventCounters().get(GlobalStatus.Rollbacked));
 
             //start more one new transaction for test timeout and let this transaction immediately timeout
             subscriber.setDownLatch(new CountDownLatch(1));

--- a/server/src/test/java/io/seata/server/event/DefaultCoreForEventBusTest.java
+++ b/server/src/test/java/io/seata/server/event/DefaultCoreForEventBusTest.java
@@ -123,9 +123,11 @@ public class DefaultCoreForEventBusTest {
             core.rollback(xid);
 
             //check
-            subscriber.getDownLatch().await(1000, TimeUnit.MILLISECONDS);
+            subscriber.getDownLatch().await(1500, TimeUnit.MILLISECONDS);
             Assertions.assertEquals(2, subscriber.getEventCounters().get(GlobalStatus.Begin).get());
-            Assertions.assertEquals(1, subscriber.getEventCounters().get(GlobalStatus.Rollbacking).get());
+            //Because of the delayed deletion of GlobalSession, and without changing the status of the Session,
+            //the 'doGlobalRollback' method will actually be triggered twice.
+            Assertions.assertEquals(2, subscriber.getEventCounters().get(GlobalStatus.Rollbacking).get());
             Assertions.assertNull(subscriber.getEventCounters().get(GlobalStatus.Rollbacked));
 
             //start more one new transaction for test timeout and let this transaction immediately timeout


### PR DESCRIPTION
…alSession

<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
GlobalSession在延迟删除的情况下，由于提前设置了Rollbacked状态导致定时任务无法即时处理。目前放弃提前设置状态，改为由DefaultCore#doGlobalRollback的执行结果来确认是否返回Rollbacked状态

In the case of delayed deletion of GlobalSession, the scheduled task cannot be processed immediately because the Rollbacked state is set in advance. At present, the advance setting state is abandoned, and the execution result of DefaultCore#doGlobalRollback is used to confirm whether to return the Rollbacked state.
### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

