### PR TITLE
bugfix: don't remove GlobalSession when retry rollback or retry commit timeout 

### DIFF
--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -21,6 +21,8 @@ The version is updated as follows:
   - [[#5266](https://github.com/seata/seata/pull/5265)] fix server console has queried the released lock
   - [[#5282](https://github.com/seata/seata/pull/5282)] parallel request handle throw IndexOutOfBoundsException
   - [[#5294](https://github.com/seata/seata/pull/5294)] fix auto-increment of pk columns in PostgreSQL/Oracle in AT mode
+  - [[#5297](https://github.com/seata/seata/pull/5297)] Correct the comment on MySQLUndoUpdateExecutor#UPDATE_SQL_TEMPLATE
+  - [[#5293](https://github.com/seata/seata/pull/5293)] Do not remove GlobalSession when retry rollback or retry commit timeout
 
 ### optimize：
   - [[#4858](https://github.com/seata/seata/pull/4858)] reorganize the usage of task session manager

--- a/changes/zh-cn/2.0.0.md
+++ b/changes/zh-cn/2.0.0.md
@@ -21,6 +21,8 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
   - [[#5266](https://github.com/seata/seata/pull/5265)] 修复控制台全局锁查询接口查到了已释放的锁
   - [[#5282](https://github.com/seata/seata/pull/5282)] 修复并行rm请求处理时数组索引越界问题
   - [[#5294](https://github.com/seata/seata/pull/5294)] 修复AT模式下pgsql/oracle的主键列自增的问题
+  - [[#5297](https://github.com/seata/seata/pull/5297)] 纠正 MySQLUndoUpdateExecutor#UPDATE_SQL_TEMPLATE 的注释
+  - [[#5293](https://github.com/seata/seata/pull/5293)] 协调器的定时任务中处理全局事务的重试回滚 或 重试提交，即使超时也不再删除事务
 
 ### optimize：
   - [[#4858](https://github.com/seata/seata/pull/4858)] 重构优化 SessionManager 用法

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/undo/mysql/MySQLUndoUpdateExecutor.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/undo/mysql/MySQLUndoUpdateExecutor.java
@@ -37,7 +37,7 @@ import io.seata.sqlparser.util.JdbcConstants;
 public class MySQLUndoUpdateExecutor extends AbstractUndoExecutor {
 
     /**
-     * UPDATE a SET x = ?, y = ?, z = ? WHERE pk1 in (?) pk2 in (?)
+     * UPDATE a SET x = ?, y = ?, z = ? WHERE pk1 =? and pk2 =?
      */
     private static final String UPDATE_SQL_TEMPLATE = "UPDATE %s SET %s WHERE %s ";
 

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
@@ -379,9 +379,6 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
                     if (ROLLBACK_RETRY_TIMEOUT_UNLOCK_ENABLE) {
                         rollbackingSession.clean();
                     }
-                    // Prevent thread safety issues
-                    SessionHolder.getRootSessionManager().removeGlobalSession(rollbackingSession);
-                    LOGGER.error("Global transaction rollback retry timeout and has removed [{}]", rollbackingSession.getXid());
 
                     SessionHelper.endRollbackFailed(rollbackingSession, true, true);
 
@@ -416,9 +413,6 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
                     return;
                 }
                 if (isRetryTimeout(now, MAX_COMMIT_RETRY_TIMEOUT, committingSession.getBeginTime())) {
-                    // Prevent thread safety issues
-                    SessionHolder.getRootSessionManager().removeGlobalSession(committingSession);
-                    LOGGER.error("Global transaction commit retry timeout and has removed [{}]", committingSession.getXid());
 
                     // commit retry timeout event
                     SessionHelper.endCommitFailed(committingSession, true, true);


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

1. Correct the comment on MySQLUndoUpdateExecutor#UPDATE_SQL_TEMPLATE (#5297)
2. https://github.com/seata/seata/issues/5295

### Ⅱ. Does this pull request fix one issue?
fixes #5297
fixes #5295

