### PR TITLE
optimize: the thread pool size of branchResultMessageExecutor

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -12,6 +12,7 @@ Add changes here for all PR submitted to the develop branch.
 
 ### optimize：
   - [[#4650](https://github.com/seata/seata/pull/4650)] fix some security vulnerabilities
+  - [[#4670](https://github.com/seata/seata/pull/4670)] optimize the thread pool size of branchResultMessageExecutor
 
 ### test:
 
@@ -21,5 +22,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [slievrly](https://github.com/slievrly)
 - [pengten](https://github.com/pengten)
 - [YSF-A](https://github.com/YSF-A)
+- [tuwenlin](https://github.com/tuwenlin)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -10,7 +10,7 @@
 
 ### optimize：
   - [[#4650](https://github.com/seata/seata/pull/4650)] 修复安全漏洞
-
+  - [[#4670](https://github.com/seata/seata/pull/4670)] 优化branchResultMessageExecutor线程池的线程数
 ### test：
 
 
@@ -20,5 +20,6 @@
 - [slievrly](https://github.com/slievrly)
 - [pengten](https://github.com/pengten)
 - [YSF-A](https://github.com/YSF-A)
+- [tuwenlin](https://github.com/tuwenlin)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/core/src/main/java/io/seata/core/rpc/netty/NettyServerConfig.java
+++ b/core/src/main/java/io/seata/core/rpc/netty/NettyServerConfig.java
@@ -63,9 +63,9 @@ public class NettyServerConfig extends NettyBaseConfig {
     private static int keepAliveTime = Integer.parseInt(System.getProperty(
             ConfigurationKeys.KEEP_ALIVE_TIME, "500"));
     private static int minBranchResultPoolSize = Integer.parseInt(System.getProperty(
-            ConfigurationKeys.MIN_BRANCH_RESULT_POOL_SIZE, "50"));
+            ConfigurationKeys.MIN_BRANCH_RESULT_POOL_SIZE, String.valueOf(WORKER_THREAD_SIZE)));
     private static int maxBranchResultPoolSize = Integer.parseInt(System.getProperty(
-            ConfigurationKeys.MAX_BRANCH_RESULT_POOL_SIZE, "500"));
+            ConfigurationKeys.MAX_BRANCH_RESULT_POOL_SIZE, String.valueOf(WORKER_THREAD_SIZE)));
     private static boolean ENABLE_TC_SERVER_BATCH_SEND_RESPONSE = CONFIG.getBoolean(ConfigurationKeys.ENABLE_TC_SERVER_BATCH_SEND_RESPONSE,
         DefaultValues.DEFAULT_ENABLE_TC_SERVER_BATCH_SEND_RESPONSE);
 


### PR DESCRIPTION
branchResultMessageExecutor只用来处理分支事务响应
![ServerOnResponseProcessor](https://user-images.githubusercontent.com/96557610/172552185-0068f3e1-fab9-48ec-95aa-2c5d02afe573.png)
coreSize和maxSize都改为2倍核心线程数
