### PR TITLE
bugfix: fix the key parameter problem of sofa-rpc setAttachment() method

### DIFF
--- a/common/src/main/java/io/seata/common/Constants.java
+++ b/common/src/main/java/io/seata/common/Constants.java
@@ -47,6 +47,11 @@ public interface Constants {
     String ROW_LOCK_KEY_SPLIT_CHAR = ";";
 
     /**
+     * The constant HIDE_KEY_PREFIX_CHAR.
+     */
+    String HIDE_KEY_PREFIX_CHAR = ".";
+
+    /**
      * the start time of transaction
      */
     String START_TIME = "start-time";

--- a/core/src/main/java/io/seata/core/context/RootContext.java
+++ b/core/src/main/java/io/seata/core/context/RootContext.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import io.seata.common.Constants;
 import io.seata.common.exception.ShouldNeverHappenException;
 import io.seata.common.util.StringUtils;
 import io.seata.core.model.BranchType;
@@ -48,6 +49,11 @@ public class RootContext {
     public static final String KEY_XID = "TX_XID";
 
     /**
+     * The constant HIDDEN_KEY_XID.
+     */
+    public static final String HIDDEN_KEY_XID = Constants.HIDE_KEY_PREFIX_CHAR + KEY_XID;
+
+    /**
      * The constant KEY_TIMEOUT.
      */
     public static final String KEY_TIMEOUT = "TX_TIMEOUT";
@@ -68,6 +74,11 @@ public class RootContext {
      * The constant KEY_BRANCH_TYPE
      */
     public static final String KEY_BRANCH_TYPE = "TX_BRANCH_TYPE";
+
+    /**
+     * The constant HIDDEN_KEY_BRANCH_TYPE
+     */
+    public static final String HIDDEN_KEY_BRANCH_TYPE = Constants.HIDE_KEY_PREFIX_CHAR + KEY_BRANCH_TYPE;
 
     /**
      * The constant KEY_GLOBAL_LOCK_FLAG, VALUE_GLOBAL_LOCK_FLAG

--- a/integration/sofa-rpc/src/main/java/io/seata/integration/sofa/rpc/TransactionContextConsumerFilter.java
+++ b/integration/sofa-rpc/src/main/java/io/seata/integration/sofa/rpc/TransactionContextConsumerFilter.java
@@ -105,14 +105,14 @@ public class TransactionContextConsumerFilter extends Filter {
      * @return
      */
     private String getRpcXid() {
-        String rpcXid = (String) RpcInternalContext.getContext().getAttachment(RootContext.KEY_XID);
+        String rpcXid = (String) RpcInternalContext.getContext().getAttachment(RootContext.HIDDEN_KEY_XID);
         if (rpcXid == null) {
-            rpcXid = (String) RpcInternalContext.getContext().getAttachment(RootContext.KEY_XID.toLowerCase());
+            rpcXid = (String) RpcInternalContext.getContext().getAttachment(RootContext.HIDDEN_KEY_XID.toLowerCase());
         }
         return rpcXid;
     }
     private String getBranchType() {
-        return (String) RpcInternalContext.getContext().getAttachment(RootContext.KEY_BRANCH_TYPE);
+        return (String) RpcInternalContext.getContext().getAttachment(RootContext.HIDDEN_KEY_BRANCH_TYPE);
     }
 
 }

--- a/integration/sofa-rpc/src/main/java/io/seata/integration/sofa/rpc/TransactionContextProviderFilter.java
+++ b/integration/sofa-rpc/src/main/java/io/seata/integration/sofa/rpc/TransactionContextProviderFilter.java
@@ -55,8 +55,8 @@ public class TransactionContextProviderFilter extends Filter {
         }
         boolean bind = false;
         if (xid != null) {
-            RpcInternalContext.getContext().setAttachment(RootContext.KEY_XID, xid);
-            RpcInternalContext.getContext().setAttachment(RootContext.KEY_BRANCH_TYPE, branchType.name());
+            RpcInternalContext.getContext().setAttachment(RootContext.HIDDEN_KEY_XID, xid);
+            RpcInternalContext.getContext().setAttachment(RootContext.HIDDEN_KEY_BRANCH_TYPE, branchType.name());
         } else {
             if (null != rpcXid) {
                 RootContext.bind(rpcXid);
@@ -72,6 +72,10 @@ public class TransactionContextProviderFilter extends Filter {
         try {
             return filterInvoker.invoke(sofaRequest);
         } finally {
+            if (xid != null) {
+                RpcInternalContext.getContext().removeAttachment(RootContext.HIDDEN_KEY_XID);
+                RpcInternalContext.getContext().removeAttachment(RootContext.HIDDEN_KEY_BRANCH_TYPE);
+            }
             if (bind) {
                 String unbindXid = RootContext.unbind();
                 if (LOGGER.isDebugEnabled()) {

--- a/integration/sofa-rpc/src/test/java/io/seata/integration/sofa/rpc/HelloServiceImpl.java
+++ b/integration/sofa-rpc/src/test/java/io/seata/integration/sofa/rpc/HelloServiceImpl.java
@@ -16,6 +16,7 @@
 package io.seata.integration.sofa.rpc;
 
 import io.seata.core.context.RootContext;
+import io.seata.core.model.BranchType;
 
 /**
  * @author Geng Zhang
@@ -25,6 +26,8 @@ public class HelloServiceImpl implements HelloService {
     private String result;
     
     private String xid;
+
+    private BranchType branchType;
 
     public HelloServiceImpl() {
 
@@ -37,10 +40,15 @@ public class HelloServiceImpl implements HelloService {
     @Override
     public String sayHello(String name, int age) {
         xid = RootContext.getXID();
+        branchType = RootContext.getBranchType();
         return result != null ? result : "hello " + name + " from server! age: " + age;
     }
 
     public String getXid() {
         return xid;
+    }
+
+    public BranchType getBranchType() {
+        return branchType;
     }
 }

--- a/integration/sofa-rpc/src/test/java/io/seata/integration/sofa/rpc/HelloServiceProxy.java
+++ b/integration/sofa-rpc/src/test/java/io/seata/integration/sofa/rpc/HelloServiceProxy.java
@@ -16,6 +16,7 @@
 package io.seata.integration.sofa.rpc;
 
 import io.seata.core.context.RootContext;
+import io.seata.core.model.BranchType;
 
 /**
  * @author Geng Zhang
@@ -23,6 +24,8 @@ import io.seata.core.context.RootContext;
 public class HelloServiceProxy implements HelloService {
 
     private String xid;
+
+    private BranchType branchType;
 
     private HelloService proxy;
 
@@ -33,10 +36,15 @@ public class HelloServiceProxy implements HelloService {
     @Override
     public String sayHello(String name, int age) {
         xid = RootContext.getXID();
+        branchType = RootContext.getBranchType();
         return proxy.sayHello(name, age);
     }
 
     public String getXid() {
         return xid;
+    }
+
+    public BranchType getBranchType() {
+        return branchType;
     }
 }

--- a/integration/sofa-rpc/src/test/java/io/seata/integration/sofa/rpc/TransactionContextFilterTest.java
+++ b/integration/sofa-rpc/src/test/java/io/seata/integration/sofa/rpc/TransactionContextFilterTest.java
@@ -24,6 +24,7 @@ import com.alipay.sofa.rpc.context.RpcRunningState;
 import com.alipay.sofa.rpc.context.RpcRuntimeContext;
 import com.alipay.sofa.rpc.core.exception.SofaRpcException;
 import io.seata.core.context.RootContext;
+import io.seata.core.model.BranchType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -91,25 +92,32 @@ public class TransactionContextFilterTest {
             helloService.sayHello("xxx", 22);
             // check C
             Assertions.assertNull(helloServiceImpl.getXid());
+            Assertions.assertNull(helloServiceImpl.getBranchType());
             // check B
             Assertions.assertNull(helloServiceProxy.getXid());
+            Assertions.assertNull(helloServiceProxy.getBranchType());
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof SofaRpcException);
         } finally {
             Assertions.assertNull(RootContext.unbind());
+            Assertions.assertNull(RootContext.unbindBranchType());
         }
 
         RootContext.bind("xidddd");
+        RootContext.bindBranchType(BranchType.AT);
         try {
             helloService.sayHello("xxx", 22);
             // check C
             Assertions.assertEquals(helloServiceImpl.getXid(), "xidddd");
+            Assertions.assertEquals(helloServiceImpl.getBranchType(), BranchType.AT);
             // check B
             Assertions.assertEquals(helloServiceProxy.getXid(), "xidddd");
+            Assertions.assertEquals(helloServiceProxy.getBranchType(), BranchType.AT);
         } catch (Exception e) {
             Assertions.assertTrue(e instanceof SofaRpcException);
         } finally {
             Assertions.assertEquals("xidddd", RootContext.unbind());
+            Assertions.assertEquals(BranchType.AT, RootContext.unbindBranchType());
         }
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
在 `sofa-rpc` 中，`RpcInternalContext.getContext().setAttachment()` 方法的 `key` 参数要求以 `.` 或者`_`开头，否则会抛异常

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix #3835

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

