### PR TITLE
bugfix: fix ClassNotFoundException caused when server starts when using Eureka

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -363,10 +363,6 @@
                         <groupId>javax.servlet</groupId>
                         <artifactId>servlet-api</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>com.github.andrewoma.dexx</groupId>
-                        <artifactId>dexx-collections</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
bugfix: fix issue#5174 , when seata.registry.type is eureka, ClassNotFoundException is reported after seata-server startup

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
bugfix: fix issue#5174 , when seata.registry.type is eureka, ClassNotFoundException is reported after seata-server startup

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #5174 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
When seata.registry.type is eureka, you can update pom.xml , then start seata-server for verify.


### Ⅳ. Describe how to verify it
update pom.xml ,then start seata-server for verify it

### Ⅴ. Special notes for reviews

