### PR TITLE
Migrate the registerProcessor method

### DIFF
--- a/core/src/main/java/io/seata/core/rpc/grpc/impl/NettyRemotingServerAdapter.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/impl/NettyRemotingServerAdapter.java
@@ -1,0 +1,33 @@
+package io.seata.core.rpc.grpc.impl;
+
+import io.seata.core.protocol.RpcMessage;
+import io.seata.core.rpc.grpc.norelativeimpl.RpcCallableServer;
+import io.seata.core.rpc.netty.NettyRemotingServer;
+import io.netty.channel.Channel;
+
+import java.util.concurrent.TimeoutException;
+
+public class NettyRemotingServerAdapter implements RpcCallableServer {
+
+    private NettyRemotingServer composition;
+
+    @Override
+    public Object sendSyncRequest(String resourceId, String clientId, Object msg) throws TimeoutException {
+        return composition.sendSyncRequest(resourceId, clientId, msg);
+    }
+
+    @Override
+    public Object sendSyncRequest(Channel conn, Object msg) throws TimeoutException {
+        return composition.sendSyncRequest(conn,msg);
+    }
+
+    @Override
+    public void sendAsyncRequest(Channel conn, Object msg) {
+        composition.sendAsyncRequest(conn, msg);
+    }
+
+    @Override
+    public void sendAsyncResponse(RpcMessage rpcMessage, Channel conn, Object msg) {
+        composition.sendAsyncResponse(rpcMessage, conn, msg);
+    }
+}

--- a/core/src/main/java/io/seata/core/rpc/grpc/impl/RmNettyRemotingClientAdapter.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/impl/RmNettyRemotingClientAdapter.java
@@ -1,0 +1,52 @@
+package io.seata.core.rpc.grpc.impl;
+
+import io.netty.channel.Channel;
+import io.seata.core.model.ResourceManager;
+import io.seata.core.protocol.RpcMessage;
+import io.seata.core.rpc.TransactionMessageHandler;
+import io.seata.core.rpc.grpc.norelativeimpl.RmRpcCallableClient;
+import io.seata.core.rpc.netty.RmNettyRemotingClient;
+
+import java.util.concurrent.TimeoutException;
+
+public class RmNettyRemotingClientAdapter extends RmRpcCallableClient {
+    private RmNettyRemotingClient composition;
+
+
+    @Override
+    public void initialize(String applicationId, String transactionServiceGroup, ResourceManager rm, TransactionMessageHandler handler) {
+        RmNettyRemotingClient rmNettyRemotingClient = RmNettyRemotingClient.getInstance(applicationId, transactionServiceGroup);
+        rmNettyRemotingClient.setResourceManager(rm);
+        rmNettyRemotingClient.setTransactionMessageHandler(handler);
+        composition = rmNettyRemotingClient;
+        rmNettyRemotingClient.init();
+    }
+
+    @Override
+    public void registerResource(String resourceGroupId, String resourceId) {
+        composition.registerResource(resourceGroupId, resourceId);
+    }
+
+    @Override
+    public Object sendSyncRequest(Object msg) throws TimeoutException {
+
+        return composition.sendSyncRequest(msg);
+    }
+
+    @Override
+    public Object sendSyncRequest(Channel channel, Object msg) throws TimeoutException {
+        return composition.sendSyncRequest(channel, msg);
+    }
+
+    @Override
+    public void sendAsyncRequest(Channel channel, Object msg) {
+        composition.sendAsyncRequest(channel, msg);
+    }
+
+    @Override
+    public void sendAsyncResponse(String serverAddress, RpcMessage rpcMessage, Object msg) {
+        composition.sendAsyncResponse(serverAddress, rpcMessage, msg);
+    }
+
+
+}

--- a/core/src/main/java/io/seata/core/rpc/grpc/impl/TmNettyRemotingClientAdapter.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/impl/TmNettyRemotingClientAdapter.java
@@ -1,0 +1,39 @@
+package io.seata.core.rpc.grpc.impl;
+
+import io.netty.channel.Channel;
+import io.seata.core.protocol.RpcMessage;
+import io.seata.core.rpc.grpc.norelativeimpl.TmRpcCallableClient;
+import io.seata.core.rpc.netty.TmNettyRemotingClient;
+
+import java.util.concurrent.TimeoutException;
+
+public class TmNettyRemotingClientAdapter extends TmRpcCallableClient {
+    private TmNettyRemotingClient composition;
+
+    @Override
+    public void initialize(String applicationId, String transactionServiceGroup) {
+        TmNettyRemotingClient tmNettyRemotingClient = TmNettyRemotingClient.getInstance(applicationId, transactionServiceGroup);
+        composition = tmNettyRemotingClient;
+        tmNettyRemotingClient.init();
+    }
+
+    @Override
+    public Object sendSyncRequest(Object msg) throws TimeoutException {
+        return composition.sendSyncRequest(msg);
+    }
+
+    @Override
+    public Object sendSyncRequest(Channel channel, Object msg) throws TimeoutException {
+        return composition.sendSyncRequest(channel, msg);
+    }
+
+    @Override
+    public void sendAsyncRequest(Channel channel, Object msg) {
+        composition.sendAsyncRequest(channel, msg);
+    }
+
+    @Override
+    public void sendAsyncResponse(String serverAddress, RpcMessage rpcMessage, Object msg) {
+        composition.sendAsyncResponse(serverAddress, rpcMessage, msg);
+    }
+}

--- a/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/Channel.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/Channel.java
@@ -1,0 +1,4 @@
+package io.seata.core.rpc.grpc.norelativeimpl;
+//网络连接接口
+public interface Channel {
+}

--- a/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/Initializable.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/Initializable.java
@@ -1,0 +1,5 @@
+package io.seata.core.rpc.grpc.norelativeimpl;
+
+public interface Initializable {
+    void initialize(String applicationId, String transactionServiceGroup);
+}

--- a/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/RmRpcCallableClient.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/RmRpcCallableClient.java
@@ -1,0 +1,47 @@
+package io.seata.core.rpc.grpc.norelativeimpl;
+
+import io.seata.common.loader.EnhancedServiceLoader;
+import io.seata.core.model.ResourceManager;
+import io.seata.core.rpc.TransactionMessageHandler;
+
+public abstract class RmRpcCallableClient implements RpcCallableClient {
+    public static final RmRpcCallableClient getInstance(){
+        return SingletonHolder.getInstance();
+    }
+
+    private ResourceManager resourceManager;
+    private TransactionMessageHandler handler;
+
+    static private class SingletonHolder{
+        private static  volatile RmRpcCallableClient singleton;
+        private static RmRpcCallableClient getInstance(){
+            if (singleton==null){
+                synchronized (SingletonHolder.class) {
+                    if (singleton == null) {
+                        singleton = EnhancedServiceLoader.load(RmRpcCallableClient.class);
+                    }
+                }
+            }
+            return singleton;
+        }
+    }
+
+    public abstract void initialize(String applicationId, String transactionServiceGroup,ResourceManager rm,TransactionMessageHandler handler);
+
+    @Override
+    public void initialize(String applicationId, String transactionServiceGroup) {
+        if (this.resourceManager == null || this.handler == null) {
+            throw new RuntimeException("have not resource manager and handler");
+        }
+        initialize(applicationId,transactionServiceGroup,this.resourceManager,this.handler);
+    }
+    public void setResourceManager(ResourceManager resourceManager) {
+        this.resourceManager = resourceManager;
+    }
+
+    public void setHandler(TransactionMessageHandler handler) {
+        this.handler = handler;
+    }
+
+    public abstract void registerResource(String resourceGroupId, String resourceId);
+}

--- a/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/RpcCallableClient.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/RpcCallableClient.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.core.rpc.grpc.norelativeimpl;
+
+import io.netty.channel.Channel;
+import io.seata.core.protocol.RpcMessage;
+
+import java.util.concurrent.TimeoutException;
+
+
+public interface RpcCallableClient extends Initializable {
+
+
+    Object sendSyncRequest(Object msg) throws TimeoutException;
+
+
+    Object sendSyncRequest(Channel channel, Object msg) throws TimeoutException;
+
+
+    void sendAsyncRequest(Channel channel, Object msg);
+
+
+    void sendAsyncResponse(String serverAddress, RpcMessage rpcMessage, Object msg);
+
+}

--- a/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/RpcCallableServer.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/RpcCallableServer.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.core.rpc.grpc.norelativeimpl;
+
+import io.seata.core.protocol.RpcMessage;
+import java.util.concurrent.TimeoutException;
+import io.netty.channel.Channel;
+
+
+public interface RpcCallableServer {
+
+
+    Object sendSyncRequest(String resourceId, String clientId, Object msg) throws TimeoutException;
+
+
+    Object sendSyncRequest(Channel conn, Object msg) throws TimeoutException;
+
+
+    void sendAsyncRequest(Channel conn, Object msg);
+
+
+    void sendAsyncResponse(RpcMessage rpcMessage, Channel conn, Object msg);
+
+
+
+}

--- a/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/TmRpcCallableClient.java
+++ b/core/src/main/java/io/seata/core/rpc/grpc/norelativeimpl/TmRpcCallableClient.java
@@ -1,0 +1,23 @@
+package io.seata.core.rpc.grpc.norelativeimpl;
+
+import io.seata.common.loader.EnhancedServiceLoader;
+
+public abstract class TmRpcCallableClient implements RpcCallableClient {
+    public static final TmRpcCallableClient getInstance(){
+        return SingletonHolder.getInstance();
+    }
+
+    static private class SingletonHolder{
+        private static  volatile TmRpcCallableClient singleton;
+        private static TmRpcCallableClient getInstance(){
+            if (singleton==null){
+                synchronized (SingletonHolder.class) {
+                    if (singleton == null) {
+                        singleton = EnhancedServiceLoader.load(TmRpcCallableClient.class);
+                    }
+                }
+            }
+            return singleton;
+        }
+    }
+}

--- a/core/src/main/resources/META-INF/services/io.seata.core.rpc.grpc.norelativeimpl.RmRpcCallableClient
+++ b/core/src/main/resources/META-INF/services/io.seata.core.rpc.grpc.norelativeimpl.RmRpcCallableClient
@@ -1,0 +1,1 @@
+io.seata.core.rpc.grpc.impl.RmNettyRemotingClientAdapter

--- a/core/src/main/resources/META-INF/services/io.seata.core.rpc.grpc.norelativeimpl.TmRpcCallableClient
+++ b/core/src/main/resources/META-INF/services/io.seata.core.rpc.grpc.norelativeimpl.TmRpcCallableClient
@@ -1,0 +1,1 @@
+io.seata.core.rpc.grpc.impl.TmNettyRemotingClientAdapter

--- a/core/src/test/java/io/seata/core/rpc/grpc/AllInOneTest.java
+++ b/core/src/test/java/io/seata/core/rpc/grpc/AllInOneTest.java
@@ -1,0 +1,4 @@
+package io.seata.core.rpc.grpc;
+
+public class AllInOneTest {
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did

I was thinking about implementing the grpc extension of the rpc module, and found that registerProcessor has little correlation with RemotingClient and RemotingServer. It is more like a feature implemented by Netty, so I migrated this method to AbstractNettyRemoting to purify the interface responsibilities.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

