### PR TITLE
bugfix: case of the pk col-name in the business sql is inconsistent with the case in the table metadata, resulting in a rollback failure

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -6,7 +6,8 @@ Add changes here for all PR submitted to the develop branch.
 - [[#XXX](https://github.com/seata/seata/pull/XXX)] XXX
 
 ### bugfix:
-- [[#XXX](https://github.com/seata/seata/pull/XXX)] XXX
+- [[#5749](https://github.com/seata/seata/pull/5749)] case of the pk col-name in the business sql is inconsistent with the case in the table metadata, resulting in a rollback failure
+
 
 ### optimize:
 - [[#XXX](https://github.com/seata/seata/pull/XXX)] XXX

--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -22,6 +22,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 <!-- Please make sure your Github ID is in the list below -->
 - [slievrly](https://github.com/slievrly)
+- [CaptHua](https://github.com/capthua)
 - [XXX](https://github.com/XXX)
 
 

--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -22,7 +22,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 
 <!-- Please make sure your Github ID is in the list below -->
 - [slievrly](https://github.com/slievrly)
-- [CaptHua](https://github.com/capthua)
+- [capthua](https://github.com/capthua)
 - [XXX](https://github.com/XXX)
 
 

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -21,7 +21,7 @@
 
 <!-- 请确保您的 GitHub ID 在以下列表中 -->
 - [slievrly](https://github.com/slievrly)
-- [CaptHua](https://github.com/capthua)
+- [capthua](https://github.com/capthua)
 - [XXX](https://github.com/XXX)
 
 

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -21,6 +21,7 @@
 
 <!-- 请确保您的 GitHub ID 在以下列表中 -->
 - [slievrly](https://github.com/slievrly)
+- [CaptHua](https://github.com/capthua)
 - [XXX](https://github.com/XXX)
 
 

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -6,7 +6,7 @@
 - [[#XXX](https://github.com/seata/seata/pull/XXX)] XXX
 
 ### bugfix:
-- [[#XXX](https://github.com/seata/seata/pull/XXX)] XXX
+- [[#5749](https://github.com/seata/seata/pull/5749)] 修复在某些情况下，业务sql中主键字段名大小写与表元数据中的不一致，导致回滚失败
 
 ### optimize:
 - [[#XXX](https://github.com/seata/seata/pull/XXX)] XXX

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.sql.rowset.serial.SerialBlob;
 import javax.sql.rowset.serial.SerialClob;
 import javax.sql.rowset.serial.SerialDatalink;
@@ -195,8 +194,7 @@ public class TableRecords implements java.io.Serializable {
     public static TableRecords buildRecords(TableMeta tmeta, ResultSet resultSet) throws SQLException {
         TableRecords records = new TableRecords(tmeta);
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-        Map<String, ColumnMeta> primaryKeyMap = tmeta.getPrimaryKeyMap();
-        Set<String> lowerCasePKColNames = primaryKeyMap.keySet().stream().map(String::toLowerCase).collect(Collectors.toSet());
+        Set<String> ignoreCasePKs = tmeta.getIgnoreCasePKs();
         int columnCount = resultSetMetaData.getColumnCount();
 
         while (resultSet.next()) {
@@ -207,7 +205,7 @@ public class TableRecords implements java.io.Serializable {
                 int dataType = col.getDataType();
                 Field field = new Field();
                 field.setName(col.getColumnName());
-                if (isPrimaryKey(colName, lowerCasePKColNames)) {
+                if (ignoreCasePKs.contains(colName)) {
                     field.setKeyType(KeyType.PRIMARY_KEY);
                 }
                 field.setType(dataType);
@@ -264,18 +262,6 @@ public class TableRecords implements java.io.Serializable {
             records.add(row);
         }
         return records;
-    }
-
-    /**
-     * Determines if the specified column is a primary key.
-     *
-     * @param columnName name of the column to be tested.
-     * @param lowerCasePKColNames lowercase primary key column name set.
-     * @return {@code true} if the column is a primary key;
-     *         {@code false} otherwise.
-     */
-    public static boolean isPrimaryKey(String columnName, Set<String> lowerCasePKColNames) {
-        return lowerCasePKColNames.contains(columnName.toLowerCase());
     }
 
     /**

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
@@ -194,7 +194,7 @@ public class TableRecords implements java.io.Serializable {
     public static TableRecords buildRecords(TableMeta tmeta, ResultSet resultSet) throws SQLException {
         TableRecords records = new TableRecords(tmeta);
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-        Set<String> ignoreCasePKs = tmeta.getIgnoreCasePKs();
+        Set<String> ignoreCasePKs = tmeta.getCaseInsensitivePKs();
         int columnCount = resultSetMetaData.getColumnCount();
 
         while (resultSet.next()) {

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/TableRecords.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.sql.rowset.serial.SerialBlob;
 import javax.sql.rowset.serial.SerialClob;
 import javax.sql.rowset.serial.SerialDatalink;
@@ -194,6 +196,7 @@ public class TableRecords implements java.io.Serializable {
         TableRecords records = new TableRecords(tmeta);
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         Map<String, ColumnMeta> primaryKeyMap = tmeta.getPrimaryKeyMap();
+        Set<String> lowerCasePKColNames = primaryKeyMap.keySet().stream().map(String::toLowerCase).collect(Collectors.toSet());
         int columnCount = resultSetMetaData.getColumnCount();
 
         while (resultSet.next()) {
@@ -204,7 +207,7 @@ public class TableRecords implements java.io.Serializable {
                 int dataType = col.getDataType();
                 Field field = new Field();
                 field.setName(col.getColumnName());
-                if (primaryKeyMap.containsKey(colName)) {
+                if (isPrimaryKey(colName, lowerCasePKColNames)) {
                     field.setKeyType(KeyType.PRIMARY_KEY);
                 }
                 field.setType(dataType);
@@ -261,6 +264,18 @@ public class TableRecords implements java.io.Serializable {
             records.add(row);
         }
         return records;
+    }
+
+    /**
+     * Determines if the specified column is a primary key.
+     *
+     * @param columnName name of the column to be tested.
+     * @param lowerCasePKColNames lowercase primary key column name set.
+     * @return {@code true} if the column is a primary key;
+     *         {@code false} otherwise.
+     */
+    public static boolean isPrimaryKey(String columnName, Set<String> lowerCasePKColNames) {
+        return lowerCasePKColNames.contains(columnName.toLowerCase());
     }
 
     /**

--- a/sqlparser/seata-sqlparser-core/src/main/java/io/seata/sqlparser/struct/TableMeta.java
+++ b/sqlparser/seata-sqlparser-core/src/main/java/io/seata/sqlparser/struct/TableMeta.java
@@ -154,11 +154,11 @@ public class TableMeta {
     }
 
     /**
-     * Gets ignore case primary key set
+     * Gets case-insensitive primary key set
      *
-     * @return ignore case, unmodifiable primary key set
+     * @return case-insensitive, unmodifiable primary key set
      */
-    public Set<String> getIgnoreCasePKs() {
+    public Set<String> getCaseInsensitivePKs() {
         Set<String> pks = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         allIndexes.forEach((key, index) -> {
             if (index.getIndextype().value() == IndexType.PRIMARY.value()) {

--- a/sqlparser/seata-sqlparser-core/src/main/java/io/seata/sqlparser/struct/TableMeta.java
+++ b/sqlparser/seata-sqlparser-core/src/main/java/io/seata/sqlparser/struct/TableMeta.java
@@ -20,6 +20,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -148,6 +151,26 @@ public class TableMeta {
         }
 
         return pk;
+    }
+
+    /**
+     * Gets ignore case primary key set
+     *
+     * @return ignore case, unmodifiable primary key set
+     */
+    public Set<String> getIgnoreCasePKs() {
+        Set<String> pks = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        allIndexes.forEach((key, index) -> {
+            if (index.getIndextype().value() == IndexType.PRIMARY.value()) {
+                for (ColumnMeta col : index.getValues()) {
+                    pks.add(col.getColumnName());
+                }
+            }
+        });
+        if (pks.size() < 1) {
+            throw new NotSupportYetException(String.format("%s needs to contain the primary key.", tableName));
+        }
+        return Collections.unmodifiableSet(pks);
     }
 
     /**


### PR DESCRIPTION
…ith the case in the table metadata, resulting in a rollback failure

<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
修复：AT模式，在某些情况下，业务sql中主键字段名大小写与表元数据中的不一致，导致回滚失败

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #5734 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

