### PR TITLE
optimize: fix the problem that protobuf compilation fails（for dev）

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -163,6 +163,11 @@
                     <groupId>org.xolstice.maven.plugins</groupId>
                     <artifactId>protobuf-maven-plugin</artifactId>
                     <version>${protobuf-maven-plugin.version}</version>
+                    <configuration>
+                        <!-- Solve the problem that protobuf compilation fails due to too long command line under the window operating system,
+                        ref: https://www.xolstice.org/protobuf-maven-plugin/usage.html -->
+                        <useArgumentFile>true</useArgumentFile>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>

--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -21,6 +21,7 @@ Add changes here for all PR submitted to the develop branch.
 - [[#5243](https://github.com/seata/seata/pull/5243)] optimize kryo 5.4.0 optimize compatibility with jdk17
 - [[#5153](https://github.com/seata/seata/pull/5153)] Only AT mode try to get channel with other app
 - [[#5177](https://github.com/seata/seata/pull/5177)] If `server.session.enable-branch-async-remove` is true, delete the branch asynchronously and unlock it synchronously.
+- [[#5273](https://github.com/seata/seata/pull/5273)] Optimize the compilation configuration of the `protobuf-maven-plugin` plug-in to solve the problem of too long command lines in higher versions.
 
 ### security:
 - [[#5172](https://github.com/seata/seata/pull/5172)] fix some security vulnerabilities
@@ -41,6 +42,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 - [Bughue](https://github.com/Bughue)
 - [pengten](https://github.com/pengten)
 - [wangliang181230](https://github.com/wangliang181230)
+- [GoodBoyCoder](https://github.com/GoodBoyCoder)
 
 
 Also, we receive many valuable issues, questions and advices from our community. Thanks for you all.

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -21,6 +21,7 @@
 - [[#5243](https://github.com/seata/seata/pull/5243)] 升级 kryo 5.4.0 优化对jdk17的兼容性
 - [[#5153](https://github.com/seata/seata/pull/5153)] 只允许AT去尝试跨RM获取channel
 - [[#5177](https://github.com/seata/seata/pull/5177)] 如果 `server.session.enable-branch-async-remove` 为真，异步删除分支，同步解锁。
+- [[#5273](https://github.com/seata/seata/pull/5273)] 优化`protobuf-maven-plugin`插件的编译配置，解决高版本的命令行过长问题
 
 ### security:
 - [[#5172](https://github.com/seata/seata/pull/5172)] 修复一些安全漏洞的版本
@@ -41,6 +42,7 @@
 - [Bughue](https://github.com/Bughue)
 - [pengten](https://github.com/pengten)
 - [wangliang181230](https://github.com/wangliang181230)
+- [GoodBoyCoder](https://github.com/GoodBoyCoder)
 
 
 同时，我们收到了社区反馈的很多有价值的issue和建议，非常感谢大家。


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
引用高版本的 `protobuf-maven-plugin` 插件时，编译会出现命令行过长导致编译失败（Window x86环境下）
目前添加 `useArgumentFile` 配置项来兼容，配置项说明：
> https://www.xolstice.org/protobuf-maven-plugin/compile-mojo.html
If set to `true`, all command line arguments to protoc will be written to a file, and only a path to that file will be passed to protoc on the command line. This helps prevent Command line is too long errors when the number of .proto files is large.NOTE: This is only supported for protoc 3.5.0 and higher.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
[<useArgumentFile>](https://www.xolstice.org/protobuf-maven-plugin/compile-mojo.html#useArgumentFile)	boolean	0.6.0	If set to true, all command line arguments to protoc will be written to a file, and only a path to that file will be passed to protoc on the command line. This helps prevent Command line is too long errors when the number of .proto files is large.
NOTE: This is only supported for protoc 3.5.0 and higher.
