### PR TITLE
optimize: add time info for global transaction timeout log

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -31,6 +31,7 @@ Add changes here for all PR submitted to the develop branch.
 - [[#5177](https://github.com/seata/seata/pull/5177)] If `server.session.enable-branch-async-remove` is true, delete the branch asynchronously and unlock it synchronously.
 - [[#5273](https://github.com/seata/seata/pull/5273)] Optimize the compilation configuration of the `protobuf-maven-plugin` plug-in to solve the problem of too long command lines in higher versions.
 - [[#5303](https://github.com/seata/seata/pull/5303)] remove startup script the -Xmn configuration
+- [[#5323](https://github.com/seata/seata/pull/5323)] add time info for global transaction timeout log
 
 ### security:
 - [[#5172](https://github.com/seata/seata/pull/5172)] fix some security vulnerabilities

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -30,6 +30,7 @@
 - [[#5177](https://github.com/seata/seata/pull/5177)] 如果 `server.session.enable-branch-async-remove` 为真，异步删除分支，同步解锁。
 - [[#5273](https://github.com/seata/seata/pull/5273)] 优化`protobuf-maven-plugin`插件的编译配置，解决高版本的命令行过长问题
 - [[#5303](https://github.com/seata/seata/pull/5303)] 移除启动脚本的-Xmn参数
+- [[#5323](https://github.com/seata/seata/pull/5323)] 为全局事务超时日志添加时间信息
 
 ### security:
 - [[#5172](https://github.com/seata/seata/pull/5172)] 修复一些安全漏洞的版本

--- a/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
+++ b/server/src/main/java/io/seata/server/coordinator/DefaultCoordinator.java
@@ -337,7 +337,7 @@ public class DefaultCoordinator extends AbstractTCInboundHandler implements Tran
                     return false;
                 }
 
-                LOGGER.info("Global transaction[{}] is timeout and will be rollback.", globalSession.getXid());
+                LOGGER.warn("Global transaction[{}] is timeout and will be rollback,transaction begin time:{} and now:{}", globalSession.getXid(), globalSession.getBeginTime(), System.currentTimeMillis());
 
                 globalSession.addSessionLifecycleListener(SessionHolder.getRootSessionManager());
                 globalSession.close();


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
在全局事务超时日志中添加全局事务开始时间及发起全局回滚的当前时间，方便用户排查是否应用是否存在异常以及优化相关参数配置
![1675927307(1)](https://user-images.githubusercontent.com/28523136/217744430-e0be4850-85a8-4fda-81e7-6d899a0247ac.png)


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

