### PR TITLE
bugfix: replace `flatten-maven-plugin` with `easyj-maven-plugin` to fix the conflict between `shade` and `flatten`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For more details about principle and design, please go to [Seata wiki page](http
 
 ## Maven dependency
 ```xml
-<seata.version>1.5.0</seata.version>
+<seata.version>1.5.1</seata.version>
 
 <dependency>
     <groupId>io.seata</groupId>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -615,30 +615,6 @@
             </resource>
         </resources>
         <plugins>
-            <!-- Easyj -->
-            <plugin>
-                <groupId>icu.easyj.maven.plugins</groupId>
-                <artifactId>easyj-maven-plugin</artifactId>
-                <executions>
-                    <!-- Use this goal to recreate the simplified pom.xml after the shade -->
-                    <execution>
-                        <id>create-pom-file</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>create-pom-file</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <!-- the config of the 'simplify-pom' plugin -->
-                <configuration>
-                    <keepProvidedDependencies>true</keepProvidedDependencies>
-                    <keepOptionalDependencies>true</keepOptionalDependencies>
-                    <excludeDependencies>
-                        <!-- Exclude dependencies that need to be shaded. -->
-                        <dependency>io.seata:*</dependency>
-                    </excludeDependencies>
-                </configuration>
-            </plugin>
             <!-- Shade -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -691,6 +667,30 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- Easyj -->
+            <plugin>
+                <groupId>icu.easyj.maven.plugins</groupId>
+                <artifactId>easyj-maven-plugin</artifactId>
+                <executions>
+                    <!-- Use this goal to recreate the '.flattened-pom.xml' after shade. -->
+                    <execution>
+                        <id>create-pom-file</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>create-pom-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <!-- the config of the 'simplify-pom' plugin -->
+                <configuration>
+                    <keepProvidedDependencies>true</keepProvidedDependencies>
+                    <keepOptionalDependencies>true</keepOptionalDependencies>
+                    <excludeDependencies>
+                        <!-- Exclude dependencies that need to be shaded. -->
+                        <dependency>io.seata:*</dependency>
+                    </excludeDependencies>
+                </configuration>
             </plugin>
             <!-- Dependency -->
             <plugin>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -615,23 +615,29 @@
             </resource>
         </resources>
         <plugins>
-            <!-- Easyj: Shade Compatible Flatten -->
+            <!-- Easyj -->
             <plugin>
                 <groupId>icu.easyj.maven.plugins</groupId>
                 <artifactId>easyj-maven-plugin</artifactId>
-                <version>${easyj-maven-plugin.version}</version>
                 <executions>
+                    <!-- Use this goal to recreate the simplified pom.xml after the shade -->
                     <execution>
-                        <id>shade-compatible-flatten</id>
-                        <phase>prepare-package</phase>
+                        <id>create-pom-file</id>
+                        <phase>package</phase>
                         <goals>
-                            <goal>shade-compatible-flatten</goal>
+                            <goal>create-pom-file</goal>
                         </goals>
-                        <configuration>
-                            <removeCurrentPluginFromPom>true</removeCurrentPluginFromPom>
-                        </configuration>
                     </execution>
                 </executions>
+                <!-- the config of the 'simplify-pom' plugin -->
+                <configuration>
+                    <keepProvidedDependencies>true</keepProvidedDependencies>
+                    <keepOptionalDependencies>true</keepOptionalDependencies>
+                    <excludeDependencies>
+                        <!-- Exclude dependencies that need to be shaded. -->
+                        <dependency>io.seata:*</dependency>
+                    </excludeDependencies>
+                </configuration>
             </plugin>
             <!-- Shade -->
             <plugin>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -30,11 +30,6 @@
     <name>Seata All-in-one ${project.version}</name>
     <description>Seata is an easy-to-use, high-performance, java based, open source distributed transaction solution.</description>
 
-    <properties>
-        <!-- seata version -->
-        <revision>1.5.0</revision>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -620,6 +615,24 @@
             </resource>
         </resources>
         <plugins>
+            <!-- Easyj: Shade Compatible Flatten -->
+            <plugin>
+                <groupId>icu.easyj.maven.plugins</groupId>
+                <artifactId>easyj-maven-plugin</artifactId>
+                <version>${easyj-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>shade-compatible-flatten</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>shade-compatible-flatten</goal>
+                        </goals>
+                        <configuration>
+                            <removeCurrentPluginFromPom>true</removeCurrentPluginFromPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Shade -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -77,7 +77,7 @@
 
         <!-- Maven plugin versions -->
         <!-- Build -->
-        <flatten-maven-plugin.version>1.1.0</flatten-maven-plugin.version>
+        <easyj-maven-plugin.version>0.5.3</easyj-maven-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <!-- Compiler -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -109,7 +109,6 @@
         <!-- Other -->
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
-        <easyj-maven-plugin.version>0.3.9</easyj-maven-plugin.version>
 
         <!-- Default values of the Maven plugins -->
         <checkstyle.skip>true</checkstyle.skip>
@@ -165,6 +164,22 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${mojo-license-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>icu.easyj.maven.plugins</groupId>
+                    <artifactId>easyj-maven-plugin</artifactId>
+                    <version>${easyj-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>simplify-pom</id>
+                            <goals>
+                                <goal>simplify-pom</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <simplifiedPomFileName>.flattened-pom.xml</simplifiedPomFileName>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -225,7 +240,7 @@
                         <fileset>
                             <directory>./</directory>
                             <includes>
-                                <include>*-pom*.xml</include>
+                                <include>*-pom.xml</include>
                                 <include>**/db_store/**</include>
                                 <include>**/sessionStore/**</include>
                                 <include>**/root.data</include>
@@ -235,31 +250,10 @@
                     </filesets>
                 </configuration>
             </plugin>
-            <!-- Flatten -->
+            <!-- EasyJ -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>flatten-maven-plugin</artifactId>
-                <version>${flatten-maven-plugin.version}</version>
-                <configuration>
-                    <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>flatten.clean</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>icu.easyj.maven.plugins</groupId>
+                <artifactId>easyj-maven-plugin</artifactId>
             </plugin>
             <!-- Enforcer -->
             <plugin>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -77,7 +77,7 @@
 
         <!-- Maven plugin versions -->
         <!-- Build -->
-        <easyj-maven-plugin.version>0.5.3</easyj-maven-plugin.version>
+        <easyj-maven-plugin.version>0.5.4</easyj-maven-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <!-- Compiler -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -169,6 +169,7 @@
                     <groupId>icu.easyj.maven.plugins</groupId>
                     <artifactId>easyj-maven-plugin</artifactId>
                     <version>${easyj-maven-plugin.version}</version>
+                    <!-- This goal can replace flatten-maven-plugin to flatten the pom, and replace '${revision}' to the actual version. -->
                     <executions>
                         <execution>
                             <id>simplify-pom</id>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -109,6 +109,7 @@
         <!-- Other -->
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+        <easyj-maven-plugin.version>0.3.9</easyj-maven-plugin.version>
 
         <!-- Default values of the Maven plugins -->
         <checkstyle.skip>true</checkstyle.skip>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -63,7 +63,7 @@
 
     <properties>
         <!-- seata version -->
-        <revision>1.5.0</revision>
+        <revision>1.5.2-SNAPSHOT</revision>
 
         <!-- Compiler settings properties -->
         <java.version>1.8</java.version>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -77,7 +77,7 @@
 
         <!-- Maven plugin versions -->
         <!-- Build -->
-        <easyj-maven-plugin.version>0.5.4</easyj-maven-plugin.version>
+        <easyj-maven-plugin.version>0.5.6</easyj-maven-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <!-- Compiler -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/changes/2.0.0.md
+++ b/changes/2.0.0.md
@@ -15,16 +15,17 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
 此版本更新如下：
 
 ### feature：
-* [[#1234](https://github.com/seata/seata/pull/1234)] 样例，后续请删除
+  - [[#1234](https://github.com/seata/seata/pull/1234)] 样例，后续请删除
 
 ### bugfix：
-* [[#1234](https://github.com/seata/seata/pull/1234)] 样例，后续请删除
+  - [[#1234](https://github.com/seata/seata/pull/1234)] 样例，后续请删除
+  - [[#4626](https://github.com/seata/seata/pull/4626)] 使用 `easyj-maven-plugin` 插件代替 `flatten-maven-plugin` 插件，修复 `shade` 插件与 `flatten` 插件不兼容的问题，导致`seata-all.pom` 中的 `${revision}` 并没有被替换，使应用端引用 `seata-all` 后无法打包。
 
 ### optimize：
-   - [[#4567](https://github.com/seata/seata/pull/4567)] 支持where条件带函数find_in_set支持
+  - [[#4567](https://github.com/seata/seata/pull/4567)] 支持where条件带函数find_in_set支持
 
 ### test：
-* [[#1234](https://github.com/seata/seata/pull/1234)] 样例，后续请删除
+  - [[#1234](https://github.com/seata/seata/pull/1234)] 样例，后续请删除
 
 
  非常感谢以下 contributors 的代码贡献。若有无意遗漏，请报告。

--- a/changes/2.0.0.md
+++ b/changes/2.0.0.md
@@ -6,7 +6,7 @@
 <details>
   <summary><mark>Release notes</mark></summary>
 
-  ### Seata 2.0.0
+### Seata 2.0.0
 
 Seata 2.0.0 发布。
 
@@ -19,7 +19,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
 
 ### bugfix：
   - [[#1234](https://github.com/seata/seata/pull/1234)] 样例，后续请删除
-  - [[#4626](https://github.com/seata/seata/pull/4626)] 使用 `easyj-maven-plugin` 插件代替 `flatten-maven-plugin` 插件，修复 `shade` 插件与 `flatten` 插件不兼容的问题，导致`seata-all.pom` 中的 `${revision}` 并没有被替换，使应用端引用 `seata-all` 后无法打包。
+  - [[#4626](https://github.com/seata/seata/pull/4626)] 使用 `easyj-maven-plugin` 插件代替 `flatten-maven-plugin` 插件，以修复 `shade` 插件与 `flatten` 插件不兼容的问题，导致`seata-all.pom` 中的 `${revision}` 并没有被替换，使应用端引用 `seata-all` 后无法打包。
 
 ### optimize：
   - [[#4567](https://github.com/seata/seata/pull/4567)] 支持where条件带函数find_in_set支持
@@ -28,18 +28,21 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#1234](https://github.com/seata/seata/pull/1234)] 样例，后续请删除
 
 
- 非常感谢以下 contributors 的代码贡献。若有无意遗漏，请报告。
+### Contributors:
 
-   - [slievrly](https://github.com/slievrly)
-   - [doubleDimple](https://github.com/doubleDimple)
+非常感谢以下 contributors 的代码贡献。若有无意遗漏，请报告。
+
+  - [slievrly](https://github.com/slievrly)
+  - [doubleDimple](https://github.com/doubleDimple)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。
 
-   #### Link
 
-   - **Seata:** https://github.com/seata/seata  
-   - **Seata-Samples:** https://github.com/seata/seata-samples   
-   - **Release:** https://github.com/seata/seata/releases
-   - **WebSite:** https://seata.io
+#### Link
+
+  - **Seata:** https://github.com/seata/seata  
+  - **Seata-Samples:** https://github.com/seata/seata-samples   
+  - **Release:** https://github.com/seata/seata/releases
+  - **WebSite:** https://seata.io
 
 </details>

--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -14,16 +14,17 @@ Seata is an easy-to-use, high-performance, open source distributed transaction s
 The version is updated as follows:
 
 ### feature：
-  * [[#1234](https://github.com/seata/seata/pull/1234)] Please delete the sample later
+  - [[#1234](https://github.com/seata/seata/pull/1234)] Please delete the sample later
 
 ### bugfix：
-  * [[#1234](https://github.com/seata/seata/pull/1234)] Please delete the sample later
+  - [[#1234](https://github.com/seata/seata/pull/1234)] Please delete the sample later
+  - [[#4626](https://github.com/seata/seata/pull/4626)] Fix the conflict between `shade` and `flatten`, replace `flatten-maven-plugin` with `easyj-maven-plugin`
 
 ### optimize：
   - [[#4567](https://github.com/seata/seata/pull/4567)] support where method condition(find_in_set)
 
 ### test:
-  * [[#1234](https://github.com/seata/seata/pull/1234)] Please delete the sample later
+  - [[#1234](https://github.com/seata/seata/pull/1234)] Please delete the sample later
 
 Thanks to these contributors for their code commits. Please report an unintended omission.
 

--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -1,11 +1,12 @@
-### 2.0.0	
+### 2.0.0
 
  [source](https://github.com/seata/seata/archive/v2.0.0.zip) |	
  [binary](https://github.com/seata/seata/releases/download/v2.0.0/seata-server-2.0.0.zip) 	
 
-<details>	
+<details>
   <summary><mark>Release notes</mark></summary>	
-  ### Seata 2.0.0	
+
+### Seata 2.0.0
 
 Seata 2.0.0 Released.
 
@@ -18,13 +19,16 @@ The version is updated as follows:
 
 ### bugfix：
   - [[#1234](https://github.com/seata/seata/pull/1234)] Please delete the sample later
-  - [[#4626](https://github.com/seata/seata/pull/4626)] Fix the conflict between `shade` and `flatten`, replace `flatten-maven-plugin` with `easyj-maven-plugin`
+  - [[#4626](https://github.com/seata/seata/pull/4626)] Replace `flatten-maven-plugin` with `easyj-maven-plugin` to fix the conflict between `shade` and `flatten`
 
 ### optimize：
-  - [[#4567](https://github.com/seata/seata/pull/4567)] support where method condition(find_in_set)
+  - [[#4567](https://github.com/seata/seata/pull/4567)] Support where method condition(find_in_set)
 
 ### test:
   - [[#1234](https://github.com/seata/seata/pull/1234)] Please delete the sample later
+
+
+### Contributors:
 
 Thanks to these contributors for their code commits. Please report an unintended omission.
 
@@ -33,12 +37,12 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.
 
- #### Link	
+
+#### Link
 
   - **Seata:** https://github.com/seata/seata
   - **Seata-Samples:** https://github.com/seata/seata-samples
   - **Release:** https://github.com/seata/seata/releases
   - **WebSite:** https://seata.io
-
 
 </details>

--- a/core/src/main/java/io/seata/core/protocol/Version.java
+++ b/core/src/main/java/io/seata/core/protocol/Version.java
@@ -36,7 +36,7 @@ public class Version {
     /**
      * The constant CURRENT.
      */
-    private static final String CURRENT = "1.5.0";
+    private static final String CURRENT = "1.5.2-SNAPSHOT";
     private static final String VERSION_0_7_1 = "0.7.1";
     private static final String VERSION_1_5_0 = "1.5.0";
     private static final int MAX_VERSION_DOT = 3;


### PR DESCRIPTION
bugfix: replace `flatten-maven-plugin` with `easyj-maven-plugin` to fix the conflict between `shade` and `flatten`

问题修复：使用 `easyj-maven-plugin` 插件代替 `flatten-maven-plugin` 插件，以修复 `shade` 插件与 `flatten` 插件不兼容的问题，导致`seata-all.pom` 中的 `${revision}` 并没有被替换为具体的版本号，导致应用端引用后打包失败。

另外，`easyj-maven-plugin` 插件还可以简化所有pom文件。

---

fixes #4618

---

`easyj-maven-plugin` 插件源码：https://github.com/easyj-projects/easyj/blob/develop/maven-plugin/