### PR TITLE
optimize: support oracle on delete tccfence logs 

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -74,6 +74,7 @@ Add changes here for all PR submitted to the develop branch.
 - [[#5051](https://github.com/seata/seata/pull/5051)] undo log dirty throw BranchRollbackFailed_Unretriable
 - [[#5075](https://github.com/seata/seata/pull/5075)] intercept the InsertOnDuplicateUpdate statement which has no primary key and unique index value
 - [[#5104](https://github.com/seata/seata/pull/5104)] remove the druid dependency in ConnectionProxy
+- [[#5124](https://github.com/seata/seata/pull/5124)] optimize : support oracle on delete tccfence logs
 
 
 ### test:

--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -74,7 +74,7 @@ Add changes here for all PR submitted to the develop branch.
 - [[#5051](https://github.com/seata/seata/pull/5051)] undo log dirty throw BranchRollbackFailed_Unretriable
 - [[#5075](https://github.com/seata/seata/pull/5075)] intercept the InsertOnDuplicateUpdate statement which has no primary key and unique index value
 - [[#5104](https://github.com/seata/seata/pull/5104)] remove the druid dependency in ConnectionProxy
-- [[#5124](https://github.com/seata/seata/pull/5124)] optimize : support oracle on delete tccfence logs
+- [[#5124](https://github.com/seata/seata/pull/5124)] support oracle on delete tccfence logs
 
 
 ### test:

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -73,6 +73,7 @@
 - [[#5051](https://github.com/seata/seata/pull/5051)] 回滚时undolog产生脏写需要抛出不再重试(BranchRollbackFailed_Unretriable)的异常
 - [[#5075](https://github.com/seata/seata/pull/5075)] 拦截没有主键及唯一索引值的insert on duplicate update语句
 - [[#5104](https://github.com/seata/seata/pull/5104)] ConnectionProxy脱离对druid的依赖
+- [[#5124](https://github.com/seata/seata/pull/5124)] 支持oracle删除tccfence记录表
 
 ### test：
 - [[#4411](https://github.com/seata/seata/pull/4411)] 测试Oracle数据库AT模式下类型支持

--- a/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
@@ -321,8 +321,8 @@ public class TCCFenceHandler {
 
     private static boolean isOracle(Connection connection) {
         try {
-            String driverName = connection.getMetaData().getDriverName();
-            return driverName.toUpperCase().contains("ORACLE");
+            String url = connection.getMetaData().getURL();
+            return url.toLowerCase().contains(":oracle:");
         } catch (SQLException e) {
             LOGGER.error("get db type fail", e);
         }

--- a/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
@@ -17,6 +17,7 @@ package io.seata.rm.tcc;
 
 import java.lang.reflect.Method;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Set;
@@ -294,6 +295,12 @@ public class TCCFenceHandler {
         int total = 0;
         try {
             connection = DataSourceUtils.getConnection(dataSource);
+            if(isOracle(connection)){
+                //delete by date if DB is oracle
+                return TCC_FENCE_DAO.deleteTCCFenceDOByDate(connection, datetime);
+            }
+
+            //delete by id if DB is not oracle
             while (true) {
                 Set<String> xidSet = TCC_FENCE_DAO.queryEndStatusXidsByDate(connection, datetime, LIMIT_DELETE);
                 if (xidSet.isEmpty()) {
@@ -310,6 +317,16 @@ public class TCCFenceHandler {
         }
         return total;
 
+    }
+
+    private static boolean isOracle(Connection connection) {
+        try {
+            String driverName = connection.getMetaData().getDriverName();
+            return driverName.toUpperCase().contains("ORACLE");
+        } catch (SQLException e) {
+            LOGGER.error("get db type fail",e);
+        }
+        return false;
     }
 
     private static void initLogCleanExecutor() {

--- a/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/TCCFenceHandler.java
@@ -295,8 +295,8 @@ public class TCCFenceHandler {
         int total = 0;
         try {
             connection = DataSourceUtils.getConnection(dataSource);
-            if(isOracle(connection)){
-                //delete by date if DB is oracle
+            if (isOracle(connection)) {
+                // delete by date if DB is oracle
                 return TCC_FENCE_DAO.deleteTCCFenceDOByDate(connection, datetime);
             }
 
@@ -324,7 +324,7 @@ public class TCCFenceHandler {
             String driverName = connection.getMetaData().getDriverName();
             return driverName.toUpperCase().contains("ORACLE");
         } catch (SQLException e) {
-            LOGGER.error("get db type fail",e);
+            LOGGER.error("get db type fail", e);
         }
         return false;
     }

--- a/tcc/src/main/java/io/seata/rm/tcc/store/TCCFenceStore.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/store/TCCFenceStore.java
@@ -85,10 +85,10 @@ public interface TCCFenceStore {
      * Delete tcc fence by datetime.
      * @param conn the connection
      * @param datetime datetime
-     * @param limit limit
      * @return the deleted row count
      */
-    int deleteTCCFenceDOByDate(Connection conn, Date datetime, int limit);
+    int deleteTCCFenceDOByDate(Connection conn, Date datetime);
+
 
     /**
      * Set LogTable Name

--- a/tcc/src/main/java/io/seata/rm/tcc/store/db/TCCFenceStoreDataBaseDAO.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/store/db/TCCFenceStoreDataBaseDAO.java
@@ -192,13 +192,12 @@ public class TCCFenceStoreDataBaseDAO implements TCCFenceStore {
     }
 
     @Override
-    public int deleteTCCFenceDOByDate(Connection conn, Date datetime, int limit) {
+    public int deleteTCCFenceDOByDate(Connection conn, Date datetime) {
         PreparedStatement ps = null;
         try {
             String sql = TCCFenceStoreSqls.getDeleteSQLByDateAndStatus(logTableName);
             ps = conn.prepareStatement(sql);
             ps.setTimestamp(1, new Timestamp(datetime.getTime()));
-            ps.setInt(2, limit);
             return ps.executeUpdate();
         } catch (SQLException e) {
             throw new StoreException(e);

--- a/tcc/src/main/java/io/seata/rm/tcc/store/db/sql/TCCFenceStoreSqls.java
+++ b/tcc/src/main/java/io/seata/rm/tcc/store/db/sql/TCCFenceStoreSqls.java
@@ -84,8 +84,7 @@ public class TCCFenceStoreSqls {
      */
     protected static final String DELETE_BY_DATE_AND_STATUS = "delete from " + LOCAL_TCC_LOG_PLACEHOLD
             + " where gmt_modified < ? "
-            + " and status in (" + TCCFenceConstant.STATUS_COMMITTED + " , " + TCCFenceConstant.STATUS_ROLLBACKED + " , " + TCCFenceConstant.STATUS_SUSPENDED + ")"
-            + " limit ?";
+            + " and status in (" + TCCFenceConstant.STATUS_COMMITTED + " , " + TCCFenceConstant.STATUS_ROLLBACKED + " , " + TCCFenceConstant.STATUS_SUSPENDED + ")";
 
     public static String getInsertLocalTCCLogSQL(String localTccTable) {
         return INSERT_LOCAL_TCC_LOG.replace(LOCAL_TCC_LOG_PLACEHOLD, localTccTable);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
支持oracle删除tccfence log。
在https://github.com/seata/seata/pull/4490 这个pr中对删除tccfence进行了优化，但是没考虑oracle的情况，所以用这个pr先支持oracle的删除。

特别说明：在4490pr里面新增了 query-by-date和delete-by-id之后，TCCFenceStoreDataBaseDAO .deleteTCCFenceDOByDate这个方法其实已经没有在使用，但由于初版的设计里对他也有改动，当时的pr里把deleteTCCFenceDOByDate里涉及的SQL语句和参数也增加了limit。这次把deleteTCCFenceDOByDate方法回滚还原回原来的样子直接支持oracle删除，而mysql等其他数据库由于不再使用这个dao方法也不会受影响。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/seata/seata/issues/5123

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

