### PR TITLE
bugfix: wrong keyword order for oracle when creating a table

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -7,6 +7,7 @@ Add changes here for all PR submitted to the develop branch.
 
 ### bugfix:
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] fix xxx
+- [[#5194](https://github.com/seata/seata/pull/5194)] fix wrong keyword order for oracle when creating a table
 
 ### optimize:
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] optimize xxx
@@ -18,5 +19,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 <!-- Please make sure your Github ID is in the list below -->
 - [slievrly](https://github.com/slievrly)
+- [xssdpgy](https://github.com/xssdpgy)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -7,6 +7,7 @@
 
 ### bugfix:
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] 修复 xxx
+- [[#5194](https://github.com/seata/seata/pull/5194)] 修复使用Oracle作为服务端DB存储时的建表失败问题
 
 ### optimize:
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] 优化 xxx
@@ -18,5 +19,6 @@
 
 <!-- 请确保您的 GitHub ID 在以下列表中 -->
 - [slievrly](https://github.com/slievrly)
+- [xssdpgy](https://github.com/xssdpgy)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -363,10 +363,6 @@
                         <groupId>javax.servlet</groupId>
                         <artifactId>servlet-api</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>com.github.andrewoma.dexx</groupId>
-                        <artifactId>dexx-collections</artifactId>
-                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/script/server/db/oracle.sql
+++ b/script/server/db/oracle.sql
@@ -48,7 +48,7 @@ CREATE TABLE lock_table
     resource_id    VARCHAR2(256),
     table_name     VARCHAR2(32),
     pk             VARCHAR2(36),
-    status         NUMBER(3)     NOT NULL DEFAULT 0,
+    status         NUMBER(3)   DEFAULT 0 NOT NULL,
     gmt_create     TIMESTAMP(0),
     gmt_modified   TIMESTAMP(0),
     PRIMARY KEY (row_key)


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
when create table 'lock_table' in Oracle, will report 'ORA-00907: missing right parenthesis'，because the DDL(field:status) has a worong keyword order in oracle, and DB will check it.
![image](https://user-images.githubusercontent.com/25602243/209111005-ab5c3ef3-001d-4052-bd12-734be790839c.png)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

