### PR TITLE
bugfix: fix could not intercept the sql witch has no primary and unique

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -35,6 +35,7 @@ Add changes here for all PR submitted to the develop branch.
 - [[#5038](https://github.com/seata/seata/pull/5038)] remove @EnableConfigurationProperties({SagaAsyncThreadPoolProperties.class})
 - [[#5050](https://github.com/seata/seata/pull/5050)] fix global session is not change to Committed in saga mode
 - [[#5031](https://github.com/seata/seata/pull/5031)] fix mysql InsertOnDuplicateUpdate should not use null index value as image sql query condition
+- [[#5075](https://github.com/seata/seata/pull/5075)] fix InsertOnDuplicateUpdateExecutor could not intercept the sql which has no primary and unique key
 
 
 ### optimize:
@@ -95,5 +96,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [neillee95](https://github.com/neillee95)
 - [crazy-sheep](https://github.com/crazy-sheep)
 - [zhangzq7](https://github.com/zhangzq7)
+- [l81893521](https://github.com/l81893521)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -37,6 +37,7 @@
 - [[#5038](https://github.com/seata/seata/pull/5038)] 修复SagaAsyncThreadPoolProperties冲突问题
 - [[#5050](https://github.com/seata/seata/pull/5050)] 修复Saga模式下全局状态未正确更改成Committed
 - [[#5031](https://github.com/seata/seata/pull/5031)] 修复InsertOnDuplicateUpdate中不应该使用null值索引作为查询条件
+- [[#5075](https://github.com/seata/seata/pull/5075)] 修复InsertOnDuplicateUpdate无法拦截无主键和唯一索引的SQL
 
 ### optimize：
 - [[#4774](https://github.com/seata/seata/pull/4774)] 优化 seataio/seata-server 镜像中的 mysql8 依赖
@@ -95,5 +96,6 @@
 - [neillee95](https://github.com/neillee95)
 - [crazy-sheep](https://github.com/crazy-sheep)
 - [zhangzq7](https://github.com/zhangzq7)
+- [l81893521](https://github.com/l81893521)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertOnDuplicateUpdateExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertOnDuplicateUpdateExecutor.java
@@ -315,7 +315,7 @@ public class MySQLInsertOnDuplicateUpdateExecutor extends MySQLInsertExecutor im
             int finalI = i;
             List<Object> paramAppenderTempList = new ArrayList<>();
             tableMeta.getAllIndexes().forEach((k, v) -> {
-                if (!v.isNonUnique() && isIndexValueNotNull(v,imageParameterMap,finalI)) {
+                if (!v.isNonUnique() && isIndexValueNotNull(v, imageParameterMap, finalI)) {
                     boolean columnIsNull = true;
                     List<String> uniqueList = new ArrayList<>();
                     for (ColumnMeta m : v.getValues()) {
@@ -404,7 +404,7 @@ public class MySQLInsertOnDuplicateUpdateExecutor extends MySQLInsertExecutor im
         return imageParameterMap;
     }
 
-    private boolean isIndexValueNotNull(IndexMeta indexMeta, Map<String, ArrayList<Object>> imageParameterMap,int rowIndex) {
+    private boolean isIndexValueNotNull(IndexMeta indexMeta, Map<String, ArrayList<Object>> imageParameterMap, int rowIndex) {
         for (ColumnMeta columnMeta : indexMeta.getValues()) {
             String columnName = columnMeta.getColumnName();
             List<Object> imageParameters = imageParameterMap.get(columnName);

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertOnDuplicateUpdateExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/exec/mysql/MySQLInsertOnDuplicateUpdateExecutor.java
@@ -269,7 +269,7 @@ public class MySQLInsertOnDuplicateUpdateExecutor extends MySQLInsertExecutor im
      */
     public TableRecords buildTableRecords2(TableMeta tableMeta, String selectSQL, ArrayList<List<Object>> paramAppenderList, List<Object> primaryKeys) throws SQLException {
         if (CollectionUtils.isEmpty(paramAppenderList)) {
-            throw new NotSupportYetException("the SQL statement has no primary key or unique index value,it will not hit any row data.recommend to convert to a normal insert statement");
+            throw new NotSupportYetException("the SQL statement has no primary key or unique index value, it will not hit any row data.recommend to convert to a normal insert statement");
         }
         ResultSet rs = null;
         try (PreparedStatement ps = statementProxy.getConnection()
@@ -346,7 +346,9 @@ public class MySQLInsertOnDuplicateUpdateExecutor extends MySQLInsertExecutor im
                     }
                 }
             });
-            paramAppenderList.add(paramAppenderTempList);
+            if (CollectionUtils.isNotEmpty(paramAppenderTempList)) {
+                paramAppenderList.add(paramAppenderTempList);
+            }
         }
         StringJoiner selectSQLJoin = new StringJoiner(", ", prefix, suffix.toString());
         return selectSQLJoin.toString();

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertOnDuplicateUpdateExecutorTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/exec/MySQLInsertOnDuplicateUpdateExecutorTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Collections;
 
 import com.google.common.collect.Lists;
+import io.seata.common.exception.NotSupportYetException;
 import io.seata.rm.datasource.ConnectionProxy;
 import io.seata.rm.datasource.PreparedStatementProxy;
 import io.seata.rm.datasource.StatementProxy;
@@ -151,6 +152,20 @@ public class MySQLInsertOnDuplicateUpdateExecutorTest {
         } catch (SQLException throwables) {
             throwables.printStackTrace();
         }
+    }
+    @Test
+    public void testBeforeImageWithNoUnique(){
+        mockImageParameterMap_contain_constant();
+        List<List<Object>> insertRows = new ArrayList<>();
+        insertRows.add(Arrays.asList("?,?,?,userStatus1"));
+        insertRows.add(Arrays.asList("?,?,?,userStatus2"));
+        when(sqlInsertRecognizer.getInsertRows(pkIndexMap.values())).thenReturn(insertRows);
+        mockInsertColumns();
+        mockAllIndexes();
+        doReturn(tableMeta).when(insertOrUpdateExecutor).getTableMeta();
+        Assertions.assertThrows(NotSupportYetException.class, () -> {
+            insertOrUpdateExecutor.beforeImage();
+        });
     }
 
     private void mockAllIndexes(){


### PR DESCRIPTION

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
fix InsertOnDuplicateUpdateExecutor could not intercept the sql which has no primary and unique key

### Ⅱ. Does this pull request fix one issue?
#5079

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

