### PR TITLE
feature: support passing `contextPath` parameter to Nacos client

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -10,6 +10,7 @@ Add changes here for all PR submitted to the develop branch.
 - [[#4877](https://github.com/seata/seata/pull/4877)] seata client support jdk17
 - [[#4468](https://github.com/seata/seata/pull/4968)] support kryo 5.3.0
 - [[#4914](https://github.com/seata/seata/pull/4914)] support mysql update join sql
+- [[#5111](https://github.com/seata/seata/pull/5111)] support passing contextPath parameter to Nacos client
 
 
 ### bugfix:

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -10,7 +10,7 @@
 - [[#4877](https://github.com/seata/seata/pull/4877)] seata client支持jdk17
 - [[#4468](https://github.com/seata/seata/pull/4968)] 支持kryo 5.3.0
 - [[#4914](https://github.com/seata/seata/pull/4914)] 支持mysql的update join联表更新语法
-
+- [[#5111](https://github.com/seata/seata/pull/5111)] 支持传递contextPath参数给Nacos客户端
 
 
 ### bugfix：

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -108,5 +108,6 @@
 - [zhangzq7](https://github.com/zhangzq7)
 - [l81893521](https://github.com/l81893521)
 - [zhuyoufeng](https://github.com/zhuyoufeng)
-- [xingfudeshi](https://github.com/xingfudeshi)
+- [xingfudeshi](https://github.com/xingfudeshi)  
+
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/config/seata-config-nacos/src/main/java/io/seata/config/nacos/NacosConfiguration.java
+++ b/config/seata-config-nacos/src/main/java/io/seata/config/nacos/NacosConfiguration.java
@@ -245,7 +245,7 @@ public class NacosConfiguration extends AbstractConfiguration {
                 }
             }
         }
-        String contextPath = StringUtils.isNotBlank(System.getProperty(CONTEXT_PATH)) ? System.getProperty(CONTEXT_PATH) : FILE_CONFIG.getConfig(getNacosContextPath());
+        String contextPath = StringUtils.isNotBlank(System.getProperty(CONTEXT_PATH)) ? System.getProperty(CONTEXT_PATH) : FILE_CONFIG.getConfig(getNacosContextPathKey());
         if (StringUtils.isNotBlank(contextPath)) {
             properties.setProperty(CONTEXT_PATH, contextPath);
         }
@@ -311,7 +311,7 @@ public class NacosConfiguration extends AbstractConfiguration {
         return sb.toString();
     }
 
-    private static String getNacosContextPath() {
+    private static String getNacosContextPathKey() {
         return String.join(ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR, ConfigurationKeys.FILE_ROOT_CONFIG, CONFIG_TYPE, CONTEXT_PATH);
     }
 

--- a/config/seata-config-nacos/src/main/java/io/seata/config/nacos/NacosConfiguration.java
+++ b/config/seata-config-nacos/src/main/java/io/seata/config/nacos/NacosConfiguration.java
@@ -27,7 +27,6 @@ import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.listener.AbstractSharedListener;
 import com.alibaba.nacos.api.exception.NacosException;
-
 import io.seata.common.exception.NotSupportYetException;
 import io.seata.common.util.CollectionUtils;
 import io.seata.common.util.StringUtils;
@@ -46,6 +45,7 @@ import org.slf4j.LoggerFactory;
  * The type Nacos configuration.
  *
  * @author slievrly
+ * @author xingfudeshi@gmail.com
  */
 public class NacosConfiguration extends AbstractConfiguration {
     private static volatile NacosConfiguration instance;
@@ -64,6 +64,7 @@ public class NacosConfiguration extends AbstractConfiguration {
     private static final String ACCESS_KEY = "accessKey";
     private static final String SECRET_KEY = "secretKey";
     private static final String USE_PARSE_RULE = "false";
+    private static final String CONTEXT_PATH = "contextPath";
     private static final Configuration FILE_CONFIG = ConfigurationFactory.CURRENT_FILE_INSTANCE;
     private static volatile ConfigService configService;
     private static final int MAP_INITIAL_CAPACITY = 8;
@@ -244,6 +245,10 @@ public class NacosConfiguration extends AbstractConfiguration {
                 }
             }
         }
+        String contextPath = StringUtils.isNotBlank(System.getProperty(CONTEXT_PATH)) ? System.getProperty(CONTEXT_PATH) : FILE_CONFIG.getConfig(getNacosContextPath());
+        if (StringUtils.isNotBlank(contextPath)) {
+            properties.setProperty(CONTEXT_PATH, contextPath);
+        }
         return properties;
     }
 
@@ -304,6 +309,10 @@ public class NacosConfiguration extends AbstractConfiguration {
         }
 
         return sb.toString();
+    }
+
+    private static String getNacosContextPath() {
+        return String.join(ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR, ConfigurationKeys.FILE_ROOT_CONFIG, CONFIG_TYPE, CONTEXT_PATH);
     }
 
     private static void initSeataConfig() {

--- a/config/seata-config-nacos/src/test/java/io/seata/config/nacos/NacosConfigurationTest.java
+++ b/config/seata-config-nacos/src/test/java/io/seata/config/nacos/NacosConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.config.nacos;
+
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+import io.seata.common.util.ReflectionUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * The type Nacos configuration test
+ *
+ * @author xingfudeshi@gmail.com
+ */
+public class NacosConfigurationTest {
+
+    @Test
+    public void testGetConfigProperties() throws Exception {
+        Method method = ReflectionUtil.getMethod(NacosConfiguration.class, "getConfigProperties");
+        Properties properties = (Properties) ReflectionUtil.invokeMethod(null, method);
+        Assertions.assertThat(properties.getProperty("contextPath")).isEqualTo("/bar");
+        System.setProperty("contextPath", "/foo");
+        properties = (Properties) ReflectionUtil.invokeMethod(null, method);
+        Assertions.assertThat(properties.getProperty("contextPath")).isEqualTo("/foo");
+    }
+
+
+}

--- a/config/seata-config-nacos/src/test/resources/registry.conf
+++ b/config/seata-config-nacos/src/test/resources/registry.conf
@@ -1,0 +1,117 @@
+#  Copyright 1999-2019 Seata.io Group.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+registry {
+  # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa、custom
+  type = "nacos"
+
+  nacos {
+    application = "seata-server"
+    serverAddr = "127.0.0.1:8848"
+    group = "SEATA_GROUP"
+    namespace = ""
+    username = ""
+    password = ""
+    contextPath = "/foo"
+    ##if use MSE Nacos with auth, mutex with username/password attribute
+    #accessKey = ""
+    #secretKey = ""
+    ##if use Nacos naming meta-data for SLB service registry, specify nacos address pattern rules here
+    #slbPattern = ""
+  }
+  eureka {
+    serviceUrl = "http://localhost:8761/eureka"
+    weight = "1"
+  }
+  redis {
+    serverAddr = "localhost:6379"
+    db = "0"
+    password = ""
+    timeout = "0"
+  }
+  zk {
+    serverAddr = "127.0.0.1:2181"
+    sessionTimeout = 6000
+    connectTimeout = 2000
+    username = ""
+    password = ""
+  }
+  consul {
+    serverAddr = "127.0.0.1:8500"
+    aclToken = ""
+  }
+  etcd3 {
+    serverAddr = "http://localhost:2379"
+  }
+  sofa {
+    serverAddr = "127.0.0.1:9603"
+    region = "DEFAULT_ZONE"
+    datacenter = "DefaultDataCenter"
+    group = "SEATA_GROUP"
+    addressWaitTime = "3000"
+  }
+  file {
+    name = "file.conf"
+  }
+  custom {
+    name = ""
+  }
+}
+
+config {
+  # file、nacos 、apollo、zk、consul、etcd3、springCloudConfig、custom
+  type = "file"
+
+  nacos {
+    serverAddr = "127.0.0.1:8848"
+    namespace = ""
+    group = "SEATA_GROUP"
+    username = ""
+    password = ""
+    contextPath = "/bar"
+    ##if use MSE Nacos with auth, mutex with username/password attribute
+    #accessKey = ""
+    #secretKey = ""
+    dataId = "seata.properties"
+  }
+  consul {
+    serverAddr = "127.0.0.1:8500"
+	key = "seata.properties"
+    aclToken = ""
+  }
+  apollo {
+    appId = "seata-server"
+    apolloMeta = "http://192.168.1.204:8801"
+    namespace = "application"
+    apolloAccesskeySecret = ""
+  }
+  zk {
+    serverAddr = "127.0.0.1:2181"
+    sessionTimeout = 6000
+    connectTimeout = 2000
+    username = ""
+    password = ""
+    nodePath = "/seata/seata.properties"
+  }
+  etcd3 {
+    serverAddr = "http://localhost:2379"
+    key = "seata.properties"
+  }
+  file {
+    name = "file.conf"
+  }
+  custom {
+    name = ""
+  }
+}

--- a/discovery/seata-discovery-nacos/src/main/java/io/seata/discovery/registry/nacos/NacosRegistryServiceImpl.java
+++ b/discovery/seata-discovery-nacos/src/main/java/io/seata/discovery/registry/nacos/NacosRegistryServiceImpl.java
@@ -269,7 +269,7 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
                 }
             }
         }
-        String contextPath = StringUtils.isNotBlank(System.getProperty(CONTEXT_PATH)) ? System.getProperty(CONTEXT_PATH) : FILE_CONFIG.getConfig(getNacosContextPath());
+        String contextPath = StringUtils.isNotBlank(System.getProperty(CONTEXT_PATH)) ? System.getProperty(CONTEXT_PATH) : FILE_CONFIG.getConfig(getNacosContextPathKey());
         if (StringUtils.isNotBlank(contextPath)) {
             properties.setProperty(CONTEXT_PATH, contextPath);
         }
@@ -328,7 +328,7 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
         return String.join(ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR, ConfigurationKeys.FILE_ROOT_REGISTRY, REGISTRY_TYPE, SLB_PATTERN);
     }
 
-    private static String getNacosContextPath() {
+    private static String getNacosContextPathKey() {
         return String.join(ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR, ConfigurationKeys.FILE_ROOT_REGISTRY, REGISTRY_TYPE, CONTEXT_PATH);
     }
 

--- a/discovery/seata-discovery-nacos/src/main/java/io/seata/discovery/registry/nacos/NacosRegistryServiceImpl.java
+++ b/discovery/seata-discovery-nacos/src/main/java/io/seata/discovery/registry/nacos/NacosRegistryServiceImpl.java
@@ -32,7 +32,6 @@ import com.alibaba.nacos.api.naming.listener.EventListener;
 import com.alibaba.nacos.api.naming.listener.NamingEvent;
 import com.alibaba.nacos.api.naming.pojo.Instance;
 import com.alibaba.nacos.api.naming.pojo.Service;
-
 import io.seata.common.util.CollectionUtils;
 import io.seata.common.util.NetUtil;
 import io.seata.common.util.StringUtils;
@@ -48,6 +47,7 @@ import org.slf4j.LoggerFactory;
  * The type Nacos registry service.
  *
  * @author slievrly
+ * @author xingfudeshi@gmail.com
  */
 public class NacosRegistryServiceImpl implements RegistryService<EventListener> {
 
@@ -67,6 +67,7 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
     private static final String ACCESS_KEY = "accessKey";
     private static final String SECRET_KEY = "secretKey";
     private static final String SLB_PATTERN = "slbPattern";
+    private static final String CONTEXT_PATH = "contextPath";
     private static final String USE_PARSE_RULE = "false";
     private static final String PUBLIC_NAMING_ADDRESS_PREFIX = "public_";
     private static final String PUBLIC_NAMING_SERVICE_META_IP_KEY = "publicIp";
@@ -268,6 +269,10 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
                 }
             }
         }
+        String contextPath = StringUtils.isNotBlank(System.getProperty(CONTEXT_PATH)) ? System.getProperty(CONTEXT_PATH) : FILE_CONFIG.getConfig(getNacosContextPath());
+        if (StringUtils.isNotBlank(contextPath)) {
+            properties.setProperty(CONTEXT_PATH, contextPath);
+        }
         return properties;
     }
 
@@ -321,6 +326,10 @@ public class NacosRegistryServiceImpl implements RegistryService<EventListener> 
 
     private static String getNacosUrlPatternOfSLB() {
         return String.join(ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR, ConfigurationKeys.FILE_ROOT_REGISTRY, REGISTRY_TYPE, SLB_PATTERN);
+    }
+
+    private static String getNacosContextPath() {
+        return String.join(ConfigurationKeys.FILE_CONFIG_SPLIT_CHAR, ConfigurationKeys.FILE_ROOT_REGISTRY, REGISTRY_TYPE, CONTEXT_PATH);
     }
 
 }

--- a/discovery/seata-discovery-nacos/src/test/java/io/seata/config/nacos/NacosRegistryServiceImplTest.java
+++ b/discovery/seata-discovery-nacos/src/test/java/io/seata/config/nacos/NacosRegistryServiceImplTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 1999-2019 Seata.io Group.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.seata.config.nacos;
+
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+import io.seata.common.util.ReflectionUtil;
+import io.seata.discovery.registry.nacos.NacosRegistryServiceImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * The type Nacos registry serivce impl test
+ *
+ * @author xingfudeshi@gmail.com
+ */
+public class NacosRegistryServiceImplTest {
+
+    @Test
+    public void testGetConfigProperties() throws Exception {
+        Method method = ReflectionUtil.getMethod(NacosRegistryServiceImpl.class, "getNamingProperties");
+        Properties properties = (Properties) ReflectionUtil.invokeMethod(null, method);
+        Assertions.assertThat(properties.getProperty("contextPath")).isEqualTo("/foo");
+        System.setProperty("contextPath", "/bar");
+        properties = (Properties) ReflectionUtil.invokeMethod(null, method);
+        Assertions.assertThat(properties.getProperty("contextPath")).isEqualTo("/bar");
+    }
+
+
+}

--- a/discovery/seata-discovery-nacos/src/test/resources/registry.conf
+++ b/discovery/seata-discovery-nacos/src/test/resources/registry.conf
@@ -1,0 +1,117 @@
+#  Copyright 1999-2019 Seata.io Group.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+registry {
+  # file 、nacos 、eureka、redis、zk、consul、etcd3、sofa、custom
+  type = "nacos"
+
+  nacos {
+    application = "seata-server"
+    serverAddr = "127.0.0.1:8848"
+    group = "SEATA_GROUP"
+    namespace = ""
+    username = ""
+    password = ""
+    contextPath = "/foo"
+    ##if use MSE Nacos with auth, mutex with username/password attribute
+    #accessKey = ""
+    #secretKey = ""
+    ##if use Nacos naming meta-data for SLB service registry, specify nacos address pattern rules here
+    #slbPattern = ""
+  }
+  eureka {
+    serviceUrl = "http://localhost:8761/eureka"
+    weight = "1"
+  }
+  redis {
+    serverAddr = "localhost:6379"
+    db = "0"
+    password = ""
+    timeout = "0"
+  }
+  zk {
+    serverAddr = "127.0.0.1:2181"
+    sessionTimeout = 6000
+    connectTimeout = 2000
+    username = ""
+    password = ""
+  }
+  consul {
+    serverAddr = "127.0.0.1:8500"
+    aclToken = ""
+  }
+  etcd3 {
+    serverAddr = "http://localhost:2379"
+  }
+  sofa {
+    serverAddr = "127.0.0.1:9603"
+    region = "DEFAULT_ZONE"
+    datacenter = "DefaultDataCenter"
+    group = "SEATA_GROUP"
+    addressWaitTime = "3000"
+  }
+  file {
+    name = "file.conf"
+  }
+  custom {
+    name = ""
+  }
+}
+
+config {
+  # file、nacos 、apollo、zk、consul、etcd3、springCloudConfig、custom
+  type = "file"
+
+  nacos {
+    serverAddr = "127.0.0.1:8848"
+    namespace = ""
+    group = "SEATA_GROUP"
+    username = ""
+    password = ""
+    contextPath = "/bar"
+    ##if use MSE Nacos with auth, mutex with username/password attribute
+    #accessKey = ""
+    #secretKey = ""
+    dataId = "seata.properties"
+  }
+  consul {
+    serverAddr = "127.0.0.1:8500"
+	key = "seata.properties"
+    aclToken = ""
+  }
+  apollo {
+    appId = "seata-server"
+    apolloMeta = "http://192.168.1.204:8801"
+    namespace = "application"
+    apolloAccesskeySecret = ""
+  }
+  zk {
+    serverAddr = "127.0.0.1:2181"
+    sessionTimeout = 6000
+    connectTimeout = 2000
+    username = ""
+    password = ""
+    nodePath = "/seata/seata.properties"
+  }
+  etcd3 {
+    serverAddr = "http://localhost:2379"
+    key = "seata.properties"
+  }
+  file {
+    name = "file.conf"
+  }
+  custom {
+    name = ""
+  }
+}

--- a/script/client/conf/registry.conf
+++ b/script/client/conf/registry.conf
@@ -23,6 +23,7 @@ registry {
     namespace = ""
     username = ""
     password = ""
+    contextPath = ""
     ##if use MSE Nacos with auth, mutex with username/password attribute
     #accessKey = ""
     #secretKey = ""
@@ -78,6 +79,7 @@ config {
     group = "SEATA_GROUP"
     username = ""
     password = ""
+    contextPath = ""
     ##if use MSE Nacos with auth, mutex with username/password attribute
     #accessKey = ""
     #secretKey = ""

--- a/script/client/spring/application.properties
+++ b/script/client/spring/application.properties
@@ -98,6 +98,7 @@ seata.config.nacos.server-addr=127.0.0.1:8848
 seata.config.nacos.group=SEATA_GROUP
 seata.config.nacos.username=
 seata.config.nacos.password=
+seata.config.nacos.contextPath=
 ##if use MSE Nacos with auth, mutex with username/password attribute
 #seata.config.nacos.access-key=
 #seata.config.nacos.secret-key=
@@ -127,6 +128,7 @@ seata.registry.nacos.group=SEATA_GROUP
 seata.registry.nacos.namespace=
 seata.registry.nacos.username=
 seata.registry.nacos.password=
+seata.registry.nacos.contextPath=
 ##if use MSE Nacos with auth, mutex with username/password attribute
 #seata.registry.nacos.access-key=
 #seata.registry.nacos.secret-key=

--- a/script/client/spring/application.yml
+++ b/script/client/spring/application.yml
@@ -92,6 +92,7 @@ seata:
       group: SEATA_GROUP
       username: ""
       password: ""
+      context-path: ""
       ##if use MSE Nacos with auth, mutex with username/password attribute
       #access-key: ""
       #secret-key: ""
@@ -124,6 +125,7 @@ seata:
       namespace: ""
       username: ""
       password: ""
+      context-path: ""
       ##if use MSE Nacos with auth, mutex with username/password attribute
       #access-key: ""
       #secret-key: ""

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/io/seata/spring/boot/autoconfigure/properties/config/ConfigNacosProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/io/seata/spring/boot/autoconfigure/properties/config/ConfigNacosProperties.java
@@ -34,6 +34,7 @@ public class ConfigNacosProperties {
     private String accessKey = "";
     private String secretKey = "";
     private String dataId = "seata.properties";
+    private String contextPath = "";
 
     public String getServerAddr() {
         return serverAddr;
@@ -104,6 +105,15 @@ public class ConfigNacosProperties {
 
     public ConfigNacosProperties setSecretKey(String secretKey) {
         this.secretKey = secretKey;
+        return this;
+    }
+
+    public String getContextPath() {
+        return contextPath;
+    }
+
+    public ConfigNacosProperties setContextPath(String contextPath) {
+        this.contextPath = contextPath;
         return this;
     }
 }

--- a/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/io/seata/spring/boot/autoconfigure/properties/registry/RegistryNacosProperties.java
+++ b/seata-spring-autoconfigure/seata-spring-autoconfigure-core/src/main/java/io/seata/spring/boot/autoconfigure/properties/registry/RegistryNacosProperties.java
@@ -36,6 +36,7 @@ public class RegistryNacosProperties {
     private String secretKey = "";
     private String application = "seata-server";
     private String slbPattern = "";
+    private String contextPath = "";
 
     public String getServerAddr() {
         return serverAddr;
@@ -126,4 +127,12 @@ public class RegistryNacosProperties {
         return this;
     }
 
+    public String getContextPath() {
+        return contextPath;
+    }
+
+    public RegistryNacosProperties setContextPath(String contextPath) {
+        this.contextPath = contextPath;
+        return this;
+    }
 }

--- a/server/src/main/resources/application.example.yml
+++ b/server/src/main/resources/application.example.yml
@@ -40,6 +40,7 @@ seata:
       group: SEATA_GROUP
       username:
       password:
+      context-path:
       ##if use MSE Nacos with auth, mutex with username/password attribute
       #access-key: ""
       #secret-key: ""
@@ -77,6 +78,7 @@ seata:
       cluster: default
       username:
       password:
+      context-path:
       ##if use MSE Nacos with auth, mutex with username/password attribute
       #access-key: ""
       #secret-key: ""


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
Support passing contextPath parameter to Nacos client

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #5110 #5012

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
I provided  some screenshots of the test

### Ⅳ. Describe how to verify it
Use nacos as discovery center and config center,and set the value of contextPath.

### Ⅴ. Special notes for reviews
<img width="450" alt="image" src="https://user-images.githubusercontent.com/24457941/204975819-711c6b42-45aa-4914-b23f-f261774e34c3.png">
<img width="770" alt="image" src="https://user-images.githubusercontent.com/24457941/204975938-6a386c37-3455-4dc6-a6f8-a859cd7a88af.png">
<img width="794" alt="image" src="https://user-images.githubusercontent.com/24457941/204976027-e8b43a09-04ea-44a9-be1d-a0d75b9dc300.png">

