### PR TITLE
bugfix: fix log in participant transaction role

### DIFF
--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -57,6 +57,7 @@ The version is updated as follows:
 - [[#5558](https://github.com/seata/seata/pull/5558)] fix mariadb rollback failed
 - [[#5556](https://github.com/seata/seata/pull/5556)] fix oracle insert undolog failed
 - [[#5577](https://github.com/seata/seata/pull/5577)] fix grpc interceptor xid unbinding problem
+- [[#5594](https://github.com/seata/seata/pull/5594)] fix log in participant transaction role
 
 ### optimize：
 - [[#5208](https://github.com/seata/seata/pull/5208)] optimize throwable getCause once more

--- a/changes/zh-cn/2.0.0.md
+++ b/changes/zh-cn/2.0.0.md
@@ -55,6 +55,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
 - [[#5558](https://github.com/seata/seata/pull/5558)] 修复mariadb回滚失败的问题
 - [[#5556](https://github.com/seata/seata/pull/5556)] 修复 oracle 插入 undolog 失败问题
 - [[#5577](https://github.com/seata/seata/pull/5577)] 修复 grpc拦截器解绑xid失败问题
+- [[#5594](https://github.com/seata/seata/pull/5594)] 修复participant情况下的重复日志
 
 ### optimize：
 - [[#5208](https://github.com/seata/seata/pull/5208)] 优化多次重复获取Throwable#getCause问题

--- a/tm/src/main/java/io/seata/tm/api/DefaultGlobalTransaction.java
+++ b/tm/src/main/java/io/seata/tm/api/DefaultGlobalTransaction.java
@@ -129,6 +129,9 @@ public class DefaultGlobalTransaction implements GlobalTransaction {
             return;
         }
         assertXIDNotNull();
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("transaction {} will be commit", xid);
+        }
         int retry = COMMIT_RETRY_COUNT <= 0 ? DEFAULT_TM_COMMIT_RETRY_COUNT : COMMIT_RETRY_COUNT;
         try {
             while (retry > 0) {
@@ -164,6 +167,9 @@ public class DefaultGlobalTransaction implements GlobalTransaction {
             return;
         }
         assertXIDNotNull();
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("transaction {} will be rollback", xid);
+        }
 
         int retry = ROLLBACK_RETRY_COUNT <= 0 ? DEFAULT_TM_ROLLBACK_RETRY_COUNT : ROLLBACK_RETRY_COUNT;
         try {

--- a/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
+++ b/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
@@ -112,6 +112,10 @@ public class TransactionalTemplate {
 
             // set current tx config to holder
             GlobalLockConfig previousConfig = replaceGlobalLockConfig(txInfo);
+            
+            if(tx.getGlobalTransactionRole()==GlobalTransactionRole.Participant){
+                LOGGER.info("join into a existing global transaction,xid={}", tx.getXid());
+            }
 
             try {
                 // 2. If the tx role is 'GlobalTransactionRole.Launcher', send the request of beginTransaction to TC,

--- a/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
+++ b/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
@@ -74,8 +74,8 @@ public class TransactionalTemplate {
                     // If transaction is existing, suspend it, and then begin new transaction.
                     if (existingTransaction(tx)) {
                         suspendedResourcesHolder = tx.suspend(false);
-                        tx = GlobalTransactionContext.createNew();
                     }
+                    tx = GlobalTransactionContext.createNew();
                     // Continue and execute with new transaction
                     break;
                 case SUPPORTS:
@@ -86,8 +86,8 @@ public class TransactionalTemplate {
                     // Continue and execute with new transaction
                     break;
                 case REQUIRED:
-                    // If current transaction is existing, execute with current transaction,
-                    // else continue and execute with new transaction.
+                    // If current transaction is existing, execute with current transaction，else create
+                    tx = GlobalTransactionContext.getCurrentOrCreate();
                     break;
                 case NEVER:
                     // If transaction is existing, throw exception.
@@ -108,11 +108,6 @@ public class TransactionalTemplate {
                     break;
                 default:
                     throw new TransactionException("Not Supported Propagation:" + propagation);
-            }
-
-            // 1.3 If null, create new transaction with role 'GlobalTransactionRole.Launcher'.
-            if (tx == null) {
-                tx = GlobalTransactionContext.createNew();
             }
 
             // set current tx config to holder
@@ -211,9 +206,9 @@ public class TransactionalTemplate {
 
         try {
             triggerBeforeCommit();
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("transaction {} will be commit", tx.getXid());
-            }
+//            if (LOGGER.isInfoEnabled()) {
+//                LOGGER.info("transaction {} will be commit", tx.getXid());
+//            }
             tx.commit();
             GlobalStatus afterCommitStatus = tx.getLocalStatus();
             TransactionalExecutor.Code code = TransactionalExecutor.Code.Unknown;
@@ -252,10 +247,10 @@ public class TransactionalTemplate {
 
         try {
             triggerBeforeRollback();
-            if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("transaction {} will be rollback, cause by:{}", tx.getXid(),
-                    originalException.getMessage());
-            }
+//            if (LOGGER.isInfoEnabled()) {
+//                LOGGER.info("transaction {} will be rollback, cause by:{}", tx.getXid(),
+//                    originalException.getMessage());
+//            }
             tx.rollback();
             triggerAfterRollback();
         } catch (TransactionException txe) {

--- a/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
+++ b/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
@@ -113,7 +113,7 @@ public class TransactionalTemplate {
             // set current tx config to holder
             GlobalLockConfig previousConfig = replaceGlobalLockConfig(txInfo);
             
-            if(tx.getGlobalTransactionRole()==GlobalTransactionRole.Participant){
+            if (tx.getGlobalTransactionRole() == GlobalTransactionRole.Participant) {
                 LOGGER.info("join into a existing global transaction,xid={}", tx.getXid());
             }
 

--- a/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
+++ b/tm/src/main/java/io/seata/tm/api/TransactionalTemplate.java
@@ -86,7 +86,7 @@ public class TransactionalTemplate {
                     // Continue and execute with new transaction
                     break;
                 case REQUIRED:
-                    // If current transaction is existing, execute with current transaction，else create
+                    // If current transaction is existing, execute with current transaction,else create
                     tx = GlobalTransactionContext.getCurrentOrCreate();
                     break;
                 case NEVER:
@@ -210,9 +210,6 @@ public class TransactionalTemplate {
 
         try {
             triggerBeforeCommit();
-//            if (LOGGER.isInfoEnabled()) {
-//                LOGGER.info("transaction {} will be commit", tx.getXid());
-//            }
             tx.commit();
             GlobalStatus afterCommitStatus = tx.getLocalStatus();
             TransactionalExecutor.Code code = TransactionalExecutor.Code.Unknown;
@@ -251,10 +248,6 @@ public class TransactionalTemplate {
 
         try {
             triggerBeforeRollback();
-//            if (LOGGER.isInfoEnabled()) {
-//                LOGGER.info("transaction {} will be rollback, cause by:{}", tx.getXid(),
-//                    originalException.getMessage());
-//            }
             tx.rollback();
             triggerAfterRollback();
         } catch (TransactionException txe) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
在事务传播过程中，如果出现Participant的情况（比如required或者support的），就会加入已存在的事务，当前逻辑在这种情况的处理存在不完善。
- 大部分情况下，核心逻辑和主要的日志写在DefaultGlobalTransaction类中，而hook处理在TransactionalTemplate（比如begin的逻辑）由于role判断写在DefaultGlobalTransaction所以没问题
- 但对于commit和rollback，日志先写在了TransactionalTemplate，没有进行role判断，所以切面第二次进入切面后TransactionalTemplate里的逻辑先不管role就打印了日志，然后进行hook，等进入DefaultGlobalTransaction后又判断了role所以其实并没有执行真正的commit/rollback。

目前的改造方式

- 把这两个关键的日志移动回DefaultGlobalTransaction内部，也就是判断完role再打印
- 优化TransactionalTemplate，日志移除，并在switch阶段就把current transaction处理干净
- hook的逻辑没有发生变化，多次进入切面依然会多次执行

不足之处讨论

- hook多次执行：加入事务在DefaultGlobalTransaction内会直接返回，但hook会再次执行，逻辑上有点奇怪，以后的改造建议是participant的情况在TransactionalTemplate就跳过去，就像斌哥说的这种情况打个日志直接execute
- 兼容性顾虑：因为按现在的逻辑加入事务也会触发hook，如果我们真的改了，用户升级时是没有感知的，如果他之前真的依赖这个hook去做重要的事情，可能带来问题
- 其他：移除的日志现在只是注释，如果大家觉得这个改动方式没问题，我会再提交一次把他删掉

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/seata/seata/issues/5567

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

