### PR TITLE
feature : skip list for undo data validation

### DIFF
--- a/common/src/main/java/io/seata/common/ConfigurationKeys.java
+++ b/common/src/main/java/io/seata/common/ConfigurationKeys.java
@@ -393,6 +393,11 @@ public interface ConfigurationKeys {
     String TRANSACTION_UNDO_DATA_VALIDATION = CLIENT_UNDO_PREFIX + "dataValidation";
 
     /**
+     * The constant TRANSACTION_UNDO_DATA_VALIDATION_SKIP.
+     */
+    String TRANSACTION_UNDO_DATA_VALIDATION_SKIP = TRANSACTION_UNDO_DATA_VALIDATION + ".skip";
+
+    /**
      * The constant TRANSACTION_UNDO_LOG_SERIALIZATION.
      */
     String TRANSACTION_UNDO_LOG_SERIALIZATION = CLIENT_UNDO_PREFIX + "logSerialization";

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/DataCompareUtils.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/DataCompareUtils.java
@@ -31,11 +31,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.HashMap;
-import java.util.Comparator;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -139,11 +135,24 @@ public class DataCompareUtils {
      * @return the result
      */
     public static Result<Boolean> isRecordsEquals(TableRecords beforeImage, TableRecords afterImage) {
+        return isRecordsEquals(new ArrayList<>(), beforeImage, afterImage);
+    }
+
+    /**
+     * Is records equals result.
+     *
+     * @param beforeImage the before image
+     * @param afterImage  the after image
+     * @return the result
+     */
+    public static Result<Boolean> isRecordsEquals(List<String> skipLowerList, TableRecords beforeImage,TableRecords afterImage) {
         if (beforeImage == null) {
-            return Result.build(afterImage == null, null);
+            return Result.build(afterImage == null || skip(skipLowerList, afterImage), null);
+        } else if (afterImage == null) {
+            return Result.build(skip(skipLowerList, beforeImage), null);
         } else {
-            if (afterImage == null) {
-                return Result.build(false, null);
+            if (skip(skipLowerList, beforeImage) || skip(skipLowerList, afterImage)) {
+                return Result.ok();
             }
             if (beforeImage.getTableName().equalsIgnoreCase(afterImage.getTableName())
                     && CollectionUtils.isSizeEquals(beforeImage.getRows(), afterImage.getRows())) {
@@ -155,6 +164,14 @@ public class DataCompareUtils {
             } else {
                 return Result.build(false, null);
             }
+        }
+    }
+
+    private static boolean skip(List<String> skipList, TableRecords image) {
+        if (CollectionUtils.isEmpty(skipList)) {
+            return false;
+        } else {
+            return skipList.contains(image.getTableName().toLowerCase());
         }
     }
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/AbstractUndoExecutor.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.alibaba.fastjson.JSON;
+import com.google.common.collect.Lists;
 import io.seata.common.util.BlobUtils;
 import io.seata.common.util.IOUtil;
 import io.seata.common.util.StringUtils;
@@ -76,6 +77,12 @@ public abstract class AbstractUndoExecutor {
      */
     public static final boolean IS_UNDO_DATA_VALIDATION_ENABLE = ConfigurationFactory.getInstance()
             .getBoolean(ConfigurationKeys.TRANSACTION_UNDO_DATA_VALIDATION, DEFAULT_TRANSACTION_UNDO_DATA_VALIDATION);
+
+    /**
+     *  skip list of undo data validation
+     */
+    public static final String UNDO_DATA_VALIDATION_SKIP = ConfigurationFactory.getInstance()
+            .getConfig(ConfigurationKeys.TRANSACTION_UNDO_DATA_VALIDATION_SKIP, "");
 
     /**
      * The Sql undo log.
@@ -232,10 +239,14 @@ public abstract class AbstractUndoExecutor {
 
         TableRecords beforeRecords = sqlUndoLog.getBeforeImage();
         TableRecords afterRecords = sqlUndoLog.getAfterImage();
+        List<String> skipTables = new ArrayList<>();
+        if (StringUtils.isNotBlank(UNDO_DATA_VALIDATION_SKIP)) {
+            skipTables = Lists.newArrayList(UNDO_DATA_VALIDATION_SKIP.trim().toLowerCase().split(","));
+        }
 
         // Compare current data with before data
         // No need undo if the before data snapshot is equivalent to the after data snapshot.
-        Result<Boolean> beforeEqualsAfterResult = DataCompareUtils.isRecordsEquals(beforeRecords, afterRecords);
+        Result<Boolean> beforeEqualsAfterResult = DataCompareUtils.isRecordsEquals(skipTables, beforeRecords, afterRecords);
         if (beforeEqualsAfterResult.getResult()) {
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("Stop rollback because there is no data change " +
@@ -248,12 +259,12 @@ public abstract class AbstractUndoExecutor {
         // Validate if data is dirty.
         TableRecords currentRecords = queryCurrentRecords(conn);
         // compare with current data and after image.
-        Result<Boolean> afterEqualsCurrentResult = DataCompareUtils.isRecordsEquals(afterRecords, currentRecords);
+        Result<Boolean> afterEqualsCurrentResult = DataCompareUtils.isRecordsEquals(skipTables, afterRecords, currentRecords);
         if (!afterEqualsCurrentResult.getResult()) {
 
             // If current data is not equivalent to the after data, then compare the current data with the before 
             // data, too. No need continue to undo if current data is equivalent to the before data snapshot
-            Result<Boolean> beforeEqualsCurrentResult = DataCompareUtils.isRecordsEquals(beforeRecords, currentRecords);
+            Result<Boolean> beforeEqualsCurrentResult = DataCompareUtils.isRecordsEquals(skipTables, beforeRecords, currentRecords);
             if (beforeEqualsCurrentResult.getResult()) {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("Stop rollback because there is no data change " +

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/DataCompareUtilsTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/DataCompareUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package io.seata.rm.datasource;
 
+import com.google.common.collect.Lists;
 import io.seata.rm.datasource.sql.struct.Field;
 import io.seata.rm.datasource.sql.struct.Row;
 import io.seata.rm.datasource.sql.struct.TableMeta;
@@ -61,13 +62,16 @@ public class DataCompareUtilsTest {
 
     @Test
     public void isRecordsEquals() {
+        List<String> skipList1 = Lists.newArrayList("Table_name".trim().toLowerCase().split(","));
+        List<String> skipList2 = Lists.newArrayList("Table_name1".trim().toLowerCase().split(","));
+        List<String> skipList3 = Lists.newArrayList("Table_name,table_name1".trim().toLowerCase().split(","));
         TableMeta tableMeta = Mockito.mock(TableMeta.class);
         Mockito.when(tableMeta.getPrimaryKeyOnlyName()).thenReturn(Arrays.asList(new String[]{"pk"}));
         Mockito.when(tableMeta.getTableName()).thenReturn("table_name");
 
         TableRecords beforeImage = new TableRecords();
-        beforeImage.setTableName("table_name");
         beforeImage.setTableMeta(tableMeta);
+        beforeImage.setTableName("table_name");
 
         List<Row> rows = new ArrayList<>();
         Row row = new Row();
@@ -78,15 +82,19 @@ public class DataCompareUtilsTest {
 
         Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, null).getResult());
         Assertions.assertFalse(DataCompareUtils.isRecordsEquals(null, beforeImage).getResult());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(skipList1, beforeImage, null).getResult());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(skipList1, null, beforeImage).getResult());
 
         TableRecords afterImage = new TableRecords();
-        afterImage.setTableName("table_name1"); // wrong table name
         afterImage.setTableMeta(tableMeta);
+        afterImage.setTableName("table_name1"); // wrong table name
 
         Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage).getResult());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(skipList3, beforeImage, afterImage).getResult());
         afterImage.setTableName("table_name");
 
         Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage).getResult());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(skipList3, beforeImage, afterImage).getResult());
 
         List<Row> rows2 = new ArrayList<>();
         Row row2 = new Row();
@@ -95,19 +103,23 @@ public class DataCompareUtilsTest {
         rows2.add(row2);
         afterImage.setRows(rows2);
         Assertions.assertTrue(DataCompareUtils.isRecordsEquals(beforeImage, afterImage).getResult());
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(skipList3, beforeImage, afterImage).getResult());
 
         field11.setValue("23456");
         Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage).getResult());
-        field11.setValue("12345");
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(skipList3, beforeImage, afterImage).getResult());
 
+        field11.setValue("12345");
         field12.setName("sex");
         Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage).getResult());
-        field12.setName("age");
+        Assertions.assertTrue(DataCompareUtils.isRecordsEquals(skipList1,beforeImage, afterImage).getResult());
 
+        field12.setName("age");
         field12.setValue("19");
         Assertions.assertFalse(DataCompareUtils.isRecordsEquals(beforeImage, afterImage).getResult());
-        field12.setName("18");
+        Assertions.assertFalse(DataCompareUtils.isRecordsEquals(skipList2, beforeImage, afterImage).getResult());
 
+        field12.setName("18");
         Field field3 = new Field("pk", 1, "12346");
         Row row3 = new Row();
         row3.add(field3);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
新增配置client.undo.dataValidation.skip ，表示可跳过校验的列表（以,分隔）
此配置在client.undo.dataValidation = true时生效。
满足跳过的逻辑是：**_beforeImage, afterImage , currentImage 其中某个的tableName存在于这个skip列表中_**。
新增了test，以及修复了之前test不严谨的部分（由于tableMeta被mock了所以setTableMeta会覆盖掉tableName）

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/seata/seata/issues/4566

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

