### PR TITLE
bugfix: change some fields type of  TableMetaCache to avoid integer overflow

### DIFF
--- a/changes/en-us/develop.md
+++ b/changes/en-us/develop.md
@@ -7,6 +7,7 @@ Add changes here for all PR submitted to the develop branch.
 
 ### bugfix:
 - [[#5749](https://github.com/seata/seata/pull/5749)] case of the pk col-name in the business sql is inconsistent with the case in the table metadata, resulting in a rollback failure
+- [[#5762](https://github.com/seata/seata/pull/5762)] change some fields type of TableMetaCache to avoid integer overflow
 
 
 ### optimize:
@@ -23,6 +24,7 @@ Thanks to these contributors for their code commits. Please report an unintended
 <!-- Please make sure your Github ID is in the list below -->
 - [slievrly](https://github.com/slievrly)
 - [capthua](https://github.com/capthua)
+- [robynron](https://github.com/robynron)
 - [XXX](https://github.com/XXX)
 
 

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -7,6 +7,7 @@
 
 ### bugfix:
 - [[#5749](https://github.com/seata/seata/pull/5749)] 修复在某些情况下，业务sql中主键字段名大小写与表元数据中的不一致，导致回滚失败
+- [[#5762](https://github.com/seata/seata/pull/5762)] 修复TableMetaCache的一些字段类型，避免溢出
 
 ### optimize:
 - [[#XXX](https://github.com/seata/seata/pull/XXX)] XXX
@@ -22,6 +23,7 @@
 <!-- 请确保您的 GitHub ID 在以下列表中 -->
 - [slievrly](https://github.com/slievrly)
 - [capthua](https://github.com/capthua)
+- [robynron](https://github.com/robynron)
 - [XXX](https://github.com/XXX)
 
 

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCache.java
@@ -169,7 +169,7 @@ public class MysqlTableMetaCache extends AbstractTableMetaCache {
                     index.setType(rsIndex.getShort("TYPE"));
                     index.setOrdinalPosition(rsIndex.getShort("ORDINAL_POSITION"));
                     index.setAscOrDesc(rsIndex.getString("ASC_OR_DESC"));
-                    index.setCardinality(rsIndex.getInt("CARDINALITY"));
+                    index.setCardinality(rsIndex.getLong("CARDINALITY"));
                     index.getValues().add(col);
                     if ("PRIMARY".equalsIgnoreCase(indexName)) {
                         index.setIndextype(IndexType.PRIMARY);

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/OracleTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/OracleTableMetaCache.java
@@ -142,7 +142,7 @@ public class OracleTableMetaCache extends AbstractTableMetaCache {
                     index.setType(rsIndex.getShort("TYPE"));
                     index.setOrdinalPosition(rsIndex.getShort("ORDINAL_POSITION"));
                     index.setAscOrDesc(rsIndex.getString("ASC_OR_DESC"));
-                    index.setCardinality(rsIndex.getInt("CARDINALITY"));
+                    index.setCardinality(rsIndex.getLong("CARDINALITY"));
                     index.getValues().add(col);
                     if (!index.isNonUnique()) {
                         index.setIndextype(IndexType.UNIQUE);

--- a/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
+++ b/rm-datasource/src/main/java/io/seata/rm/datasource/sql/struct/cache/PostgresqlTableMetaCache.java
@@ -160,7 +160,7 @@ public class PostgresqlTableMetaCache extends AbstractTableMetaCache {
                     index.setType(rsIndex.getShort("type"));
                     index.setOrdinalPosition(rsIndex.getShort("ordinal_position"));
                     index.setAscOrDesc(rsIndex.getString("asc_or_desc"));
-                    index.setCardinality(rsIndex.getInt("cardinality"));
+                    index.setCardinality(rsIndex.getLong("cardinality"));
                     index.getValues().add(col);
                     if (!index.isNonUnique()) {
                         index.setIndextype(IndexType.UNIQUE);

--- a/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCacheTest.java
+++ b/rm-datasource/src/test/java/io/seata/rm/datasource/sql/struct/cache/MysqlTableMetaCacheTest.java
@@ -55,9 +55,9 @@ public class MysqlTableMetaCacheTest {
 
     private static Object[][] indexMetas =
         new Object[][] {
-            new Object[] {"PRIMARY", "id", false, "", 3, 0, "A", 34},
-            new Object[] {"name1", "name1", false, "", 3, 1, "A", 34},
-            new Object[] {"name2", "name2", true, "", 3, 2, "A", 34},
+            new Object[] {"PRIMARY", "id", false, "", 3, 0, "A", 34L},
+            new Object[] {"name1", "name1", false, "", 3, 1, "A", 34L},
+            new Object[] {"name2", "name2", true, "", 3, 2, "A", 34L},
         };
 
     @Test

--- a/sqlparser/seata-sqlparser-core/src/main/java/io/seata/sqlparser/struct/IndexMeta.java
+++ b/sqlparser/seata-sqlparser-core/src/main/java/io/seata/sqlparser/struct/IndexMeta.java
@@ -35,7 +35,7 @@ public class IndexMeta {
     private short type;
     private IndexType indextype;
     private String ascOrDesc;
-    private int cardinality;
+    private long cardinality;
     private int ordinalPosition;
 
     /**
@@ -157,7 +157,7 @@ public class IndexMeta {
      *
      * @return the cardinality
      */
-    public int getCardinality() {
+    public long getCardinality() {
         return cardinality;
     }
 
@@ -166,7 +166,7 @@ public class IndexMeta {
      *
      * @param cardinality the cardinality
      */
-    public void setCardinality(int cardinality) {
+    public void setCardinality(long cardinality) {
         this.cardinality = cardinality;
     }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->
在`TableMetaCache`中，某些`filed`如`CARDINALITY`与`MySQL`的`jdbc`中类型定义不一致，可能会导致`Integer`类型溢出，需要修改二者为一致类型。
![image](https://github.com/seata/seata/assets/38815080/e8a70d1a-dd39-44d3-926a-ecc66e18714e)

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
Fixes #5761 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

