### PR TITLE
optimize: optimize nacos config and naming properties 

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -203,6 +203,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4436](https://github.com/seata/seata/pull/4436)] 优化file模式下的global session查询接口
   - [[#4431](https://github.com/seata/seata/pull/4431)] 优化redis模式查询globalSession限制查询条数
   - [[#4465](https://github.com/seata/seata/pull/4465)] 优化TC 批量响应客户端模式客户端版本传输方式
+  - [[#4478](https://github.com/seata/seata/pull/4478)] 优化 Nacos 配置和注册元数据属性
 
 
 ### test：

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -207,6 +207,7 @@
   - [[#4436](https://github.com/seata/seata/pull/4436)] optimize global session query in file mode
   - [[#4431](https://github.com/seata/seata/pull/4431)] limit the number of queries in Redis storage mode
   - [[#4465](https://github.com/seata/seata/pull/4465)] optimize client version transfer in tc batch response to client mode.
+  - [[#4478](https://github.com/seata/seata/pull/4478)] optimize Nacos config and naming properties
   
   ### test:	
 

--- a/common/src/main/java/io/seata/common/ConfigurationKeys.java
+++ b/common/src/main/java/io/seata/common/ConfigurationKeys.java
@@ -46,7 +46,6 @@ public interface ConfigurationKeys {
      */
     String DATA_TYPE = "dataType";
 
-
     /**
      * The constant SEATA_PREFIX.
      */
@@ -808,4 +807,14 @@ public interface ConfigurationKeys {
      * The constant ENABLE_BRANCH_ASYNC_REMOVE
      */
     String ENABLE_BRANCH_ASYNC_REMOVE = SERVER_PREFIX + SESSION_PREFIX + "enableBranchAsyncRemove";
+
+    /**
+     * The constant IS_USE_CLOUD_NAMESPACE_PARSING.
+     */
+    String IS_USE_CLOUD_NAMESPACE_PARSING = "nacos.use.cloud.namespace.parsing";
+
+    /**
+     * The constant IS_USE_ENDPOINT_PARSING_RULE.
+     */
+    String IS_USE_ENDPOINT_PARSING_RULE = "nacos.use.endpoint.parsing.rule";
 }

--- a/config/seata-config-nacos/src/main/java/io/seata/config/nacos/NacosConfiguration.java
+++ b/config/seata-config-nacos/src/main/java/io/seata/config/nacos/NacosConfiguration.java
@@ -203,9 +203,9 @@ public class NacosConfiguration extends AbstractConfiguration {
 
     private static Properties getConfigProperties() {
         Properties properties = new Properties();
-        if (System.getProperty(ENDPOINT_KEY) != null) {
-            properties.setProperty(ENDPOINT_KEY, System.getProperty(ENDPOINT_KEY));
-        } else if (System.getProperty(PRO_SERVER_ADDR_KEY) != null) {
+        System.setProperty(ConfigurationKeys.IS_USE_CLOUD_NAMESPACE_PARSING, "false");
+        System.setProperty(ConfigurationKeys.IS_USE_ENDPOINT_PARSING_RULE, "false");
+        if (System.getProperty(PRO_SERVER_ADDR_KEY) != null) {
             properties.setProperty(PRO_SERVER_ADDR_KEY, System.getProperty(PRO_SERVER_ADDR_KEY));
         } else {
             String address = FILE_CONFIG.getConfig(getNacosAddrFileKey());

--- a/discovery/seata-discovery-nacos/src/main/java/io/seata/discovery/registry/nacos/NacosRegistryServiceImpl.java
+++ b/discovery/seata-discovery-nacos/src/main/java/io/seata/discovery/registry/nacos/NacosRegistryServiceImpl.java
@@ -144,9 +144,9 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
                     }
                     subscribe(clusterName, event -> {
                         List<Instance> instances = ((NamingEvent) event).getInstances();
-                        if (null == instances && null != CLUSTER_ADDRESS_MAP.get(clusterName)) {
-                            CLUSTER_ADDRESS_MAP.remove(clusterName);
-                        } else if (!CollectionUtils.isEmpty(instances)) {
+                        if (CollectionUtils.isEmpty(instances) && null != CLUSTER_ADDRESS_MAP.get(clusterName)) {
+                            LOGGER.info("receive empty server list,cluster:{}",clusterName);
+                        } else {
                             List<InetSocketAddress> newAddressList = instances.stream()
                                     .filter(eachInstance -> eachInstance.isEnabled() && eachInstance.isHealthy())
                                     .map(eachInstance -> new InetSocketAddress(eachInstance.getIp(), eachInstance.getPort()))
@@ -184,9 +184,9 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
 
     private static Properties getNamingProperties() {
         Properties properties = new Properties();
-        if (System.getProperty(ENDPOINT_KEY) != null) {
-            properties.setProperty(ENDPOINT_KEY, System.getProperty(ENDPOINT_KEY));
-        } else if (System.getProperty(PRO_SERVER_ADDR_KEY) != null) {
+        System.setProperty(ConfigurationKeys.IS_USE_CLOUD_NAMESPACE_PARSING, "false");
+        System.setProperty(ConfigurationKeys.IS_USE_ENDPOINT_PARSING_RULE, "false");
+        if (System.getProperty(PRO_SERVER_ADDR_KEY) != null) {
             properties.setProperty(PRO_SERVER_ADDR_KEY, System.getProperty(PRO_SERVER_ADDR_KEY));
         } else {
             String address = FILE_CONFIG.getConfig(getNacosAddrFileKey());


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did

optimize: optimize nacos config and naming properties 
- The problem that Seata cannot use the real registry when the registry of RPC or Rest services is not the same as Seata's and the service's registry uses the -D（-D tenant.id）startup parameter to specify the highest priority access for Nacos metadata.



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

