### PR TITLE
bugfix: FileTransactionStoreManagerTest NPE

### DIFF
--- a/server/src/test/java/io/seata/server/session/GlobalSessionTest.java
+++ b/server/src/test/java/io/seata/server/session/GlobalSessionTest.java
@@ -21,11 +21,11 @@ import java.util.stream.Stream;
 import io.seata.core.model.BranchStatus;
 import io.seata.core.model.BranchType;
 import io.seata.core.model.GlobalStatus;
-import io.seata.server.storage.file.session.FileSessionManager;
 import io.seata.server.store.StoreConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -45,12 +45,12 @@ import static io.seata.common.DefaultValues.DEFAULT_TX_GROUP;
 public class GlobalSessionTest {
 
 
-    @BeforeAll
+    @BeforeEach
     public static void setUp(ApplicationContext context){
 
     }
     @BeforeAll
-    public static void init(){
+    public static void init(ApplicationContext context){
         SessionHolder.init(StoreConfig.SessionMode.FILE);
     }
     @AfterAll

--- a/server/src/test/java/io/seata/server/session/GlobalSessionTest.java
+++ b/server/src/test/java/io/seata/server/session/GlobalSessionTest.java
@@ -25,7 +25,6 @@ import io.seata.server.store.StoreConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -45,10 +44,6 @@ import static io.seata.common.DefaultValues.DEFAULT_TX_GROUP;
 public class GlobalSessionTest {
 
 
-    @BeforeEach
-    public static void setUp(ApplicationContext context){
-
-    }
     @BeforeAll
     public static void init(ApplicationContext context){
         SessionHolder.init(StoreConfig.SessionMode.FILE);

--- a/server/src/test/java/io/seata/server/store/file/FileTransactionStoreManagerTest.java
+++ b/server/src/test/java/io/seata/server/store/file/FileTransactionStoreManagerTest.java
@@ -35,6 +35,7 @@ import org.assertj.core.util.Files;
 import org.junit.jupiter.api.*;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 
 /**
  * @author ggndnn
@@ -43,7 +44,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class FileTransactionStoreManagerTest {
 
     @BeforeAll
-    public static void init(){
+    public static void init(ApplicationContext context){
         SessionHolder.init(StoreConfig.SessionMode.FILE);
     }
     @AfterAll


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](https://github.com/seata/seata/tree/develop/changes).

### Ⅰ. Describe what this PR did
由于时不时github action的ci跑测试用例的顺序变化,老是会出现各种各样测试用例间顺序变化造成的问题,这次问题就是因为单纯的加beforeall的FileTransactionStoreManagerTest ,没有注入applicationcontext,导致environment为npe,而sessionholder初始化需要config,这个config又是被springbootprovider代理,需要使用environment,导致了npe,以往这个测试用例并不是作为server侧第一跑的测试用例,所以在ServerApplicationListener的事件中已经对ObjectHolder赋值了environment,所以在以前就没有遇到这种情况.
目前把几个beforeall中带有sessionholder#init的地方都进行了修复

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #5429

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

