### PR TITLE
bugfix: fix the `asyncCommit` and `queueToRetryCommit` always failed in db mode

### DIFF
--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -27,8 +27,7 @@ The version is updated as follows:
 ### bugfix：
 - [[#5194](https://github.com/seata/seata/pull/5194)] fix wrong keyword order for oracle when creating a table
 - [[#5021](https://github.com/seata/seata/pull/5201)] fix JDK Reflection for Spring origin proxy failed in JDK17
-- [[#5023](https://github.com/seata/seata/pull/5203)] fix `seata-core` dependency transitive conflict in  
-  `seata-dubbo`
+- [[#5023](https://github.com/seata/seata/pull/5203)] fix `seata-core` dependency transitive conflict in `seata-dubbo`
 - [[#5224](https://github.com/seata/seata/pull/5224)] fix oracle initialize script index_name is duplicate
 - [[#5233](https://github.com/seata/seata/pull/5233)] fix the inconsistent configuration item names related to LoadBalance
 - [[#5245](https://github.com/seata/seata/pull/5245)] fix the incomplete dependency of distribution module
@@ -58,6 +57,7 @@ The version is updated as follows:
 - [[#5556](https://github.com/seata/seata/pull/5556)] fix oracle insert undolog failed
 - [[#5577](https://github.com/seata/seata/pull/5577)] fix grpc interceptor xid unbinding problem
 - [[#5594](https://github.com/seata/seata/pull/5594)] fix log in participant transaction role
+- [[#5604](https://github.com/seata/seata/pull/5604)] fix the `asyncCommit` and `queueToRetryCommit` always failed in db mode
 
 ### optimize：
 - [[#5208](https://github.com/seata/seata/pull/5208)] optimize throwable getCause once more

--- a/changes/zh-cn/2.0.0.md
+++ b/changes/zh-cn/2.0.0.md
@@ -56,6 +56,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
 - [[#5556](https://github.com/seata/seata/pull/5556)] 修复 oracle 插入 undolog 失败问题
 - [[#5577](https://github.com/seata/seata/pull/5577)] 修复 grpc拦截器解绑xid失败问题
 - [[#5594](https://github.com/seata/seata/pull/5594)] 修复participant情况下的重复日志
+- [[#5604](https://github.com/seata/seata/pull/5604)] 修复在DB模式下 `asyncCommit` 和 `queueToRetryCommit` 两个方法总是失败的问题
 
 ### optimize：
 - [[#5208](https://github.com/seata/seata/pull/5208)] 优化多次重复获取Throwable#getCause问题

--- a/server/src/main/java/io/seata/server/session/GlobalSession.java
+++ b/server/src/main/java/io/seata/server/session/GlobalSession.java
@@ -761,13 +761,11 @@ public class GlobalSession implements SessionLifecycle, SessionStorable {
     }
 
     public void asyncCommit() throws TransactionException {
-        this.setStatus(GlobalStatus.AsyncCommitting);
         // [optimize-session-manager] add--> root manager.update
         SessionHolder.getRootSessionManager().updateGlobalSessionStatus(this, GlobalStatus.AsyncCommitting);
     }
 
     public void queueToRetryCommit() throws TransactionException {
-        this.setStatus(GlobalStatus.CommitRetrying);
         // [optimize-session-manager] add--> root manager.update
         SessionHolder.getRootSessionManager().updateGlobalSessionStatus(this,GlobalStatus.CommitRetrying);
     }

--- a/server/src/main/java/io/seata/server/storage/db/store/LogStoreDataBaseDAO.java
+++ b/server/src/main/java/io/seata/server/storage/db/store/LogStoreDataBaseDAO.java
@@ -254,7 +254,7 @@ public class LogStoreDataBaseDAO implements LogStore {
             ps = conn.prepareStatement(sql);
             ps.setInt(1, globalTransactionDO.getStatus());
             ps.setString(2, globalTransactionDO.getXid());
-            ps.setInt(3, expectedStatus.intValue());
+            ps.setInt(3, expectedStatus);
             return ps.executeUpdate() > 0;
         } catch (SQLException e) {
             throw new StoreException(e);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
In the db mode, the `GlobalSession.asyncCommit` and `GlobalSession.queueToRetryCommit` always failed.
在DB模式下，`GlobalSession.asyncCommit` 和 `GlobalSession.queueToRetryCommit` 两个方法总是失败。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
复现 `asyncCommit` 报错：一个全局事务可以异步全局提交，就会碰到该问题。比如：全部是AT分支。
复现 `queueToRetryCommit` 报错：可以在分支提交时，设置断点，故意把RM关掉，让一个分支提交失败，让全局事务进入异步重试提交。

### Ⅴ. Special notes for reviews

