### PR TITLE
bugfix: fix the incomplete dependency of distribution module

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -11,6 +11,7 @@ Add changes here for all PR submitted to the develop branch.
 - [[#5023](https://github.com/seata/seata/pull/5203)] Fix `seata-core` dependency transitive conflict in `seata-dubbo`
 - [[#5224](https://github.com/seata/seata/pull/5224)] fix oracle initialize script index_name is duplicate 
 - [[#5233](https://github.com/seata/seata/pull/5233)] fix the inconsistent configuration item names related to LoadBalance
+- [[#5245](https://github.com/seata/seata/pull/5245)] fix the incomplete dependency of distribution module
 
 
 

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -11,6 +11,7 @@
 - [[#5023](https://github.com/seata/seata/pull/5203)] 修复 `seata-core` 模块传递依赖冲突
 - [[#5224](https://github.com/seata/seata/pull/5224)] 修复 oracle初始化脚本索引名重复的问题
 - [[#5233](https://github.com/seata/seata/pull/5233)] 修复LoadBalance相关配置不一致的问题
+- [[#5245](https://github.com/seata/seata/pull/5245)] 修复不完整的distribution模块依赖
 
 
 ### optimize:

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -37,6 +37,11 @@
                     <artifactId>seata-server</artifactId>
                     <version>${project.version}</version>
                 </dependency>
+                <dependency>
+                    <groupId>io.seata</groupId>
+                    <artifactId>apm-seata-skywalking-plugin</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
             </dependencies>
             <build>
                 <finalName>seata</finalName>


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
Add apm-seata-skywalking-plugin to the dependency of distribution module，so it can be built before distribution.
The reason is, we have to build ext/apm-skywalking before we move this folder to distribution folder.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix #5245 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
There is no code change.

### Ⅳ. Describe how to verify it
mvn -Prelease-seata -Dmaven.test.skip=true clean install -U
We can see apm-seata-skywalking-plugin build before seata-distribution.
And we can see /ext folder under distribution/target/seata-server-1.6.1/seata
![image](https://user-images.githubusercontent.com/33556050/213714591-962bdae4-2979-4f5d-9197-8ff99652cfdb.png)
![image](https://user-images.githubusercontent.com/33556050/213714845-758e27e5-7837-44e4-b64d-b36b7b11cdb2.png)

### Ⅴ. Special notes for reviews

