### PR TITLE
Test support for arm64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,3 +49,39 @@ jobs:
           else
             ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
           fi
+  arm64-test: 
+     runs-on: ubuntu-latest
+     strategy:
+      fail-fast: false
+      matrix:
+        springboot: [
+          2.7.2          -Dspring-framework.version=5.3.22,
+          2.6.10         -Dspring-framework.version=5.3.22,
+          2.5.14         -Dspring-framework.version=5.3.20,
+          2.4.13         -Dspring-framework.version=5.3.13,
+          2.3.12.RELEASE -Dspring-framework.version=5.2.15.RELEASE,
+          2.2.13.RELEASE -Dspring-framework.version=5.2.12.RELEASE,
+          #2.1.18.RELEASE,
+          #2.0.9.RELEASE,
+          #1.5.22.RELEASE,
+          #1.4.7.RELEASE,
+          #1.3.8.RELEASE,
+          #1.2.8.RELEASE,
+          #1.1.12.RELEASE,
+          #1.0.2.RELEASE
+        ]
+
+     steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+      - name: install
+        run: |
+               docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+               arm64v8/ubuntu:20.04 \
+               bash -exc 'apt-get update -y && \
+                apt-get install maven -y'
+      - name: test-arm64
+        run: |
+            ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          


### PR DESCRIPTION
Added arm64 test support in **.github/workflows/test.yml** file for running the test for arm64 platform.

Signed-off-by: [odidev@puresoftware.com](mailto:odidev@puresoftware.com)