### PR TITLE
bugfix: cluster cannot be customized when redis serves as the registry

### DIFF
--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -67,6 +67,7 @@ The version is updated as follows:
 - [[#5748](https://github.com/seata/seata/pull/5748)] case of the pk col-name in the business sql is inconsistent with the case in the table metadata, resulting in a rollback failure
 - [[#5745](https://github.com/seata/seata/pull/5745)] fix the problem that the parameter prefix requirement of the setAttachment method in sofa-rpc is not met
 - [[#5772](https://github.com/seata/seata/pull/5762)] change some fields type of TableMetaCache to avoid integer overflow
+- [[#5794](https://github.com/seata/seata/pull/5794)] Solution cluster cannot be customized when redis serves as the registry
 
 ### optimize：
 - [[#5208](https://github.com/seata/seata/pull/5208)] optimize throwable getCause once more

--- a/changes/en-us/2.0.0.md
+++ b/changes/en-us/2.0.0.md
@@ -67,7 +67,7 @@ The version is updated as follows:
 - [[#5748](https://github.com/seata/seata/pull/5748)] case of the pk col-name in the business sql is inconsistent with the case in the table metadata, resulting in a rollback failure
 - [[#5745](https://github.com/seata/seata/pull/5745)] fix the problem that the parameter prefix requirement of the setAttachment method in sofa-rpc is not met
 - [[#5772](https://github.com/seata/seata/pull/5762)] change some fields type of TableMetaCache to avoid integer overflow
-- [[#5794](https://github.com/seata/seata/pull/5794)] Solution cluster cannot be customized when redis serves as the registry
+- [[#5787](https://github.com/seata/seata/pull/5794)] Solution cluster cannot be customized when redis serves as the registry
 
 ### optimize：
 - [[#5208](https://github.com/seata/seata/pull/5208)] optimize throwable getCause once more

--- a/changes/zh-cn/2.0.0.md
+++ b/changes/zh-cn/2.0.0.md
@@ -66,6 +66,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
 - [[#5748](https://github.com/seata/seata/pull/5748)] 修复在某些情况下，业务sql中主键字段名大小写与表元数据中的不一致，导致回滚失败
 - [[#5745](https://github.com/seata/seata/pull/5745)] 修复不满足 sofa-rpc 中 setAttachment 方法的参数前缀要求问题
 - [[#5772](https://github.com/seata/seata/pull/5762)] 修复TableMetaCache的一些字段类型，避免溢出
+- [[#5794](https://github.com/seata/seata/pull/5794)] 解决redis作为注册中心时cluster无法自定义的BUG
 
 ### optimize：
 - [[#5208](https://github.com/seata/seata/pull/5208)] 优化多次重复获取Throwable#getCause问题

--- a/changes/zh-cn/2.0.0.md
+++ b/changes/zh-cn/2.0.0.md
@@ -66,7 +66,7 @@ Seata 是一款开源的分布式事务解决方案，提供高性能和简单�
 - [[#5748](https://github.com/seata/seata/pull/5748)] 修复在某些情况下，业务sql中主键字段名大小写与表元数据中的不一致，导致回滚失败
 - [[#5745](https://github.com/seata/seata/pull/5745)] 修复不满足 sofa-rpc 中 setAttachment 方法的参数前缀要求问题
 - [[#5772](https://github.com/seata/seata/pull/5762)] 修复TableMetaCache的一些字段类型，避免溢出
-- [[#5794](https://github.com/seata/seata/pull/5794)] 解决redis作为注册中心时cluster无法自定义的BUG
+- [[#5787](https://github.com/seata/seata/pull/5794)] 解决redis作为注册中心时cluster无法自定义的BUG
 
 ### optimize：
 - [[#5208](https://github.com/seata/seata/pull/5208)] 优化多次重复获取Throwable#getCause问题

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -14,6 +14,7 @@
 - [[#5245](https://github.com/seata/seata/pull/5245)] 修复不完整的distribution模块依赖
 - [[#5239](https://github.com/seata/seata/pull/5239)] 修复当使用JDK代理时，`getConfig` 方法获取部分配置时抛出 `ClassCastException` 异常的问题
 - [[#5462](https://github.com/seata/seata/pull/5462)] 在RM中使用`@GlobalTransactional`时,如果RM执行失败会抛出`ShouldNeverHappenException`
+- [[#5794](https://github.com/seata/seata/pull/5794)] 解决redis作为注册中心时cluster无法自定义的BUG
 
 ### optimize:
 - [[#5208](https://github.com/seata/seata/pull/5208)] 优化多次重复获取Throwable#getCause问题

--- a/changes/zh-cn/develop.md
+++ b/changes/zh-cn/develop.md
@@ -14,7 +14,6 @@
 - [[#5245](https://github.com/seata/seata/pull/5245)] 修复不完整的distribution模块依赖
 - [[#5239](https://github.com/seata/seata/pull/5239)] 修复当使用JDK代理时，`getConfig` 方法获取部分配置时抛出 `ClassCastException` 异常的问题
 - [[#5462](https://github.com/seata/seata/pull/5462)] 在RM中使用`@GlobalTransactional`时,如果RM执行失败会抛出`ShouldNeverHappenException`
-- [[#5794](https://github.com/seata/seata/pull/5794)] 解决redis作为注册中心时cluster无法自定义的BUG
 
 ### optimize:
 - [[#5208](https://github.com/seata/seata/pull/5208)] 优化多次重复获取Throwable#getCause问题

--- a/discovery/seata-discovery-redis/src/main/java/io/seata/discovery/registry/redis/RedisRegistryServiceImpl.java
+++ b/discovery/seata-discovery-redis/src/main/java/io/seata/discovery/registry/redis/RedisRegistryServiceImpl.java
@@ -195,7 +195,7 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
             try {
                 try (Jedis jedis = jedisPool.getResource()) {
                     // try update Map every 2s
-                    updateClusterAddressMap(jedis, redisRegistryKey);
+                    updateClusterAddressMap(jedis, redisRegistryKey, cluster);
                 }
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);
@@ -232,7 +232,7 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
         if (!LISTENER_SERVICE_MAP.containsKey(clusterName)) {
             String redisRegistryKey = REDIS_FILEKEY_PREFIX + clusterName;
             try (Jedis jedis = jedisPool.getResource()) {
-                updateClusterAddressMap(jedis, redisRegistryKey);
+                updateClusterAddressMap(jedis, redisRegistryKey, clusterName);
             }
             subscribe(clusterName, msg -> {
                 String[] msgr = msg.split("-");
@@ -286,7 +286,7 @@ public class RedisRegistryServiceImpl implements RegistryService<RedisListener> 
         }
     }
 
-    private void updateClusterAddressMap(Jedis jedis, String redisRegistryKey) {
+    private void updateClusterAddressMap(Jedis jedis, String redisRegistryKey, String clusterName) {
         ScanParams scanParams = new ScanParams();
         scanParams.count(10);
         scanParams.match(redisRegistryKey + "_*");


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [x] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
解决redis作为注册中心时cluster自定义就会报错的BUG 【no available service found in cluster 'ordos_111.56.115.158', please make sure registry config correct and keep your seata server running】

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
没有

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
该问题无法添加测试用例

### Ⅳ. Describe how to verify it
如何复现错误：
使用redis作为注册中心，且当server端和client端配置同样的cluster（非default）时，导致客户端一直报错（实际上我的cluster已经注册到了redis）

通过Debug发现：
无论在配置文件中指定什么cluster，以下代码中的CLUSTER_ADDRESS_MAP都会使用default作为键，而不是自定义的cluster
``` java
        #310行
        if (!newAddressSet.equals(CLUSTER_ADDRESS_MAP.get(clusterName))) {
            CLUSTER_ADDRESS_MAP.put(clusterName, newAddressSet);
        }
```
而获取配置信息的代码处是用自定义cluster而非default作为键
``` java
       #253行
       return new ArrayList<>(CLUSTER_ADDRESS_MAP.getOrDefault(clusterName, Collections.emptySet()));
```

以上代码出自io.seata.discovery.registry.redis.RedisRegistryServiceImpl文件

### Ⅴ. Special notes for reviews

