### PR TITLE
optimize: use HmacSHA256 instead of HmacSHA1 for ram signature

### DIFF
--- a/changes/1.5.0.md
+++ b/changes/1.5.0.md
@@ -219,6 +219,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#4451](https://github.com/seata/seata/pull/4451)] filesessionmanager改为单例并优化任务线程池处理
   - [[#4551](https://github.com/seata/seata/pull/4551)] 优化 metrics rt 统计问题
   - [[#4574](https://github.com/seata/seata/pull/4574)] 支持 accessKey/secretKey 配置自动注入
+  - [[#4583](https://github.com/seata/seata/pull/4583)] DefaultAuthSigner的默认签名加密方法替换为HmacSHA256
 
 ### test：
 

--- a/changes/en-us/1.5.0.md
+++ b/changes/en-us/1.5.0.md
@@ -223,6 +223,7 @@
   - [[#4451](https://github.com/seata/seata/pull/4451)] filesessionmanager changed to singleton and optimized task thread pool processing
   - [[#4551](https://github.com/seata/seata/pull/4551)] optimize metrics rt statistics
   - [[#4574](https://github.com/seata/seata/pull/4574)] support accessKey/secretKey auto configuration
+  - [[#4583](https://github.com/seata/seata/pull/4583)] use HmacSHA256 instead of HmacSHA1 for ram signature
 
 
 

--- a/core/src/main/java/io/seata/core/auth/AuthSigner.java
+++ b/core/src/main/java/io/seata/core/auth/AuthSigner.java
@@ -19,5 +19,11 @@ package io.seata.core.auth;
  * @author slievrly
  */
 public interface AuthSigner {
+    
     String sign(String data, String key);
+    
+    default String getSignVersion() {
+        return null;
+    }
+    
 }

--- a/core/src/main/java/io/seata/core/auth/DefaultAuthSigner.java
+++ b/core/src/main/java/io/seata/core/auth/DefaultAuthSigner.java
@@ -23,6 +23,7 @@ import io.seata.common.util.StringUtils;
  */
 @LoadLevel(name = "defaultAuthSigner", order = 100)
 public class DefaultAuthSigner implements AuthSigner {
+    
     @Override
     public String sign(String data, String key) {
         if (StringUtils.isNotBlank(key) && StringUtils.isNotBlank(data)) {
@@ -30,4 +31,10 @@ public class DefaultAuthSigner implements AuthSigner {
         }
         return data;
     }
+    
+    @Override
+    public String getSignVersion() {
+        return "V4";
+    }
+    
 }

--- a/core/src/main/java/io/seata/core/auth/RamSignAdapter.java
+++ b/core/src/main/java/io/seata/core/auth/RamSignAdapter.java
@@ -104,7 +104,6 @@ public class RamSignAdapter {
             Mac mac = Mac.getInstance(signMethod);
             mac.init(new SecretKeySpec(regionSignkey, signMethod));
             byte[] thirdSigningKey = mac.doFinal(productCode.getBytes(StandardCharsets.UTF_8));
-            // 计算最终派生秘钥
             mac = Mac.getInstance(signMethod);
             mac.init(new SecretKeySpec(thirdSigningKey, signMethod));
             return mac.doFinal(CONSTANT.getBytes(StandardCharsets.UTF_8));

--- a/core/src/main/java/io/seata/core/auth/RamSignAdapter.java
+++ b/core/src/main/java/io/seata/core/auth/RamSignAdapter.java
@@ -21,6 +21,11 @@ import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 /**
  * adapt ram sign interface
@@ -29,11 +34,89 @@ import java.nio.charset.StandardCharsets;
  */
 public class RamSignAdapter {
     
-    public static final String SHA_ENCRYPT = "HmacSHA1";
+    private static final String SHA256_ENCRYPT = "HmacSHA256";
+    
+    private static final String PREFIX = "aliyun_v4";
+    
+    private static final String CONSTANT = "aliyun_v4_request";
+    
+    private static final String DEFAULT_REGION = "cn-beijing";
+    
+    private static final String DEFAULT_PRODCUT_CODE = "seata";
+    
+    private static final DateTimeFormatter DTF = DateTimeFormatter.ofPattern("yyyyMMdd");
     
     /**
-     * get ram sign
-     * Sign with hmac SHA1 encrtpt
+     * get date level signing key
+     *
+     * @param secret     secret
+     * @param date       data, yyyyMMdd
+     * @param signMethod HmacSHA256
+     * @return date level signing key
+     */
+    private static byte[] getDateSigningKey(String secret, String date, String signMethod) {
+        try {
+            Mac mac = Mac.getInstance(signMethod);
+            mac.init(new SecretKeySpec((PREFIX + secret).getBytes(StandardCharsets.UTF_8), signMethod));
+            return mac.doFinal(date.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("unsupport Algorithm:" + signMethod);
+        } catch (InvalidKeyException e) {
+            throw new RuntimeException("InvalidKey");
+        }
+    }
+    
+    /**
+     * get date&region level signing key
+     *
+     * @param secret     secret
+     * @param date       data
+     * @param region     region
+     * @param signMethod HmacSHA256
+     * @return date&region level signing key
+     */
+    private static byte[] getRegionSigningKey(String secret, String date, String region, String signMethod) {
+        byte[] dateSignkey = getDateSigningKey(secret, date, signMethod);
+        try {
+            Mac mac = Mac.getInstance(signMethod);
+            mac.init(new SecretKeySpec(dateSignkey, signMethod));
+            return mac.doFinal(region.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("unsupport Algorithm:" + signMethod);
+        } catch (InvalidKeyException e) {
+            throw new RuntimeException("InvalidKey");
+        }
+    }
+    
+    /**
+     * get date&region&product level signing key
+     *
+     * @param secret      secret
+     * @param date        date
+     * @param region      region
+     * @param productCode productCode
+     * @param signMethod  signMethod
+     * @return date&region&product level signing key
+     */
+    private static byte[] getProductSigningKey(String secret, String date, String region, String productCode, String signMethod) {
+        byte[] regionSignkey = getRegionSigningKey(secret, date, region, signMethod);
+        try {
+            Mac mac = Mac.getInstance(signMethod);
+            mac.init(new SecretKeySpec(regionSignkey, signMethod));
+            byte[] thirdSigningKey = mac.doFinal(productCode.getBytes(StandardCharsets.UTF_8));
+            // 计算最终派生秘钥
+            mac = Mac.getInstance(signMethod);
+            mac.init(new SecretKeySpec(thirdSigningKey, signMethod));
+            return mac.doFinal(CONSTANT.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("unsupport Algorithm:" + signMethod);
+        } catch (InvalidKeyException e) {
+            throw new RuntimeException("InvalidKey");
+        }
+    }
+    
+    /**
+     * get ram sign Sign with hmac SHA1 encrtpt
      *
      * @param encryptText encrypt text
      * @param encryptKey  encrypt key
@@ -41,11 +124,14 @@ public class RamSignAdapter {
      */
     public static String getRamSign(String encryptText, String encryptKey) {
         try {
-            byte[] data = encryptKey.getBytes(StandardCharsets.UTF_8);
+            String[] encryptData = encryptText.split(",");
+            byte[] data = getProductSigningKey(encryptKey,
+                    LocalDateTime.ofEpochSecond(Long.parseLong(encryptData[2]) / 1000, 0, ZoneOffset.UTC).format(DTF),
+                    DEFAULT_REGION, DEFAULT_PRODCUT_CODE, SHA256_ENCRYPT);
             // Construct a key according to the given byte array, and the second parameter specifies the name of a key algorithm
-            SecretKey secretKey = new SecretKeySpec(data, SHA_ENCRYPT);
+            SecretKey secretKey = new SecretKeySpec(data, SHA256_ENCRYPT);
             // Generate a Mac object specifying Mac algorithm
-            Mac mac = Mac.getInstance(SHA_ENCRYPT);
+            Mac mac = Mac.getInstance(SHA256_ENCRYPT);
             // Initialize the Mac object with the given key
             mac.init(secretKey);
             byte[] text = encryptText.getBytes(StandardCharsets.UTF_8);

--- a/core/src/main/java/io/seata/core/protocol/RegisterTMRequest.java
+++ b/core/src/main/java/io/seata/core/protocol/RegisterTMRequest.java
@@ -34,6 +34,7 @@ public class RegisterTMRequest extends AbstractIdentifyRequest implements Serial
     public static final String UDATA_DIGEST = "digest";
     public static final String UDATA_IP = "ip";
     public static final String UDATA_TIMESTAMP = "timestamp";
+    public static final String UDATA_AUTH_VERSION = "authVersion";
 
     /**
      * Instantiates a new Register tm request.

--- a/core/src/main/java/io/seata/core/rpc/netty/TmNettyRemotingClient.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/TmNettyRemotingClient.java
@@ -267,6 +267,7 @@ public final class TmNettyRemotingClient extends AbstractNettyRemotingClient {
         sb.append(RegisterTMRequest.UDATA_AK).append(EXTRA_DATA_KV_CHAR).append(accessKey).append(EXTRA_DATA_SPLIT_CHAR);
         sb.append(RegisterTMRequest.UDATA_DIGEST).append(EXTRA_DATA_KV_CHAR).append(digest).append(EXTRA_DATA_SPLIT_CHAR);
         sb.append(RegisterTMRequest.UDATA_TIMESTAMP).append(EXTRA_DATA_KV_CHAR).append(timestamp).append(EXTRA_DATA_SPLIT_CHAR);
+        sb.append(RegisterTMRequest.UDATA_AUTH_VERSION).append(EXTRA_DATA_KV_CHAR).append(signer.getSignVersion()).append(EXTRA_DATA_SPLIT_CHAR);
         return sb.toString();
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
use HmacSHA256 instead of HmacSHA1 for ram signature

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

