### PR TITLE
optimize: mysql 8.0.29 not should be hold for connection

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -11,6 +11,7 @@ Add changes here for all PR submitted to the develop branch.
 ### optimize:
 - [[#4774](https://github.com/seata/seata/pull/4774)] optimize mysql8 dependencies for seataio/seata-server image
 - [[#4790](https://github.com/seata/seata/pull/4790)] Add a github action to publish Seata to OSSRH
+- [[#4765](https://github.com/seata/seata/pull/4765)] mysql 8.0.29 not should be hold for connection
 
 
 ### test:
@@ -22,6 +23,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 <!-- Please make sure your Github ID is in the list below -->
 - [slievrly](https://github.com/slievrly)
 - [wangliang181230](https://github.com/wangliang181230)
-
+- [a364176773](https://github.com/a364176773)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -11,6 +11,7 @@
 ### optimize：
 - [[#4774](https://github.com/seata/seata/pull/4774)] 优化 seataio/seata-server 镜像中的 mysql8 依赖
 - [[#4790](https://github.com/seata/seata/pull/4790)] 添加一个 github action，用于自动发布Seata到OSSRH
+- [[#4765](https://github.com/seata/seata/pull/4765)] mysql8.0.29版本及以上XA模式不持connection至二阶段
 
 
 ### test：

--- a/core/src/main/java/io/seata/core/protocol/Version.java
+++ b/core/src/main/java/io/seata/core/protocol/Version.java
@@ -112,7 +112,7 @@ public class Version {
         return isAboveOrEqualVersion150;
     }
 
-    private static long convertVersion(String version) throws IncompatibleVersionException {
+    public static long convertVersion(String version) throws IncompatibleVersionException {
         String[] parts = StringUtils.split(version, '.');
         long result = 0L;
         int i = 1;

--- a/rm-datasource/src/main/java/io/seata/rm/BaseDataSourceResource.java
+++ b/rm-datasource/src/main/java/io/seata/rm/BaseDataSourceResource.java
@@ -54,6 +54,8 @@ public abstract class BaseDataSourceResource<T extends Holdable> implements Seat
 
     protected Driver driver;
 
+    private boolean shouldBeHeld = false;
+
     private Map<String, T> keeper = new ConcurrentHashMap<>();
 
     private static final Cache<String, BranchStatus> BRANCH_STATUS_CACHE =
@@ -217,4 +219,11 @@ public abstract class BaseDataSourceResource<T extends Holdable> implements Seat
         return keeper;
     }
 
+    public boolean isShouldBeHeld() {
+        return shouldBeHeld;
+    }
+
+    public void setShouldBeHeld(boolean shouldBeHeld) {
+        this.shouldBeHeld = shouldBeHeld;
+    }
 }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/ConnectionProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/ConnectionProxyXA.java
@@ -77,9 +77,7 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
     public ConnectionProxyXA(Connection originalConnection, XAConnection xaConnection, BaseDataSourceResource resource,
         String xid) {
         super(originalConnection, xaConnection, resource, xid);
-        if (resource instanceof DataSourceProxyXA) {
-            this.shouldBeHeld = ((DataSourceProxyXA)resource).isShouldBeHeld();
-        }
+        this.shouldBeHeld = resource.isShouldBeHeld();
     }
 
     public void init() {
@@ -101,14 +99,18 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
     }
 
     private void keepIfNecessary() {
-        resource.hold(xaBranchXid.toString(), this);
+        if (shouldBeHeld()) {
+            resource.hold(xaBranchXid.toString(), this);
+        }
     }
 
     private void releaseIfNecessary() {
-        if (this.xaBranchXid != null) {
-            String xaBranchXid = this.xaBranchXid.toString();
-            if (isHeld()) {
-                resource.release(xaBranchXid, this);
+        if (shouldBeHeld()) {
+            if (this.xaBranchXid != null) {
+                String xaBranchXid = this.xaBranchXid.toString();
+                if (isHeld()) {
+                    resource.release(xaBranchXid, this);
+                }
             }
         }
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/ConnectionProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/ConnectionProxyXA.java
@@ -30,7 +30,6 @@ import io.seata.core.model.BranchStatus;
 import io.seata.core.model.BranchType;
 import io.seata.rm.BaseDataSourceResource;
 import io.seata.rm.DefaultResourceManager;
-import io.seata.sqlparser.util.JdbcConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/ConnectionProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/ConnectionProxyXA.java
@@ -63,6 +63,8 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
     private volatile Long prepareTime = null;
 
     private volatile Integer timeout = null;
+    
+    private boolean shouldBeHeld = false;
 
     /**
      * Constructor of Connection Proxy for XA mode.
@@ -72,8 +74,12 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
      * @param resource The corresponding Resource(DataSource proxy) from which the connections was created.
      * @param xid Seata global transaction xid.
      */
-    public ConnectionProxyXA(Connection originalConnection, XAConnection xaConnection, BaseDataSourceResource resource, String xid) {
+    public ConnectionProxyXA(Connection originalConnection, XAConnection xaConnection, BaseDataSourceResource resource,
+        String xid) {
         super(originalConnection, xaConnection, resource, xid);
+        if (resource instanceof DataSourceProxyXA) {
+            this.shouldBeHeld = ((DataSourceProxyXA)resource).isShouldBeHeld();
+        }
     }
 
     public void init() {
@@ -328,8 +334,7 @@ public class ConnectionProxyXA extends AbstractConnectionProxyXA implements Hold
 
     @Override
     public boolean shouldBeHeld() {
-        return JdbcConstants.MYSQL.equals(resource.getDbType()) || JdbcConstants.MARIADB.equals(resource.getDbType())
-               || StringUtils.isBlank(resource.getDbType());
+        return shouldBeHeld || StringUtils.isBlank(resource.getDbType());
     }
 
     public Long getPrepareTime() {

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
@@ -26,7 +26,6 @@ import javax.sql.XAConnection;
 import io.seata.core.constants.DBType;
 import io.seata.core.context.RootContext;
 import io.seata.core.model.BranchType;
-import io.seata.core.model.ResourceManager;
 import io.seata.core.protocol.Version;
 import io.seata.rm.DefaultResourceManager;
 import io.seata.rm.datasource.SeataDataSourceProxy;

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
@@ -54,7 +54,7 @@ public class DataSourceProxyXA extends AbstractDataSourceProxyXA {
         this.dataSource = dataSource;
         this.branchType = BranchType.XA;
         JdbcUtils.initDataSourceResource(this, dataSource, resourceGroupId);
-        if (dbType.equalsIgnoreCase(DBType.MYSQL.name())) {
+        if (DBType.MYSQL.name().equalsIgnoreCase(dbType)) {
             ResourceManagerXA resourceManagerXA =
                 (ResourceManagerXA)DefaultResourceManager.get().getResourceManager(BranchType.XA);
             resourceManagerXA.initXaTwoPhaseTimeoutChecker();
@@ -72,6 +72,8 @@ public class DataSourceProxyXA extends AbstractDataSourceProxyXA {
                 setShouldBeHeld(true);
                 LOGGER.info("get mysql version fail error: {}", e.getMessage());
             }
+        }else if (DBType.MARIADB.name().equalsIgnoreCase(dbType)) {
+            setShouldBeHeld(true);
         }
         //Set the default branch type to 'XA' in the RootContext.
         RootContext.setDefaultBranchType(this.getBranchType());

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
@@ -72,7 +72,7 @@ public class DataSourceProxyXA extends AbstractDataSourceProxyXA {
                 setShouldBeHeld(true);
                 LOGGER.info("get mysql version fail error: {}", e.getMessage());
             }
-        }else if (DBType.MARIADB.name().equalsIgnoreCase(dbType)) {
+        } else if (DBType.MARIADB.name().equalsIgnoreCase(dbType)) {
             setShouldBeHeld(true);
         }
         //Set the default branch type to 'XA' in the RootContext.

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/DataSourceProxyXA.java
@@ -56,11 +56,6 @@ public class DataSourceProxyXA extends AbstractDataSourceProxyXA {
         this.branchType = BranchType.XA;
         JdbcUtils.initDataSourceResource(this, dataSource, resourceGroupId);
         if (DBType.MYSQL.name().equalsIgnoreCase(dbType)) {
-            Optional.ofNullable(DefaultResourceManager.get().getResourceManager(BranchType.XA)).ifPresent(resourceManager -> {
-                if (resourceManager instanceof ResourceManagerXA) {
-                    ((ResourceManagerXA)resourceManager).initXaTwoPhaseTimeoutChecker();
-                }
-            });
             try (Connection connection = dataSource.getConnection();
                 PreparedStatement preparedStatement = connection.prepareStatement("SELECT VERSION()");
                 ResultSet versionResult = preparedStatement.executeQuery()) {
@@ -78,6 +73,11 @@ public class DataSourceProxyXA extends AbstractDataSourceProxyXA {
         } else if (DBType.MARIADB.name().equalsIgnoreCase(dbType)) {
             setShouldBeHeld(true);
         }
+        Optional.ofNullable(DefaultResourceManager.get().getResourceManager(BranchType.XA)).ifPresent(resourceManager -> {
+            if (resourceManager instanceof ResourceManagerXA) {
+                ((ResourceManagerXA)resourceManager).initXaTwoPhaseTimeoutChecker();
+            }
+        });
         //Set the default branch type to 'XA' in the RootContext.
         RootContext.setDefaultBranchType(this.getBranchType());
     }

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/xa/ResourceManagerXA.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/xa/ResourceManagerXA.java
@@ -52,35 +52,52 @@ public class ResourceManagerXA extends AbstractDataSourceCacheResourceManager {
     /**
      * The Timer check xa branch two phase hold timeout.
      */
-    protected final ScheduledExecutorService xaTwoPhaseTimeoutChecker = new ScheduledThreadPoolExecutor(1,
-            new NamedThreadFactory("xaTwoPhaseTimeoutChecker", 1, true));
+    protected volatile ScheduledExecutorService xaTwoPhaseTimeoutChecker;
 
     @Override
     public void init() {
         LOGGER.info("ResourceManagerXA init ...");
-        xaTwoPhaseTimeoutChecker.scheduleAtFixedRate(new Runnable() {
-            @Override
-            public void run() {
-                for (Map.Entry<String, Resource> entry : dataSourceCache.entrySet()) {
-                    BaseDataSourceResource resource = (BaseDataSourceResource) entry.getValue();
-                    Map<String, ConnectionProxyXA> keeper = resource.getKeeper();
-                    for (Map.Entry<String, ConnectionProxyXA> connectionEntry : keeper.entrySet()) {
-                        ConnectionProxyXA connection = connectionEntry.getValue();
-                        long now = System.currentTimeMillis();
-                        synchronized (connection) {
-                            if (connection.getPrepareTime() != null &&
-                                    now - connection.getPrepareTime() > TWO_PHASE_HOLD_TIMEOUT) {
-                                try {
-                                    connection.closeForce();
-                                } catch (SQLException e) {
-                                    LOGGER.info("Force close the xa physical connection fail", e);
+    }
+
+    public void initXaTwoPhaseTimeoutChecker() {
+        if (xaTwoPhaseTimeoutChecker == null) {
+            synchronized (this) {
+                if (xaTwoPhaseTimeoutChecker == null) {
+                    boolean shouldBeHold = dataSourceCache.values().parallelStream().anyMatch(resource -> {
+                        if (resource instanceof DataSourceProxyXA) {
+                            return ((DataSourceProxyXA)resource).isShouldBeHeld();
+                        }
+                        return false;
+                    });
+                    if (shouldBeHold) {
+                        xaTwoPhaseTimeoutChecker = new ScheduledThreadPoolExecutor(1,
+                            new NamedThreadFactory("xaTwoPhaseTimeoutChecker", 1, true));
+                        xaTwoPhaseTimeoutChecker.scheduleAtFixedRate(() -> {
+                            for (Map.Entry<String, Resource> entry : dataSourceCache.entrySet()) {
+                                BaseDataSourceResource resource = (BaseDataSourceResource)entry.getValue();
+                                if (resource instanceof DataSourceProxyXA) {
+                                    Map<String, ConnectionProxyXA> keeper = resource.getKeeper();
+                                    for (Map.Entry<String, ConnectionProxyXA> connectionEntry : keeper.entrySet()) {
+                                        ConnectionProxyXA connection = connectionEntry.getValue();
+                                        long now = System.currentTimeMillis();
+                                        synchronized (connection) {
+                                            if (connection.getPrepareTime() != null
+                                                && now - connection.getPrepareTime() > TWO_PHASE_HOLD_TIMEOUT) {
+                                                try {
+                                                    connection.closeForce();
+                                                } catch (SQLException e) {
+                                                    LOGGER.info("Force close the xa physical connection fail", e);
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
-                        }
+                        }, SCHEDULE_DELAY_MILLS, SCHEDULE_INTERVAL_MILLS, TimeUnit.MILLISECONDS);
                     }
                 }
             }
-        }, SCHEDULE_DELAY_MILLS, SCHEDULE_INTERVAL_MILLS, TimeUnit.MILLISECONDS);
+        }
     }
 
     @Override


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
1.mysql8.0.29允许不同的连接进行二阶段的行为，因此在此版本下无需持有连接至二阶段
mariadb经测试无法如此，所以必须和低版本的mysql一致处理
2.抽离xa兜底断开物理连接的线程池构建，只有在需要hold连接至二阶段的哪些datasource存在在进行构建线程池和任务运行

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

