### PR TITLE
optimize: publish images based on java 8/17 and support maven-3.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 4
       - name: "Build with Maven"
         run: |
           if [ "${{ matrix.java }}" == "8" ]; then
@@ -33,29 +36,31 @@ jobs:
           elif [ "${{ matrix.java }}" == "17" ]; then
             ./mvnw -T 4C clean test -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
           fi
-      # step 4
+      # step 5
       - name: "Codecov"
         if: matrix.java == '17'
         uses: codecov/codecov-action@v2.1.0
 
   # job 2: Test on 'arm64v8/ubuntu' OS.
   build_arm64-binary:
-     runs-on: ubuntu-latest
-     if: ${{ github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'snapshot' || github.ref_name == '2.x') }}
-     strategy:
-       fail-fast: false
-     steps:
-       # step 1
-       - uses: actions/checkout@v2
-       # step 2
-       - name: Set up QEMU
-         id: qemu
-         uses: docker/setup-qemu-action@v1
-       # step 3
-       - name: Build arm-binary
-         run: |
-           docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-             arm64v8/ubuntu:20.04 \
-             bash -exc 'apt-get update -y && \
-             apt-get install maven -y && \
-             mvn -Prelease-seata -Dmaven.test.skip=true clean install -U'
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'snapshot' || github.ref_name == '2.x') }}
+    strategy:
+      fail-fast: false
+    steps:
+      # step 1
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      # step 2
+      - name: "Set up QEMU"
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+      # step 3
+      - name: "Build arm-binary"
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+            arm64v8/ubuntu:20.04 \
+            bash -exc 'apt-get update -y && \
+            apt-get install maven -y && \
+            mvn -version && \
+            mvn -Prelease-seata -DskipTests clean install -U'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,53 +7,55 @@ on:
     branches: [ 2.x, develop, master ]
 
 jobs:
-  build_arm64-binary: 
-     runs-on: ubuntu-latest
-     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/2.x') }}
-     strategy:
-      fail-fast: false
-     steps:
-      - uses: actions/checkout@v2
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-      - name: Build arm-binary
-        run: |
-               docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-               arm64v8/ubuntu:20.04 \
-               bash -exc 'apt-get update -y && \
-                apt-get install maven -y && \
-                mvn -Prelease-seata -Dmaven.test.skip=true clean install -U'
-
+  # job 1: Test based on java 8 and 17. Do not checkstyle.
   build:
     name: "build"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11 ]
+        java: [ 8, 17 ]
     steps:
       # step 1
       - name: "Checkout"
         uses: actions/checkout@v2.4.0
-
       # step 2
       - name: "Set up Java JDK"
         uses: actions/setup-java@v2.5.0
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-
       # step 3
       - name: "Build with Maven"
         run: |
           if [ "${{ matrix.java }}" == "8" ]; then
             ./mvnw -T 4C clean test -Dcheckstyle.skip=false -Dlicense.skip=false -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
-          elif [ "${{ matrix.java }}" == "11" ]; then
+          elif [ "${{ matrix.java }}" == "17" ]; then
             ./mvnw -T 4C clean test -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
           fi
-
       # step 4
       - name: "Codecov"
-        if: matrix.java == '8'
+        if: matrix.java == '17'
         uses: codecov/codecov-action@v2.1.0
+
+  # job 2: Test on 'arm64v8/ubuntu' OS.
+  build_arm64-binary:
+     runs-on: ubuntu-latest
+     if: ${{ github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'snapshot' || github.ref_name == '2.x') }}
+     strategy:
+       fail-fast: false
+     steps:
+       # step 1
+       - uses: actions/checkout@v2
+       # step 2
+       - name: Set up QEMU
+         id: qemu
+         uses: docker/setup-qemu-action@v1
+       # step 3
+       - name: Build arm-binary
+         run: |
+           docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+             arm64v8/ubuntu:20.04 \
+             bash -exc 'apt-get update -y && \
+             apt-get install maven -y && \
+             mvn -Prelease-seata -Dmaven.test.skip=true clean install -U'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,6 @@ jobs:
           docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
             arm64v8/ubuntu:20.04 \
             bash -exc 'apt-get update -y && \
-            apt-get install maven -y && \
-            mvn -version && \
-            mvn -Prelease-seata -DskipTests clean install -U'
+                       apt-get install maven -y && \
+                       mvn -version && \
+                       mvn -Prelease-seata -DskipTests clean install -U'

--- a/.github/workflows/publishes.yml
+++ b/.github/workflows/publishes.yml
@@ -10,48 +10,73 @@ on:
     - cron: '0 16 * * *' #GMT+0
 
 jobs:
-  publish:
-    name: "Publish"
+  # job 1
+  publish-to-OSSRH:
+    name: "Publish to OSSRH"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        type: [ "OSSRH", "image" ]
     steps:
       # step 1
       - name: "Checkout"
         uses: actions/checkout@v2.4.0
-
       # step 2
       - name: "Setup Java JDK"
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v3.9.0
         with:
           distribution: 'zulu'
           java-version: 8
           server-id: oss_seata
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
-
-      # step 3 for type=OSSRH
-      - name: "Import GPG-SECRET-KEY, Package and Publish-To-OSSRH"
-        if: matrix.type == 'OSSRH'
+          server-username: OSSRH_USERNAME # Environment variable name for the username for authentication to the Apache Maven repository. Default is $GITHUB_ACTOR
+          server-password: OSSRH_PASSWORD # Environment variable name for password or token for authentication to the Apache Maven repository. Default is $GITHUB_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE # Environment variable name for the GPG private key passphrase. Default is $GPG_PASSPHRASE
+      # step 3
+      - name: "Publish to OSSRH"
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USER }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          cat <(echo -e "${{ secrets.GPG_PRIVATE_KEY }}") | gpg --batch --import;
-          ./mvnw -T 4C clean deploy -Prelease,release-by-github-actions -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          ./mvnw -T 4C clean deploy -Prelease,release-by-github-actions -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
-      # step 4 for type=image
-      - name: "Package and Publish-Image-To-DockerHub"
-        if: matrix.type == 'image'
+  # job 2
+  publish-images-to-dockerhub:
+    name: "Publish images to DockerHub"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 8, 17 ]
+    steps:
+      # step 1
+      - name: "Checkout"
+        uses: actions/checkout@v2.4.0
+      # step 2
+      - name: "Setup Java JDK"
+        uses: actions/setup-java@v3.9.0
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+      # step 3 based on java8
+      - name: "Publish images to DockerHub based on java8"
+        if: matrix.java == 8
         env:
-          IMAGE_NAME: openjdk:8u342
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: |
           if [ "${{ github.ref_name }}" == "develop" ] || [ "${{ github.ref_name }}" == "snapshot"  || [ "${{ github.ref_name }}" == "2.x" ]; then
-            ./mvnw -T 4C clean package -Pimage               -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+            ./mvnw -T 4C clean package -Dimage.name=openjdk:8u342      -Pimage                                    -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
           else
-            ./mvnw -T 4C clean package -Pimage,release-image -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+            ./mvnw -T 4C clean package -Dimage.name=openjdk:8u342      -Pimage,release-image-based-on-java8       -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+            ./mvnw -T 4C clean package -Dimage.name=openjdk:8u342-slim -Pimage,release-image-based-on-java8-slim  -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
           fi
+      # step 3 based on java17
+      - name: "Publish images to DockerHub based on java17"
+        if: ${{ matrix.java == 17 && github.ref_name != 'develop' && github.ref_name != 'snapshot' && github.ref_name != '2.x' }}
+        env:
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          ./mvnw -T 4C clean package -Dimage.name=openjdk:17.0.2       -Pimage,release-image-based-on-java17      -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
+          ./mvnw -T 4C clean package -Dimage.name=openjdk:17.0.2-slim  -Pimage,release-image-based-on-java17-slim -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;

--- a/.github/workflows/publishes.yml
+++ b/.github/workflows/publishes.yml
@@ -32,6 +32,9 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE # Environment variable name for the GPG private key passphrase. Default is $GPG_PASSPHRASE
       # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 4
       - name: "Publish to OSSRH"
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USER }}
@@ -58,7 +61,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-      # step 3 based on java8
+      # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 4 based on java8
       - name: "Publish images to DockerHub based on java8"
         if: matrix.java == 8
         env:
@@ -71,7 +77,7 @@ jobs:
             ./mvnw -T 4C clean package -Dimage.name=openjdk:8u342      -Pimage,release-image-based-on-java8       -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
             ./mvnw -T 4C clean package -Dimage.name=openjdk:8u342-slim -Pimage,release-image-based-on-java8-slim  -DskipTests -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
           fi
-      # step 3 based on java17
+      # step 4 based on java17
       - name: "Publish images to DockerHub based on java17"
         if: ${{ matrix.java == 17 && github.ref_name != 'develop' && github.ref_name != 'snapshot' && github.ref_name != '2.x' }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         java: [ 8, 11, 17 ]
         springboot: [
-          2.7.6          -Dspring-framework.version=5.3.24,
+          2.7.8          -Dspring-framework.version=5.3.25,
           2.6.14         -Dspring-framework.version=5.3.24,
           2.5.14         -Dspring-framework.version=5.3.20,
           2.4.13         -Dspring-framework.version=5.3.13,
@@ -58,7 +58,7 @@ jobs:
       matrix:
         java: [ 17 ]
         springboot: [
-          3.0.0 -Dspring-framework.version=6.0.2 -Dspring-boot-for-server.version=2.4.13 -Dspring-framework-for-server.version=5.3.18 -Dkotlin-maven-plugin.version=1.7.22
+          3.0.2 -Dspring-framework.version=6.0.4 -Dspring-boot-for-server.version=2.5.14 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22
         ]
     steps:
       # step 1
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         springboot: [
-          2.7.6          -Dspring-framework.version=5.3.24,
+          2.7.8          -Dspring-framework.version=5.3.25,
           2.6.14         -Dspring-framework.version=5.3.24,
           2.5.14         -Dspring-framework.version=5.3.20,
           2.4.13         -Dspring-framework.version=5.3.13,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         java: [ 8, 11, 17 ]
         springboot: [
-          2.7.8          -Dspring-framework.version=5.3.25,
+          2.7.9          -Dspring-framework.version=5.3.25,
           2.6.14         -Dspring-framework.version=5.3.24,
           2.5.14         -Dspring-framework.version=5.3.20,
           2.4.13         -Dspring-framework.version=5.3.13,
@@ -40,6 +40,9 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 4
       - name: "Test with Maven"
         # https://docs.github.com/cn/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#github-context
         run: |
@@ -58,7 +61,7 @@ jobs:
       matrix:
         java: [ 17 ]
         springboot: [
-          3.0.2 -Dspring-framework.version=6.0.4 -Dspring-boot-for-server.version=2.5.14 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22
+          3.0.4 -Dspring-framework.version=6.0.6 -Dspring-boot-for-server.version=2.5.14 -Dspring-framework-for-server.version=5.3.20 -Dkotlin-maven-plugin.version=1.7.22
         ]
     steps:
       # step 1
@@ -71,18 +74,21 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       # step 3
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 4
       - name: "Test with Maven"
         run: |
           ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=false -Dlicense.skip=false -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn;
 
   # job 3
   arm64-test:
-     runs-on: ubuntu-latest
-     strategy:
+    runs-on: ubuntu-latest
+    strategy:
       fail-fast: false
       matrix:
         springboot: [
-          2.7.8          -Dspring-framework.version=5.3.25,
+          2.7.9          -Dspring-framework.version=5.3.25,
           2.6.14         -Dspring-framework.version=5.3.24,
           2.5.14         -Dspring-framework.version=5.3.20,
           2.4.13         -Dspring-framework.version=5.3.13,
@@ -97,17 +103,25 @@ jobs:
           #1.1.12.RELEASE,
           #1.0.2.RELEASE
         ]
-     steps:
-      - uses: actions/checkout@v2
-      - name: Set up QEMU
+    steps:
+      # step 1
+      - name: "Checkout"
+        uses: actions/checkout@v2
+      # step 2
+      - name: "Set up QEMU"
         id: qemu
         uses: docker/setup-qemu-action@v1
-      - name: install
+      # step 3
+      - name: "install"
         run: |
-               docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
-               arm64v8/ubuntu:20.04 \
-               bash -exc 'apt-get update -y && \
-                apt-get install maven -y'
-      - name: test-arm64
+          docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+            arm64v8/ubuntu:20.04 \
+            bash -exc 'apt-get update -y && \
+            apt-get install maven -y'
+      # step 4
+      - name: "Print maven version"
+        run: ./mvnw -version
+      # step 5
+      - name: "test-arm64"
         run: |
-            ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true  -Dlicense.skip=true  -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          
+          ./mvnw -T 4C clean test -Dspring-boot.version=${{ matrix.springboot }} -Dcheckstyle.skip=true -Dlicense.skip=true -e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
           docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
             arm64v8/ubuntu:20.04 \
             bash -exc 'apt-get update -y && \
-            apt-get install maven -y'
+                       apt-get install maven -y'
       # step 4
       - name: "Print maven version"
         run: ./mvnw -version

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -73,7 +73,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- The version of spring-boot for 'spring-boot-dependencies' and 'spring-boot-maven-plugin' -->
-        <spring-boot.version>2.5.14</spring-boot.version>
+        <spring-boot.version>2.5.13</spring-boot.version>
         <spring-framework.version>5.3.20</spring-framework.version>
 
         <!-- For test -->

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -82,7 +82,7 @@
 
         <!-- Maven plugin versions -->
         <!-- Build -->
-        <easyj-maven-plugin.version>1.1.2</easyj-maven-plugin.version>
+        <easyj-maven-plugin.version>1.1.5</easyj-maven-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <!-- Compiler -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -73,7 +73,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- The version of spring-boot for 'spring-boot-dependencies' and 'spring-boot-maven-plugin' -->
-        <spring-boot.version>2.5.13</spring-boot.version>
+        <spring-boot.version>2.5.14</spring-boot.version>
         <spring-framework.version>5.3.20</spring-framework.version>
 
         <!-- For test -->
@@ -126,6 +126,7 @@
 
         <!-- For docker image-->
         <image.publish.skip>true</image.publish.skip>
+        <image.name>${IMAGE_NAME}</image.name>
         <image.tags>latest</image.tags>
 
         <dependencies.copy.skip>true</dependencies.copy.skip>
@@ -300,9 +301,6 @@
         <!-- profile: release -->
         <profile>
             <id>release</id>
-            <properties>
-                <image.tags>${project.version},latest</image.tags>
-            </properties>
             <build>
                 <plugins>
                     <!-- Javadoc -->

--- a/common/src/test/java/io/seata/common/util/ReflectionUtilTest.java
+++ b/common/src/test/java/io/seata/common/util/ReflectionUtilTest.java
@@ -189,6 +189,7 @@ public class ReflectionUtilTest {
     }
 
     @Test
+    @DisabledOnJre(JRE.JAVA_17) // `ReflectionUtil.getAnnotationValues` does not supported java17
     public void testGetAnnotationValues() throws NoSuchMethodException, NoSuchFieldException {
         Assertions.assertEquals(new LinkedHashMap<>(), ReflectionUtil
             .getAnnotationValues(this.getClass().getMethod("testGetAnnotationValues").getAnnotation(Test.class)));

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -35,6 +35,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- junit5 -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- spring-framework-->
             <dependency>
                 <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -157,17 +157,37 @@
             <id>image</id>
             <properties>
                 <image.publish.skip>false</image.publish.skip>
-                <image.tags>latest</image.tags>
                 <dependencies.copy.skip>false</dependencies.copy.skip>
                 <mysql.jdbc.version>5.1.42</mysql.jdbc.version>
                 <mysql8.jdbc.version>8.0.27</mysql8.jdbc.version>
             </properties>
         </profile>
-        <!-- profile: release-image -->
+        <!-- profile: release-image-based-on-java8 -->
         <profile>
-            <id>release-image</id>
+            <id>release-image-based-on-java8</id>
             <properties>
                 <image.tags>${project.version},latest</image.tags>
+            </properties>
+        </profile>
+        <!-- profile: release-image-based-on-java8-slim -->
+        <profile>
+            <id>release-image-based-on-java8-slim</id>
+            <properties>
+                <image.tags>${project.version}-slim</image.tags>
+            </properties>
+        </profile>
+        <!-- profile: release-image-based-on-java17 -->
+        <profile>
+            <id>release-image-based-on-java17</id>
+            <properties>
+                <image.tags>${project.version}.jre17</image.tags>
+            </properties>
+        </profile>
+        <!-- profile: release-image-based-on-java17-slim -->
+        <profile>
+            <id>release-image-based-on-java17-slim</id>
+            <properties>
+                <image.tags>${project.version}.jre17-slim</image.tags>
             </properties>
         </profile>
         <!-- profile: arrch64 -->

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>${maven-source-plugin.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.java.template</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -289,7 +289,7 @@
                 <version>${jib-maven-plugin.version}</version>
                 <configuration>
                     <from>
-                        <image>${IMAGE_NAME}</image>
+                        <image>${image.name}</image>
                         <platforms>
                             <platform>
                                 <os>linux</os>


### PR DESCRIPTION
optimize: publish images based on java `8`, `8-slim`, `17`, `17-slim`, see #5168
optimize: upgrade `easyj-maven-plugin` to `1.1.5` for support `maven-3.9.0` , see #5402