### PR TITLE
optimize：adjust too short length(possible error) of table field 'lock_table.row_key'

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -11,6 +11,7 @@ Add changes here for all PR submitted to the develop branch.
 
 ### optimize:
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] optimize xxx
+- [[#5196](https://github.com/seata/seata/pull/5196)] optimize too short length of table field lock_table.row_key
 
 ### test:
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] add test for xxx

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -11,6 +11,7 @@
 
 ### optimize:
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] 优化 xxx
+- [[#5196](https://github.com/seata/seata/pull/5196)] 调整过短的lock_table.row_key表字段长度
 
 ### test:
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] 增加 xxx 测试

--- a/script/server/db/mysql.sql
+++ b/script/server/db/mysql.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS `branch_table`
 -- the table to store lock data
 CREATE TABLE IF NOT EXISTS `lock_table`
 (
-    `row_key`        VARCHAR(128) NOT NULL,
+    `row_key`        VARCHAR(330) NOT NULL,
     `xid`            VARCHAR(128),
     `transaction_id` BIGINT,
     `branch_id`      BIGINT       NOT NULL,

--- a/script/server/db/oracle.sql
+++ b/script/server/db/oracle.sql
@@ -41,7 +41,7 @@ CREATE INDEX idx_xid ON branch_table (xid);
 -- the table to store lock data
 CREATE TABLE lock_table
 (
-    row_key        VARCHAR2(128) NOT NULL,
+    row_key        VARCHAR2(330) NOT NULL,
     xid            VARCHAR2(128),
     transaction_id NUMBER(19),
     branch_id      NUMBER(19)    NOT NULL,

--- a/script/server/db/postgresql.sql
+++ b/script/server/db/postgresql.sql
@@ -41,7 +41,7 @@ CREATE INDEX idx_xid ON public.branch_table (xid);
 -- the table to store lock data
 CREATE TABLE IF NOT EXISTS public.lock_table
 (
-    row_key        VARCHAR(128) NOT NULL,
+    row_key        VARCHAR(330) NOT NULL,
     xid            VARCHAR(128),
     transaction_id BIGINT,
     branch_id      BIGINT       NOT NULL,


### PR DESCRIPTION
optimize(maybe bugfix)：adjust too short length(possible error) of table field 'lock_table.row_key'

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
adjust length of table field 'lock_table.row_key',
according to the method 'io.seata.core.lock.AbstractLocker#convertToLockDO(io.seata.core.lock.RowLock)', the field 'lock_table.row_key' is union by 'lock_table.resource_id','lock_table.table_name' and 'lock_table.pk'，
![image](https://user-images.githubusercontent.com/25602243/209431098-0a102868-3253-4e89-8a9f-6d55c85ee9da.png)
but the length setting of field 'lock_table.row_key' is too short ,so when insert into ‘lock_table’  and the length sum of the other three fields beyond  'VARCHAR(128)', error will occur.
![image](https://user-images.githubusercontent.com/25602243/209431913-7eca3bb4-12b2-40a2-966e-bab62787aad6.png)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

