### PR TITLE
optimize: optimize TransactionHook execution time when transaction ar…

### DIFF
--- a/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
+++ b/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
@@ -297,6 +297,7 @@ public class TransactionalTemplate {
     private void cleanUp() {
         if (TransactionDepthManager.isOriginDepth()) {
             TransactionHookManager.clear();
+            TransactionDepthManager.clear();
         }
     }
 

--- a/tm/src/main/java/io/seata/tm/api/transaction/SuspendedResourcesHolder.java
+++ b/tm/src/main/java/io/seata/tm/api/transaction/SuspendedResourcesHolder.java
@@ -30,16 +30,26 @@ public class SuspendedResourcesHolder {
      * The xid
      */
     private String xid;
+    /**
+     * the depth
+     */
+    private Integer depth;
 
-    public SuspendedResourcesHolder(String xid) {
+    public SuspendedResourcesHolder(String xid, Integer depth) {
         if (xid == null) {
             throw new IllegalArgumentException("xid must be not null");
         }
         this.xid = xid;
+        this.depth = depth;
     }
 
     @Nonnull
     public String getXid() {
         return xid;
+    }
+
+    @Nonnull
+    public Integer getDepth() {
+        return depth;
     }
 }

--- a/tm/src/main/java/io/seata/tm/api/transaction/TransactionDepthManager.java
+++ b/tm/src/main/java/io/seata/tm/api/transaction/TransactionDepthManager.java
@@ -1,0 +1,30 @@
+package io.seata.tm.api.transaction;
+
+/**
+ * Used to avoid early hook execution when transactions are nested
+ * @author ninggc
+ */
+public class TransactionDepthManager {
+    private static final ThreadLocal<Integer> depth = ThreadLocal.withInitial(() -> 0);
+
+    public static void depthInc() {
+        depth.set(depth.get() + 1);
+    }
+
+    public static void depthDec() {
+        depth.set(depth.get() - 1);
+    }
+
+    public static boolean isOriginDepth() {
+        return Integer.valueOf(0).equals(depth.get());
+    }
+
+    public static Integer suspend() {
+        depth.remove();
+        return depth.get();
+    }
+
+    public static void resume(Integer resumeDepth) {
+        depth.set(resumeDepth);
+    }
+}

--- a/tm/src/main/java/io/seata/tm/api/transaction/TransactionDepthManager.java
+++ b/tm/src/main/java/io/seata/tm/api/transaction/TransactionDepthManager.java
@@ -5,26 +5,31 @@ package io.seata.tm.api.transaction;
  * @author ninggc
  */
 public class TransactionDepthManager {
-    private static final ThreadLocal<Integer> depth = ThreadLocal.withInitial(() -> 0);
+    private static final ThreadLocal<Integer> LOCAL_DEPTH = ThreadLocal.withInitial(() -> 0);
 
     public static void depthInc() {
-        depth.set(depth.get() + 1);
+        LOCAL_DEPTH.set(LOCAL_DEPTH.get() + 1);
     }
 
     public static void depthDec() {
-        depth.set(depth.get() - 1);
+        LOCAL_DEPTH.set(LOCAL_DEPTH.get() - 1);
     }
 
     public static boolean isOriginDepth() {
-        return Integer.valueOf(0).equals(depth.get());
+        // Compatible with last depthDec action
+        return LOCAL_DEPTH.get() <= 1;
     }
 
     public static Integer suspend() {
-        depth.remove();
-        return depth.get();
+        LOCAL_DEPTH.remove();
+        return LOCAL_DEPTH.get();
     }
 
     public static void resume(Integer resumeDepth) {
-        depth.set(resumeDepth);
+        LOCAL_DEPTH.set(resumeDepth);
+    }
+
+    public static void clear() {
+        LOCAL_DEPTH.remove();
     }
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
多个@GlobalTransactional注解嵌套时，hook会在最内层的注解方法执行完就会调用

我查看了代码，如图所示的位置
![image](https://user-images.githubusercontent.com/16892791/173541156-c29abd2b-5369-4d26-8d1d-12af48c9d41f.png)

```
            triggerBeforeCommit();
            tx.commit();
```
tx.commit里做了role == Participant判断，所以只有最外层会执行，但是hook没有做这个判断，会直接调用的（且TransactionHook其实在Participant也是要执行的，不能直接使用该判断），当出现嵌套注解@GlobalTransaction时，内层的切面结束时，便会提前调用hook的afterCompletion()等一系列方法，并通过cleanUp方法清楚TransactionHook，期望行为应该是最外层事务切面结束时再触发TransactionHook的行为


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
双层@GlobalTransactional嵌套时观察TransactionHook执行行为是否正常
```
@Service
public class GlobalTransactionTemplate {

    @GlobalTransactional
    public <T> T doWithGT(Supplier<T> supplier) {
        return supplier.get();
    }

}

```
```
        globalTransactionTemplate.doWithGT(() -> {
            log.info("before 1 gtx");
            TransactionHookManager.registerHook(new OnlyLogTransactionHook());

            globalTransactionTemplate.doWithNewGT(() -> {
                log.info("before 2 gtx");
                TransactionHookManager.registerHook(new OnlyLogTransactionHook());
                log.info("after 2 gtx");
                return null;
            });

            log.info("after 1 gtx");
            return null;
        });
```

```
public class OnlyLogTransactionHook implements TransactionHook {

    @Override
    public void beforeBegin() {
        log.info("beforeBegin");
    }

    @Override
    public void afterBegin() {
        log.info("afterBegin");
    }

    @Override
    public void beforeCommit() {
        log.info("beforeCommit");
    }

    @Override
    public void afterCommit() {
        log.info("afterCommit");
    }

    @Override
    public void beforeRollback() {
        log.info("beforeRollback");
    }

    @Override
    public void afterRollback() {
        log.info("afterRollback");
    }

    @Override
    public void afterCompletion() {
        log.info("afterCompletion");
    }
}
```

### Ⅴ. Special notes for reviews

