### PR TITLE
fix(sec): upgrade com.h2database:h2 to 2.1.210

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -13,10 +13,7 @@
   ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~  See the License for the specific language governing permissions and
   ~  limitations under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.seata</groupId>
         <artifactId>seata-build</artifactId>
@@ -90,7 +87,7 @@
         <mysql.version>5.1.35</mysql.version>
         <ojdbc.version>19.3.0.0</ojdbc.version>
         <postgresql.version>42.1.4</postgresql.version>
-        <h2.version>1.4.181</h2.version>
+        <h2.version>2.1.210</h2.version>
         <mariadb.version>2.7.2</mariadb.version>
         <!-- db connection pool -->
         <druid.version>1.2.6</druid.version>


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in com.h2database:h2 1.4.181
- [CVE-2018-14335](https://www.oscs1024.com/hd/CVE-2018-14335)
- [CVE-2021-42392](https://www.oscs1024.com/hd/CVE-2021-42392)
- [CVE-2022-23221](https://www.oscs1024.com/hd/CVE-2022-23221)
- [MPS-2022-52737](https://www.oscs1024.com/hd/MPS-2022-52737)


### What did I do？
Upgrade com.h2database:h2 from 1.4.181 to 2.1.210 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS