### PR TITLE
bugfix: oracle initialize script index_name is duplicate

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -8,6 +8,7 @@ Add changes here for all PR submitted to the develop branch.
 ### bugfix:
 - [[#5194](https://github.com/seata/seata/pull/5194)] fix wrong keyword order for oracle when creating a table
 - [[#5021](https://github.com/seata/seata/pull/5201)] Fix JDK Reflection for Spring origin proxy failed in JDK17
+- [[#5224](https://github.com/seata/seata/pull/5224)] fix oracle initialize script index_name is duplicate 
 
 ### optimize:
 - [[#5212](https://github.com/seata/seata/pull/5212)] optimize log message level
@@ -21,5 +22,6 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [slievrly](https://github.com/slievrly)
 - [xssdpgy](https://github.com/xssdpgy)
 - [albumenj](https://github.com/albumenj)
+- [PeppaO](https://github.com/PeppaO)
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -9,6 +9,7 @@
 - [[#xxx](https://github.com/seata/seata/pull/xxx)] 修复 xxx
 - [[#5194](https://github.com/seata/seata/pull/5194)] 修复使用Oracle作为服务端DB存储时的建表失败问题
 - [[#5021](https://github.com/seata/seata/pull/5201)] 修复 JDK17 下获取 Spring 原始代理对象失败的问题
+- [[#5224](https://github.com/seata/seata/pull/5224)] 修复 oracle初始化脚本索引名重复的问题
 
 ### optimize:
 - [[#5212](https://github.com/seata/seata/pull/5212)] 优化不合理的日志信息级别
@@ -22,5 +23,6 @@
 - [slievrly](https://github.com/slievrly)
 - [xssdpgy](https://github.com/xssdpgy)
 - [albumenj](https://github.com/albumenj)
+- [PeppaO](https://github.com/PeppaO)
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。

--- a/script/server/db/oracle.sql
+++ b/script/server/db/oracle.sql
@@ -56,7 +56,7 @@ CREATE TABLE lock_table
 
 comment on column lock_table.status is '0:locked ,1:rollbacking';
 CREATE INDEX idx_branch_id ON lock_table (branch_id);
-CREATE INDEX idx_xid ON lock_table (xid);
+CREATE INDEX idx_lock_table_xid ON lock_table (xid);
 CREATE INDEX idx_status ON lock_table (status);
 
 CREATE TABLE distributed_lock (


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
修复：oracle.sql脚本执行错误，索引名重复

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

