### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -13,10 +13,7 @@
   ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~  See the License for the specific language governing permissions and
   ~  limitations under the License.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.seata</groupId>
         <artifactId>seata-build</artifactId>
@@ -89,7 +86,7 @@
         <!-- db -->
         <mysql.version>5.1.35</mysql.version>
         <ojdbc.version>19.3.0.0</ojdbc.version>
-        <postgresql.version>42.1.4</postgresql.version>
+        <postgresql.version>42.4.1</postgresql.version>
         <h2.version>1.4.181</h2.version>
         <mariadb.version>2.7.2</mariadb.version>
         <!-- db connection pool -->


### PR DESCRIPTION
### What happened？
There are 5 security vulnerabilities found in org.postgresql:postgresql 42.1.4
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)
- [CVE-2022-26520](https://www.oscs1024.com/hd/CVE-2022-26520)
- [CVE-2018-10936](https://www.oscs1024.com/hd/CVE-2018-10936)
- [CVE-2020-13692](https://www.oscs1024.com/hd/CVE-2020-13692)
- [CVE-2022-21724](https://www.oscs1024.com/hd/CVE-2022-21724)


### What did I do？
Upgrade org.postgresql:postgresql from 42.1.4 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS