### PR TITLE
Feature: when use tcc fence, add a config to enable empty rollback

### DIFF
--- a/common/src/main/java/io/seata/common/Constants.java
+++ b/common/src/main/java/io/seata/common/Constants.java
@@ -166,4 +166,9 @@ public interface Constants {
      */
     String SKIP_CHECK_LOCK = "skipCheckLock";
 
+    /**
+     * the constant ENABLE_EMPTY_ROLLBACK;
+     */
+    String ENABLE_EMPTY_ROLLBACK = "enableEmptyRollback";
+
 }

--- a/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
@@ -167,7 +167,7 @@ public class TCCFenceHandler {
      * @param branchId              the branch transaction id
      * @param args                  rollback method's parameters
      * @param actionName            the action name
-     * @param enableEmptyRollback
+     * @param enableEmptyRollback   if enable empty rollback
      * @return the boolean
      */
     public static boolean rollbackFence(Method rollbackMethod, Object targetTCCBean,

--- a/tcc/src/main/java/io/seata/rm/tcc/TCCResourceManager.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/TCCResourceManager.java
@@ -161,8 +161,10 @@ public class TCCResourceManager extends AbstractResourceManager {
             // add idempotent and anti hanging
             if (Boolean.TRUE.equals(businessActionContext.getActionContext(Constants.USE_TCC_FENCE))) {
                 try {
+                    boolean enableEmptyRollback = Boolean.TRUE.equals(
+                            businessActionContext.getActionContext(Constants.ENABLE_EMPTY_ROLLBACK));
                     result = TCCFenceHandler.rollbackFence(rollbackMethod, targetTCCBean, xid, branchId,
-                            args, tccResource.getActionName());
+                            args, tccResource.getActionName(), enableEmptyRollback);
                 } catch (SkipCallbackWrapperException | UndeclaredThrowableException e) {
                     throw e.getCause();
                 }

--- a/tcc/src/main/java/io/seata/rm/tcc/api/TwoPhaseBusinessAction.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/api/TwoPhaseBusinessAction.java
@@ -75,6 +75,13 @@ public @interface TwoPhaseBusinessAction {
     boolean useTCCFence() default false;
 
     /**
+     * whether use TCC fence and enableEmptyRollback is true.
+     * seata will not intercept empty rollback
+     * @return the boolean
+     */
+    boolean enableEmptyRollback() default false;
+
+    /**
      * commit method's args
      *
      * @return the Class[]

--- a/tcc/src/main/java/io/seata/rm/tcc/interceptor/ActionInterceptorHandler.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/interceptor/ActionInterceptorHandler.java
@@ -237,6 +237,7 @@ public class ActionInterceptorHandler {
             context.put(Constants.ROLLBACK_METHOD, businessAction.rollbackMethod());
             context.put(Constants.ACTION_NAME, businessAction.name());
             context.put(Constants.USE_TCC_FENCE, businessAction.useTCCFence());
+            context.put(Constants.ENABLE_EMPTY_ROLLBACK, businessAction.enableEmptyRollback());
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
在TCC注解中添加一个配置去开关空回滚的拦截能力, 具体场景可在 #4530  中了解。该PR希望大佬们可以一起交流讨论，提供一些建议

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #4530 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

