### PR TITLE
refactor：Migrate the registerProcessor method

### DIFF
--- a/core/src/main/java/io/seata/core/rpc/RemotingClient.java
+++ b/core/src/main/java/io/seata/core/rpc/RemotingClient.java
@@ -20,9 +20,6 @@ import io.seata.core.protocol.AbstractMessage;
 import io.seata.core.protocol.RpcMessage;
 import io.seata.core.rpc.netty.RmNettyRemotingClient;
 import io.seata.core.rpc.netty.TmNettyRemotingClient;
-import io.seata.core.rpc.processor.RemotingProcessor;
-
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -93,13 +90,4 @@ public interface RemotingClient {
      * @param requestMessage the request message
      */
     void onRegisterMsgFail(String serverAddress, Channel channel, Object response, AbstractMessage requestMessage);
-
-    /**
-     * register processor
-     *
-     * @param messageType {@link io.seata.core.protocol.MessageType}
-     * @param processor   {@link RemotingProcessor}
-     * @param executor    thread pool
-     */
-    void registerProcessor(final int messageType, final RemotingProcessor processor, final ExecutorService executor);
 }

--- a/core/src/main/java/io/seata/core/rpc/RemotingServer.java
+++ b/core/src/main/java/io/seata/core/rpc/RemotingServer.java
@@ -17,9 +17,6 @@ package io.seata.core.rpc;
 
 import io.netty.channel.Channel;
 import io.seata.core.protocol.RpcMessage;
-import io.seata.core.rpc.processor.RemotingProcessor;
-
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -68,14 +65,5 @@ public interface RemotingServer {
      * @param msg        transaction message {@link io.seata.core.protocol}
      */
     void sendAsyncResponse(RpcMessage rpcMessage, Channel channel, Object msg);
-
-    /**
-     * register processor
-     *
-     * @param messageType {@link io.seata.core.protocol.MessageType}
-     * @param processor   {@link RemotingProcessor}
-     * @param executor    thread pool
-     */
-    void registerProcessor(final int messageType, final RemotingProcessor processor, final ExecutorService executor);
 
 }

--- a/core/src/main/java/io/seata/core/rpc/netty/AbstractNettyRemoting.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/AbstractNettyRemoting.java
@@ -369,6 +369,15 @@ public abstract class AbstractNettyRemoting implements Disposable {
      */
     public abstract void destroyChannel(String serverAddress, Channel channel);
 
+    /**
+     * register processor
+     *
+     * @param messageType {@link io.seata.core.protocol.MessageType}
+     * @param processor   {@link RemotingProcessor}
+     * @param executor    thread pool
+     */
+   public abstract void registerProcessor(final int messageType, final RemotingProcessor processor, final ExecutorService executor);
+
     protected void doBeforeRpcHooks(String remoteAddr, RpcMessage request) {
         for (RpcHook rpcHook: rpcHooks) {
             rpcHook.doBeforeRequest(remoteAddr, request);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did

I was thinking about implementing the grpc extension of the rpc module, and found that registerProcessor has little correlation with RemotingClient and RemotingServer. It is more like a feature implemented by Netty, so I migrated this method to AbstractNettyRemoting to purify the interface responsibilities.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

