### PR TITLE
optimize: upgrade easyj-maven-plugin to 1.1.5 for support maven 3.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,4 +59,5 @@ jobs:
             arm64v8/ubuntu:20.04 \
             bash -exc 'apt-get update -y && \
             apt-get install maven -y && \
+            mvn -version && \
             mvn -Prelease-seata -DskipTests clean install -U'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,24 +7,7 @@ on:
     branches: [ 2.x, develop, master ]
 
 jobs:
-  build_arm64-binary: 
-     runs-on: ubuntu-latest
-     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/2.x') }}
-     strategy:
-      fail-fast: false
-     steps:
-      - uses: actions/checkout@v2
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-      - name: Build arm-binary
-        run: |
-               docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-               arm64v8/ubuntu:20.04 \
-               bash -exc 'apt-get update -y && \
-                apt-get install maven -y && \
-                mvn -Prelease-seata -Dmaven.test.skip=true clean install -U'
-
+  # job 1
   build:
     name: "build"
     runs-on: ubuntu-latest
@@ -36,15 +19,16 @@ jobs:
       # step 1
       - name: "Checkout"
         uses: actions/checkout@v2.4.0
-
       # step 2
       - name: "Set up Java JDK"
         uses: actions/setup-java@v2.5.0
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-
       # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 4
       - name: "Build with Maven"
         run: |
           if [ "${{ matrix.java }}" == "8" ]; then
@@ -52,8 +36,26 @@ jobs:
           elif [ "${{ matrix.java }}" == "11" ]; then
             ./mvnw -T 4C clean test -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
           fi
-
-      # step 4
+      # step 5
       - name: "Codecov"
         if: matrix.java == '8'
         uses: codecov/codecov-action@v2.1.0
+
+  # job 2
+  build_arm64-binary:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/2.x') }}
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+      - name: Build arm-binary
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+            arm64v8/ubuntu:20.04 \
+            bash -exc 'apt-get update -y && \
+            apt-get install maven -y && \
+            mvn -Prelease-seata -Dmaven.test.skip=true clean install -U'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
   # job 2: Test on 'arm64v8/ubuntu' OS.
   build_arm64-binary:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'snapshot' || github.ref_name == '2.x') }}
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
   # job 2: Test on 'arm64v8/ubuntu' OS.
   build_arm64-binary:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'snapshot' || github.ref_name == '2.x') }}
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,15 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up QEMU
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Set up QEMU"
         id: qemu
         uses: docker/setup-qemu-action@v1
-      - name: Build arm-binary
+      - name: "Build arm-binary"
         run: |
           docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
             arm64v8/ubuntu:20.04 \
             bash -exc 'apt-get update -y && \
             apt-get install maven -y && \
-            mvn -Prelease-seata -Dmaven.test.skip=true clean install -U'
+            mvn -Prelease-seata -DskipTests clean install -U'

--- a/.github/workflows/publishes.yml
+++ b/.github/workflows/publishes.yml
@@ -32,7 +32,11 @@ jobs:
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
 
-      # step 3 for type=OSSRH
+      # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+
+      # step 4 for type=OSSRH
       - name: "Import GPG-SECRET-KEY, Package and Publish-To-OSSRH"
         if: matrix.type == 'OSSRH'
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         java: [ 8, 11, 17 ]
         springboot: [
-          2.7.6          -Dspring-framework.version=5.3.24,
+          2.7.9          -Dspring-framework.version=5.3.25,
           2.6.14         -Dspring-framework.version=5.3.24,
           2.5.14         -Dspring-framework.version=5.3.20,
           2.4.13         -Dspring-framework.version=5.3.13,
@@ -61,7 +61,8 @@ jobs:
       matrix:
         java: [ 17 ]
         springboot: [
-          3.0.0 -Dspring-framework.version=6.0.2 -Dspring-boot-for-server.version=2.4.13 -Dspring-framework-for-server.version=5.3.18 -Dkotlin-maven-plugin.version=1.7.22
+          3.0.0 -Dspring-framework.version=6.0.2 -Dspring-boot-for-server.version=2.5.13 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22,
+          3.0.3 -Dspring-framework.version=6.0.5 -Dspring-boot-for-server.version=2.5.13 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22
         ]
     steps:
       # step 1
@@ -88,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         springboot: [
-          2.7.6          -Dspring-framework.version=5.3.24,
+          2.7.9          -Dspring-framework.version=5.3.25,
           2.6.14         -Dspring-framework.version=5.3.24,
           2.5.14         -Dspring-framework.version=5.3.20,
           2.4.13         -Dspring-framework.version=5.3.13,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 4
       - name: "Test with Maven"
         # https://docs.github.com/cn/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#github-context
         run: |
@@ -71,6 +74,9 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 4
       - name: "Test with Maven"
         run: |
           ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=false -Dlicense.skip=false -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
@@ -98,16 +104,19 @@ jobs:
           #1.0.2.RELEASE
         ]
      steps:
-      - uses: actions/checkout@v2
-      - name: Set up QEMU
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      - name: "Set up QEMU"
         id: qemu
         uses: docker/setup-qemu-action@v1
-      - name: install
+      - name: "install"
         run: |
-               docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-               arm64v8/ubuntu:20.04 \
-               bash -exc 'apt-get update -y && \
-                apt-get install maven -y'
-      - name: test-arm64
+          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+            arm64v8/ubuntu:20.04 \
+            bash -exc 'apt-get update -y && \
+            apt-get install maven -y'
+      - name: "Print maven version"
+        run: ./mvnw -version
+      - name: "test-arm64"
         run: |
-            ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          
+          ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         java: [ 17 ]
         springboot: [
-          3.0.3 -Dspring-framework.version=6.0.5 -Dspring-boot-for-server.version=2.5.14 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22
+          3.0.4 -Dspring-framework.version=6.0.6 -Dspring-boot-for-server.version=2.5.14 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22
         ]
     steps:
       # step 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,4 +120,4 @@ jobs:
         run: ./mvnw -version
       - name: "test-arm64"
         run: |
-          ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          
+          ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true -Dlicense.skip=true -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,25 +103,25 @@ jobs:
           #1.1.12.RELEASE,
           #1.0.2.RELEASE
         ]
-      steps:
-        # step 1
-        - name: "Checkout"
-          uses: actions/checkout@v2
-        # step 2
-        - name: "Set up QEMU"
-          id: qemu
-          uses: docker/setup-qemu-action@v1
-        # step 3
-        - name: "install"
-          run: |
-            docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-              arm64v8/ubuntu:20.04 \
-              bash -exc 'apt-get update -y && \
-              apt-get install maven -y'
-        # step 4
-        - name: "Print maven version"
-          run: ./mvnw -version
-        # step 5
-        - name: "test-arm64"
-          run: |
-            ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true -Dlicense.skip=true -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          
+    steps:
+      # step 1
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      # step 2
+      - name: "Set up QEMU"
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+      # step 3
+      - name: "install"
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+            arm64v8/ubuntu:20.04 \
+            bash -exc 'apt-get update -y && \
+            apt-get install maven -y'
+      # step 4
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 5
+      - name: "test-arm64"
+        run: |
+          ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true -Dlicense.skip=true -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,7 @@ jobs:
       matrix:
         java: [ 17 ]
         springboot: [
-          3.0.0 -Dspring-framework.version=6.0.4 -Dspring-boot-for-server.version=2.5.13 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22,
-          3.0.3 -Dspring-framework.version=6.0.5 -Dspring-boot-for-server.version=2.5.13 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22
+          3.0.3 -Dspring-framework.version=6.0.5 -Dspring-boot-for-server.version=2.5.14 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22
         ]
     steps:
       # step 1
@@ -84,8 +83,8 @@ jobs:
 
   # job 3
   arm64-test:
-     runs-on: ubuntu-latest
-     strategy:
+    runs-on: ubuntu-latest
+    strategy:
       fail-fast: false
       matrix:
         springboot: [
@@ -104,20 +103,25 @@ jobs:
           #1.1.12.RELEASE,
           #1.0.2.RELEASE
         ]
-     steps:
-      - name: "Checkout"
-        uses: actions/checkout@v2
-      - name: "Set up QEMU"
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-      - name: "install"
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-            arm64v8/ubuntu:20.04 \
-            bash -exc 'apt-get update -y && \
-            apt-get install maven -y'
-      - name: "Print maven version"
-        run: ./mvnw -version
-      - name: "test-arm64"
-        run: |
-          ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true -Dlicense.skip=true -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          
+      steps:
+        # step 1
+        - name: "Checkout"
+          uses: actions/checkout@v2
+        # step 2
+        - name: "Set up QEMU"
+          id: qemu
+          uses: docker/setup-qemu-action@v1
+        # step 3
+        - name: "install"
+          run: |
+            docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+              arm64v8/ubuntu:20.04 \
+              bash -exc 'apt-get update -y && \
+              apt-get install maven -y'
+        # step 4
+        - name: "Print maven version"
+          run: ./mvnw -version
+        # step 5
+        - name: "test-arm64"
+          run: |
+            ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true -Dlicense.skip=true -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -73,7 +73,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- The version of spring-boot for 'spring-boot-dependencies' and 'spring-boot-maven-plugin' -->
-        <spring-boot.version>2.5.14</spring-boot.version>
+        <spring-boot.version>2.5.13</spring-boot.version>
         <spring-framework.version>5.3.20</spring-framework.version>
 
         <!-- For test -->

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -82,7 +82,7 @@
 
         <!-- Maven plugin versions -->
         <!-- Build -->
-        <easyj-maven-plugin.version>1.1.2</easyj-maven-plugin.version>
+        <easyj-maven-plugin.version>1.1.5</easyj-maven-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <!-- Compiler -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>${maven-source-plugin.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.java.template</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
optimize: upgrade `easyj-maven-plugin` to `1.1.5` for support `maven 3.9.0`, and optimize github actions

由于近期github actions的部分虚拟机使用的是maven 3.9.0，所以要兼容一下。

1. upgrade `easyj-maven-plugin` to `1.1.5` for support `maven 3.9.0`
2. 优化github actions
3. github actions里，添加打印maven版本，用于参考。
