### PR TITLE
fix: postgres can not support ‘order by’ after ‘count(*)’

### DIFF
--- a/common/src/main/java/io/seata/common/util/PageUtil.java
+++ b/common/src/main/java/io/seata/common/util/PageUtil.java
@@ -129,6 +129,7 @@ public class PageUtil {
             case "mysql":
             case "h2":
             case "postgresql":
+                return sourceSql.replaceAll("order by.*", "");
             case "oceanbase":
             case "oracle":
                 return sourceSql.replaceAll("(?i)(?<=select)(.*)(?=from)", " count(1) ");


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
postgres 不支持查询 count() 的时候进行 order by,需要将 order by 去掉

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
在 server 使用 pg 的前提下，进行控制台查询会报错。

### Ⅴ. Special notes for reviews

