### PR TITLE
optimize : change transaction state thread-safe in db mode

### DIFF
--- a/core/src/main/java/io/seata/core/store/LogStore.java
+++ b/core/src/main/java/io/seata/core/store/LogStore.java
@@ -67,6 +67,15 @@ public interface LogStore {
     boolean updateGlobalTransactionDO(GlobalTransactionDO globalTransactionDO);
 
     /**
+     * Update global transaction do boolean.
+     *
+     * @param globalTransactionDO the global transaction do
+     * @param expectedStatus the expected Status
+     * @return the boolean
+     */
+    boolean updateGlobalTransactionDO(GlobalTransactionDO globalTransactionDO, Integer expectedStatus);
+
+    /**
      * Delete global transaction do boolean.
      *
      * @param globalTransactionDO the global transaction do

--- a/core/src/main/java/io/seata/core/store/db/sql/log/LogStoreSqls.java
+++ b/core/src/main/java/io/seata/core/store/db/sql/log/LogStoreSqls.java
@@ -56,6 +56,14 @@ public interface LogStoreSqls {
     String getUpdateGlobalTransactionStatusSQL(String globalTable);
 
     /**
+     * Get update global transaction status sql string.
+     *
+     * @param globalTable the global table
+     * @return the string
+     */
+    String getUpdateGlobalTransactionStatusByStatusSQL(String globalTable);
+
+    /**
      * Get delete global transaction sql string.
      *
      * @param globalTable the global table

--- a/core/src/main/java/io/seata/core/store/db/sql/log/MysqlLogStoreSqls.java
+++ b/core/src/main/java/io/seata/core/store/db/sql/log/MysqlLogStoreSqls.java
@@ -41,6 +41,12 @@ public class MysqlLogStoreSqls extends AbstractLogStoreSqls {
             + " where " + ServerTableColumnsName.GLOBAL_TABLE_XID + " = ?";
 
     /**
+     * The constant UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_MYSQL.
+     */
+    public static final String UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_MYSQL =
+        UPDATE_GLOBAL_TRANSACTION_STATUS_MYSQL + " and " + ServerTableColumnsName.GLOBAL_TABLE_STATUS + " = ?";
+
+    /**
      * The constant QUERY_GLOBAL_TRANSACTION_BY_STATUS.
      */
     public static final String QUERY_GLOBAL_TRANSACTION_BY_STATUS_MYSQL = "select " + ALL_GLOBAL_COLUMNS
@@ -89,6 +95,11 @@ public class MysqlLogStoreSqls extends AbstractLogStoreSqls {
     @Override
     public String getUpdateGlobalTransactionStatusSQL(String globalTable) {
         return UPDATE_GLOBAL_TRANSACTION_STATUS_MYSQL.replace(GLOBAL_TABLE_PLACEHOLD, globalTable);
+    }
+
+    @Override
+    public String getUpdateGlobalTransactionStatusByStatusSQL(String globalTable) {
+        return UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_MYSQL.replace(GLOBAL_TABLE_PLACEHOLD, globalTable);
     }
 
     @Override

--- a/core/src/main/java/io/seata/core/store/db/sql/log/OracleLogStoreSqls.java
+++ b/core/src/main/java/io/seata/core/store/db/sql/log/OracleLogStoreSqls.java
@@ -41,6 +41,12 @@ public class OracleLogStoreSqls extends AbstractLogStoreSqls {
             + " where " + ServerTableColumnsName.GLOBAL_TABLE_XID + " = ?";
 
     /**
+     * The constant UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_ORACLE.
+     */
+    public static final String UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_ORACLE =
+        UPDATE_GLOBAL_TRANSACTION_STATUS_ORACLE + " and " + ServerTableColumnsName.GLOBAL_TABLE_STATUS + " = ?";
+
+    /**
      * The constant QUERY_GLOBAL_TRANSACTION_BY_STATUS_ORACLE.
      */
     public static final String QUERY_GLOBAL_TRANSACTION_BY_STATUS_ORACLE = "select A.* from ("
@@ -95,6 +101,11 @@ public class OracleLogStoreSqls extends AbstractLogStoreSqls {
     @Override
     public String getUpdateGlobalTransactionStatusSQL(String globalTable) {
         return UPDATE_GLOBAL_TRANSACTION_STATUS_ORACLE.replace(GLOBAL_TABLE_PLACEHOLD, globalTable);
+    }
+
+    @Override
+    public String getUpdateGlobalTransactionStatusByStatusSQL(String globalTable) {
+        return UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_ORACLE.replace(GLOBAL_TABLE_PLACEHOLD, globalTable);
     }
 
     @Override

--- a/core/src/main/java/io/seata/core/store/db/sql/log/PostgresqlLogStoreSqls.java
+++ b/core/src/main/java/io/seata/core/store/db/sql/log/PostgresqlLogStoreSqls.java
@@ -41,6 +41,13 @@ public class PostgresqlLogStoreSqls extends AbstractLogStoreSqls {
         + " where " + ServerTableColumnsName.GLOBAL_TABLE_XID + " = ?";
 
     /**
+     * The constant UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_POSTGRESQL.
+     */
+    public static final String UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_POSTGRESQL =
+        UPDATE_GLOBAL_TRANSACTION_STATUS_POSTGRESQL + " and " + ServerTableColumnsName.GLOBAL_TABLE_STATUS + " = ?";
+
+
+    /**
      * This constant QUERY_GLOBAL_TRANSACTION_BY_STATUS_POSTGRESQL.
      */
     public static final String QUERY_GLOBAL_TRANSACTION_BY_STATUS_POSTGRESQL = "select " + ALL_GLOBAL_COLUMNS
@@ -92,6 +99,11 @@ public class PostgresqlLogStoreSqls extends AbstractLogStoreSqls {
     @Override
     public String getUpdateGlobalTransactionStatusSQL(String globalTable) {
         return UPDATE_GLOBAL_TRANSACTION_STATUS_POSTGRESQL.replace(GLOBAL_TABLE_PLACEHOLD, globalTable);
+    }
+
+    @Override
+    public String getUpdateGlobalTransactionStatusByStatusSQL(String globalTable) {
+        return UPDATE_GLOBAL_TRANSACTION_STATUS_BY_STATUS_POSTGRESQL.replace(GLOBAL_TABLE_PLACEHOLD, globalTable);
     }
 
     @Override

--- a/server/src/main/java/io/seata/server/session/AbstractSessionManager.java
+++ b/server/src/main/java/io/seata/server/session/AbstractSessionManager.java
@@ -76,10 +76,10 @@ public abstract class AbstractSessionManager implements SessionManager {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("MANAGER[{}] SESSION[{}] {}", name, session, LogOperation.GLOBAL_UPDATE);
         }
-        session.setStatus(status);
-        if (GlobalStatus.Rollbacking == status) {
+        if (GlobalStatus.Rollbacking == status || GlobalStatus.TimeoutRollbacking == status) {
             session.getBranchSessions().forEach(i -> i.setLockStatus(LockStatus.Rollbacking));
         }
+        session.setStatus(status);
         writeSession(LogOperation.GLOBAL_UPDATE, session);
     }
 

--- a/server/src/main/java/io/seata/server/session/GlobalSession.java
+++ b/server/src/main/java/io/seata/server/session/GlobalSession.java
@@ -64,6 +64,10 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
     private static ThreadLocal<ByteBuffer> byteBufferThreadLocal = ThreadLocal.withInitial(() -> ByteBuffer.allocate(
         MAX_GLOBAL_SESSION_SIZE));
 
+    /**
+     * ThreadLocal should be optimize.
+     * It is tied to the current threading model. threadlocal's public set method does nothing to protect it from abuse.
+     */
     private static final ThreadLocal<GlobalStatus> EXPECTED_STATUS_THREAD_LOCAL = new ThreadLocal<>();
 
     /**

--- a/server/src/main/java/io/seata/server/storage/db/session/DataBaseSessionManager.java
+++ b/server/src/main/java/io/seata/server/storage/db/session/DataBaseSessionManager.java
@@ -69,10 +69,17 @@ public class DataBaseSessionManager extends AbstractSessionManager implements In
 
     @Override
     public void updateGlobalSessionStatus(GlobalSession session, GlobalStatus status) throws TransactionException {
-        session.setStatus(status);
-        boolean ret = transactionStoreManager.writeSession(LogOperation.GLOBAL_UPDATE, session);
-        if (!ret) {
-            throw new StoreException("updateGlobalSessionStatus failed.");
+        try {
+            // set expected status threadlocal
+            session.setExpectedStatusFromCurrent();
+            session.setStatus(status);
+            boolean ret = transactionStoreManager.writeSession(LogOperation.GLOBAL_UPDATE, session);
+            if (!ret) {
+                throw new StoreException("updateGlobalSessionStatus failed.");
+            }
+        } finally {
+            // remove expected status threadlocal
+            session.cleanExpectedStatus();
         }
     }
 

--- a/server/src/main/java/io/seata/server/storage/db/store/DataBaseTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/db/store/DataBaseTransactionStoreManager.java
@@ -100,7 +100,12 @@ public class DataBaseTransactionStoreManager extends AbstractTransactionStoreMan
         if (LogOperation.GLOBAL_ADD.equals(logOperation)) {
             return logStore.insertGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session));
         } else if (LogOperation.GLOBAL_UPDATE.equals(logOperation)) {
+            GlobalSession globalSession = (GlobalSession)session;
+            if (globalSession.getExpectedStatus() != null) {
+                return logStore.updateGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session), globalSession.getExpectedStatus().getCode());
+            } else {
             return logStore.updateGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session));
+            }
         } else if (LogOperation.GLOBAL_REMOVE.equals(logOperation)) {
             return logStore.deleteGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session));
         } else if (LogOperation.BRANCH_ADD.equals(logOperation)) {

--- a/server/src/main/java/io/seata/server/storage/db/store/DataBaseTransactionStoreManager.java
+++ b/server/src/main/java/io/seata/server/storage/db/store/DataBaseTransactionStoreManager.java
@@ -102,9 +102,10 @@ public class DataBaseTransactionStoreManager extends AbstractTransactionStoreMan
         } else if (LogOperation.GLOBAL_UPDATE.equals(logOperation)) {
             GlobalSession globalSession = (GlobalSession)session;
             if (globalSession.getExpectedStatus() != null) {
-                return logStore.updateGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session), globalSession.getExpectedStatus().getCode());
+                return logStore.updateGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session),
+                    globalSession.getExpectedStatus().getCode());
             } else {
-            return logStore.updateGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session));
+                return logStore.updateGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session));
             }
         } else if (LogOperation.GLOBAL_REMOVE.equals(logOperation)) {
             return logStore.deleteGlobalTransactionDO(SessionConverter.convertGlobalTransactionDO(session));

--- a/server/src/main/java/io/seata/server/storage/db/store/LogStoreDataBaseDAO.java
+++ b/server/src/main/java/io/seata/server/storage/db/store/LogStoreDataBaseDAO.java
@@ -237,6 +237,26 @@ public class LogStoreDataBaseDAO implements LogStore {
     }
 
     @Override
+    public boolean updateGlobalTransactionDO(GlobalTransactionDO globalTransactionDO, Integer expectedStatus){
+        String sql = LogStoreSqlsFactory.getLogStoreSqls(dbType).getUpdateGlobalTransactionStatusByStatusSQL(globalTable);
+        Connection conn = null;
+        PreparedStatement ps = null;
+        try {
+            conn = logStoreDataSource.getConnection();
+            conn.setAutoCommit(true);
+            ps = conn.prepareStatement(sql);
+            ps.setInt(1, globalTransactionDO.getStatus());
+            ps.setString(2, globalTransactionDO.getXid());
+            ps.setInt(3, expectedStatus.intValue());
+            return ps.executeUpdate() > 0;
+        } catch (SQLException e) {
+            throw new StoreException(e);
+        } finally {
+            IOUtil.close(ps, conn);
+        }
+    }
+
+    @Override
     public boolean deleteGlobalTransactionDO(GlobalTransactionDO globalTransactionDO) {
         String sql = LogStoreSqlsFactory.getLogStoreSqls(dbType).getDeleteGlobalTransactionSQL(globalTable);
         Connection conn = null;

--- a/server/src/main/java/io/seata/server/storage/db/store/LogStoreDataBaseDAO.java
+++ b/server/src/main/java/io/seata/server/storage/db/store/LogStoreDataBaseDAO.java
@@ -237,8 +237,9 @@ public class LogStoreDataBaseDAO implements LogStore {
     }
 
     @Override
-    public boolean updateGlobalTransactionDO(GlobalTransactionDO globalTransactionDO, Integer expectedStatus){
-        String sql = LogStoreSqlsFactory.getLogStoreSqls(dbType).getUpdateGlobalTransactionStatusByStatusSQL(globalTable);
+    public boolean updateGlobalTransactionDO(GlobalTransactionDO globalTransactionDO, Integer expectedStatus) {
+        String sql =
+            LogStoreSqlsFactory.getLogStoreSqls(dbType).getUpdateGlobalTransactionStatusByStatusSQL(globalTable);
         Connection conn = null;
         PreparedStatement ps = null;
         try {

--- a/server/src/test/java/io/seata/server/session/db/DataBaseSessionManagerTest.java
+++ b/server/src/test/java/io/seata/server/session/db/DataBaseSessionManagerTest.java
@@ -161,7 +161,6 @@ public class DataBaseSessionManagerTest {
 
         sessionManager.addGlobalSession(session);
 
-        session.setStatus(GlobalStatus.Committing);
         sessionManager.updateGlobalSessionStatus(session, GlobalStatus.Committing);
 
         String sql = "select * from global_table where xid= '"+xid+"'";

--- a/server/src/test/java/io/seata/server/store/db/LogStoreDataBaseDAOTest.java
+++ b/server/src/test/java/io/seata/server/store/db/LogStoreDataBaseDAOTest.java
@@ -400,6 +400,58 @@ public class LogStoreDataBaseDAOTest {
     }
 
     @Test
+    public void updateGlobalTransactionDOExpected() throws SQLException {
+        GlobalTransactionDO globalTransactionDO = new GlobalTransactionDO();
+        globalTransactionDO.setXid("abc-123:222");
+        globalTransactionDO.setApplicationData("abc=5454");
+        globalTransactionDO.setTransactionServiceGroup("abc");
+        globalTransactionDO.setTransactionName("test");
+        globalTransactionDO.setTransactionId(12345);
+        globalTransactionDO.setTimeout(20);
+        globalTransactionDO.setBeginTime(System.currentTimeMillis());
+        globalTransactionDO.setApplicationId("test");
+        globalTransactionDO.setStatus(1);
+
+        boolean ret = logStoreDataBaseDAO.insertGlobalTransactionDO(globalTransactionDO);
+        Assertions.assertTrue(ret);
+
+        String sql = "select * from global_table where xid= 'abc-123:222'";
+        String delSql = "delete from global_table where xid= 'abc-123:222'";
+        Connection conn = null;
+        try{
+            conn = dataSource.getConnection();
+            ResultSet rs = conn.createStatement().executeQuery(sql);
+            if(rs.next()){
+                Assertions.assertTrue(true);
+                Assertions.assertEquals(1, rs.getInt("status"));
+            }else{
+                Assertions.assertTrue(false);
+            }
+            rs.close();
+
+            //update
+            globalTransactionDO.setStatus(2);
+            Assertions.assertTrue(logStoreDataBaseDAO.updateGlobalTransactionDO(globalTransactionDO,1));
+
+            rs = conn.createStatement().executeQuery(sql);
+            if(rs.next()){
+                Assertions.assertTrue(true);
+                Assertions.assertEquals(2, rs.getInt("status"));
+            }else{
+                Assertions.assertTrue(false);
+            }
+            rs.close();
+
+            //delete
+            conn.createStatement().execute(delSql);
+
+        }finally {
+            IOUtil.close(conn);
+        }
+
+    }
+
+    @Test
     public void deleteGlobalTransactionDO() throws SQLException {
         GlobalTransactionDO globalTransactionDO = new GlobalTransactionDO();
         globalTransactionDO.setXid("abc-123:555");


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
更新globalstatus的时候采用线程安全的方式，阻止预期状态不匹配的操作继续执行。
目前的思路是：rollback和commit都用乐观锁方式去更新globalsession的status，更新成功的会往下执行。没有更新成功的会遇到异常而中断。
传参expected status方式使用threadlocal

以下两个pr优化了之后，这个pr可以简化
https://github.com/seata/seata/pull/4858
https://github.com/seata/seata/pull/4881

原pr关闭
https://github.com/seata/seata/pull/4383

### Ⅱ. Does this pull request fix one issue?
fixes https://github.com/seata/seata/issues/4372

### Ⅲ. Why don't you add test cases (unit test/integration test)?
### Ⅳ. Describe how to verify it
### Ⅴ. Special notes for reviews